### PR TITLE
Fix: gorilla_cli.py `model` to `model-path`

### DIFF
--- a/inference/README.md
+++ b/inference/README.md
@@ -44,7 +44,7 @@ Simply run the command below to start chatting with Gorilla:
 
 ```bash 
 cd serve
-python3 gorilla_cli.py --model path/to/gorilla-7b-{hf,th,tf}-v0
+python3 gorilla_cli.py --model-path path/to/gorilla-7b-{hf,th,tf}-v0
 ```
 
 ### [Optional] Batch Inference on a Prompt File

--- a/inference/README.md
+++ b/inference/README.md
@@ -43,8 +43,7 @@ python3 apply_delta.py
 Simply run the command below to start chatting with Gorilla: 
 
 ```bash 
-cd serve
-python3 gorilla_cli.py --model-path path/to/gorilla-7b-{hf,th,tf}-v0
+python3 serve/gorilla_cli.py --model-path path/to/gorilla-7b-{hf,th,tf}-v0
 ```
 
 ### [Optional] Batch Inference on a Prompt File

--- a/inference/serve/gorilla_cli.py
+++ b/inference/serve/gorilla_cli.py
@@ -2,7 +2,7 @@
 Chat with a model with command line interface.
 
 Usage:
-python3 gorilla_cli.py --model path/to/gorilla-7b-hf-v0
+python3 gorilla_cli.py --model-path path/to/gorilla-7b-hf-v0
 
 Thanks to LMSYS for the template of this code.
 """


### PR DESCRIPTION
In gorilla_cli.py the argument must be `model-path` and not `model`