### PR TITLE
Releasing Torch and TF weights 🚀 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,16 @@ By Shishir G. Patil, Tianjun Zhang, Xin Wang, and Joseph E. Gonzalez  ([Project 
 `Gorilla` enables LLMs to use tools by invoking APIs. Given a natural language query, Gorilla comes up with the semantically- and syntactically- correct API to invoke. With Gorilla, we are the first to demonstrate how to use LLMs to invoke 1,600+ (and growing) API calls accurately while reducing hallucination. We also release APIBench, the largest collection of APIs, curated and easy to be trained on! Join us, as we try to expand the largest API store and teach LLMs how to write them! Hop on our Discord, or open a PR, or email us if you would like to have your API incorporated as well.
 
 ## News
+- :rocket: [05/28] Released Torch Hub and TensorFlow Hub Models!
 - :rocket: [05/27] Released the first Gorilla model! [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1DEBPsccVLF_aUnmD0FwPeHFrtdC0QIUP?usp=sharing) and [:hugs:](https://huggingface.co/gorilla-llm/gorilla-7b-hf-delta-v0)!
 - :fire: [05/27] We released the APIZoo contribution guide for community API contributions!
 - :fire: [05/25] We release the APIBench dataset and the evaluation code of Gorilla!
 
 ## Get Started 
 
-### Install Dependencies
+Inference: Run Gorilla locally [`inference/README.md`](inference/README.md)
 
-Use the following command to install dependencies. These are only for evaluation, additional dependencies for inference and training are in their respective sub-directories.
-
-```bash
-conda create -n gorilla python=3.8
-conda activate gorilla
-pip install -r requirements.txt
-```
-
-We have included prompts and responces for the APIBench with and without retrievers along with the Abstract Syntax Tree (AST) matching evaluation script at [evaluation](https://github.com/ShishirPatil/gorilla/tree/main/eval).
+Evaluation: We have included prompts and responces for the APIBench with and without retrievers along with the Abstract Syntax Tree (AST) matching evaluation script at [evaluation](https://github.com/ShishirPatil/gorilla/tree/main/eval).
 
 ## Repository Organization
 
@@ -106,7 +99,7 @@ In the immediate future, we plan to release the following:
 - [X] Hosted Gorilla LLM chat for HF model APIs [May 27, 2023]
 - [X] Release weights for HF model APIs [May 27, 2023]
 - [X] Run Gorilla LLM locally [May 28, 2023]
-- [] Release weights for all APIs from APIBench [May 28, 2023]
+- [X] Release weights for all APIs from APIBench [May 28, 2023]
 - [] Release a commercially usable, Apache 2.0 licensed Gorilla model [Jun 5, 2023] 
 - [] Train a model with first batch of community contributed APIs from APIZoo [Jun 5, 2023]
 - [] Release training code [Jun 5, 2023]

--- a/inference/README.md
+++ b/inference/README.md
@@ -6,7 +6,7 @@
 
 You can either run Gorilla through our hosted [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1DEBPsccVLF_aUnmD0FwPeHFrtdC0QIUP?usp=sharing) or run it locally on your machine. Here, are the instructions to run it locally.
 
-`gorilla-7b-hf-v0` is the first set of weights we released :tada: It chooses from 925 HF APIs in a 0-shot fashion (without any retrieval). In spirit of openess, we do not filter, nor carry out any post processing either to the prompt nor response :gift: We will release TorchHub, TensorFlow, and the combined {HF+TF+TH} model weights also. Keep in mind that `gorilla-7b-hf-v0` does not have any geenric chat capability.  We do have a model with all the 1600+ APIs which also has chat capability, which we release slowly to accomodate server demand. 
+`gorilla-7b-hf-v0` is the first set of weights we released :tada: It chooses from 925 HF APIs in a 0-shot fashion (without any retrieval). Update: We released `gorilla-7b-th-v0` with 94 (exhaustive) APIs from Torch Hub and `gorilla-7b-tf-v0` with 626 (exhaustive) APIs from Tensorflow. In spirit of openess, we do not filter, nor carry out any post processing either to the prompt nor response :gift: Keep in mind that the current `gorilla-7b-*` models do not have any geenric chat capability.  We do have a model with all the 1600+ APIs which also has chat capability, which we release slowly to accomodate server demand. 
 
 ### Install Dependencies
 

--- a/inference/README.md
+++ b/inference/README.md
@@ -8,6 +8,8 @@ You can either run Gorilla through our hosted [![Colab](https://colab.research.g
 
 `gorilla-7b-hf-v0` is the first set of weights we released :tada: It chooses from 925 HF APIs in a 0-shot fashion (without any retrieval). Update: We released `gorilla-7b-th-v0` with 94 (exhaustive) APIs from Torch Hub and `gorilla-7b-tf-v0` with 626 (exhaustive) APIs from Tensorflow. In spirit of openess, we do not filter, nor carry out any post processing either to the prompt nor response :gift: Keep in mind that the current `gorilla-7b-*` models do not have any geenric chat capability.  We do have a model with all the 1600+ APIs which also has chat capability, which we release slowly to accomodate server demand. 
 
+All delta weights hosted at [https://huggingface.co/gorilla-llm/](https://huggingface.co/gorilla-llm/). 
+
 ### Install Dependencies
 
 You should install dependencies using the following command: 


### PR DESCRIPTION
In this PR we release the weights for Gorilla 0-shot model for Torch Hub and Tensorflow Hub APIs 🎉

It chooses from 626 (exhaustive) TensorFlow v2 APIs, and 94 (exhaustive) Torch Hub  in a 0-shot fashion (without any retrieval). In the spirit of being open, we do not filter, nor carry out any post processing either to the prompt nor response 🎁 We would like to remind the community that neither of `gorilla-7b-hf-v0`, `gorilla-7b-tf-v0`, nor `gorilla-7b-th-v0` have any generic chat capability. We do have a model with all the 1600+ APIs which also has generic chat capability, which we release slowly to accommodate server demand.

You can play around with Gorilla either through our hosted colab (OpenAI Chat completion API compliant) or you can download and run it locally.

Thank you for all the comments and suggestions so far! Keep them coming!!!

🚀 🚀 🚀