### PR TITLE
Adding BM25 and GPT retrievers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **:rocket: Try Gorilla in 60s** [![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1DEBPsccVLF_aUnmD0FwPeHFrtdC0QIUP?usp=sharing) 
 
-:computer: Use [Gorilla in your CLI](https://github.com/gorilla-llm/gorilla-cli)
+:computer: Use [Gorilla in your CLI](https://github.com/gorilla-llm/gorilla-cli) with `pip install gorilla-cli`
 
 **:newspaper_roll: Checkout our paper!** [![arXiv](https://img.shields.io/badge/arXiv-2305.15334-<COLOR>.svg?style=flat-square)](https://arxiv.org/abs/2305.15334)
 

--- a/data/README.md
+++ b/data/README.md
@@ -116,3 +116,16 @@ Submit a json file containing the list of json objects:
 **LLM assistance for LLM API dataset :wink:**:
 
 Visit our website [Coming Soon!], where you can type in the API URL and we'll output an API submission for you! You can choose to submit or edit before and submitting. Easy and quick!
+
+## Citation
+
+If you use Gorilla or APIBench, please cite our paper:
+
+```text
+@article{patil2023gorilla,
+  title={Gorilla: Large Language Model Connected with Massive APIs},
+  author={Shishir G. Patil and Tianjun Zhang and Xin Wang and Joseph E. Gonzalez},
+  year={2023},
+  journal={arXiv preprint arXiv:2305.15334},
+} 
+```

--- a/eval/README.md
+++ b/eval/README.md
@@ -12,10 +12,10 @@ To get LLM responses for the API calls, use the following command:
 python get_llm_responses.py --model gpt-3.5-turbo --api_key $API_KEY --output_file gpt-3.5-turbo_torchhub_0_shot.jsonl --question_data eval-data/questions/torchhub/questions_torchhub_0_shot.jsonl --api_name torchhub
 ```
 
-### Getting Responses with Retrievers (BM25 or GPTIndex)
+### Getting Responses with Retrievers (`bm25` or `gpt`)
 
 ```bash
-python get_llm_responses_retriever.py --model gpt-3.5-turbo --api_key $API_KEY --output_file gpt-3.5-turbo_torchhub_0_shot.jsonl --question_data eval-data/questions/torchhub/questions_torchhub_0_shot.jsonl --api_name torchhub --api_dataset ../data/api/torchhub_api.jsonl
+python get_llm_responses_retriever.py --retriever bm25 --model gpt-3.5-turbo --api_key $API_KEY --output_file gpt-3.5-turbo_torchhub_0_shot.jsonl --question_data eval-data/questions/torchhub/questions_torchhub_0_shot.jsonl --api_name torchhub --api_dataset ../data/api/torchhub_api.jsonl
 ```
 
 ### Evaluate the Response with AST tree matching

--- a/eval/README.md
+++ b/eval/README.md
@@ -4,12 +4,18 @@
 
 ## Get Started
 
-### Getting GPT-3.5-turbo, GPT-4 and Claude Responses
+### Getting GPT-3.5-turbo, GPT-4 and Claude Responses (0-Shot)
 
 To get LLM responses for the API calls, use the following command:
 
 ```bash
 python get_llm_responses.py --model gpt-3.5-turbo --api_key $API_KEY --output_file gpt-3.5-turbo_torchhub_0_shot.jsonl --question_data eval-data/questions/torchhub/questions_torchhub_0_shot.jsonl --api_name torchhub
+```
+
+### Getting Responses with Retrievers (BM25 or GPTIndex)
+
+```bash
+python get_llm_responses_retriever.py --model gpt-3.5-turbo --api_key $API_KEY --output_file gpt-3.5-turbo_torchhub_0_shot.jsonl --question_data eval-data/questions/torchhub/questions_torchhub_0_shot.jsonl --api_name torchhub --api_dataset ../data/api/torchhub_api.jsonl
 ```
 
 ### Evaluate the Response with AST tree matching

--- a/eval/eval-scripts/ast_eval_hf.py
+++ b/eval/eval-scripts/ast_eval_hf.py
@@ -1,3 +1,17 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import json 
 from codebleu.parser import DFG_python,DFG_java,DFG_ruby,DFG_go,DFG_php,DFG_javascript,DFG_csharp

--- a/eval/eval-scripts/ast_eval_hf.py
+++ b/eval/eval-scripts/ast_eval_hf.py
@@ -14,22 +14,9 @@
 
 import argparse
 import json 
-from codebleu.parser import DFG_python,DFG_java,DFG_ruby,DFG_go,DFG_php,DFG_javascript,DFG_csharp
-from codebleu.parser import (remove_comments_and_docstrings,
-                   tree_to_token_index,
-                   index_to_code_token,
-                   tree_to_variable_index)
+
 from tree_sitter import Language, Parser
 
-dfg_function={
-    'python':DFG_python,
-    'java':DFG_java,
-    'ruby':DFG_ruby,
-    'go':DFG_go,
-    'php':DFG_php,
-    'javascript':DFG_javascript,
-    'c_sharp':DFG_csharp,
-}
 
 # Get all the subtrees given a root_node
 def get_all_sub_trees(root_node):

--- a/eval/eval-scripts/ast_eval_tf.py
+++ b/eval/eval-scripts/ast_eval_tf.py
@@ -14,22 +14,7 @@
 
 import argparse
 import json 
-from codebleu.parser import DFG_python,DFG_java,DFG_ruby,DFG_go,DFG_php,DFG_javascript,DFG_csharp
-from codebleu.parser import (remove_comments_and_docstrings,
-                   tree_to_token_index,
-                   index_to_code_token,
-                   tree_to_variable_index)
 from tree_sitter import Language, Parser
-
-dfg_function={
-    'python':DFG_python,
-    'java':DFG_java,
-    'ruby':DFG_ruby,
-    'go':DFG_go,
-    'php':DFG_php,
-    'javascript':DFG_javascript,
-    'c_sharp':DFG_csharp,
-}
 
 # Get all the subtrees given a root_node
 def get_all_sub_trees(root_node):

--- a/eval/eval-scripts/ast_eval_tf.py
+++ b/eval/eval-scripts/ast_eval_tf.py
@@ -1,3 +1,17 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import json 
 from codebleu.parser import DFG_python,DFG_java,DFG_ruby,DFG_go,DFG_php,DFG_javascript,DFG_csharp

--- a/eval/eval-scripts/ast_eval_th.py
+++ b/eval/eval-scripts/ast_eval_th.py
@@ -14,33 +14,9 @@
 
 import argparse
 import json
-from codebleu.parser import (
-    DFG_python,
-    DFG_java,
-    DFG_ruby,
-    DFG_go,
-    DFG_php,
-    DFG_javascript,
-    DFG_csharp,
-)
-from codebleu.parser import (
-    remove_comments_and_docstrings,
-    tree_to_token_index,
-    index_to_code_token,
-    tree_to_variable_index,
-)
 from tree_sitter import Language, Parser
 import concurrent.futures
 
-dfg_function = {
-    "python": DFG_python,
-    "java": DFG_java,
-    "ruby": DFG_ruby,
-    "go": DFG_go,
-    "php": DFG_php,
-    "javascript": DFG_javascript,
-    "c_sharp": DFG_csharp,
-}
 
 # Get all the subtrees given a root_node
 def get_all_sub_trees(root_node):

--- a/eval/eval-scripts/ast_eval_th.py
+++ b/eval/eval-scripts/ast_eval_th.py
@@ -130,7 +130,7 @@ def process_response(response, api_database, qa_pairs, ast_database):
     try:
         output = response["text"]
     except:
-        print("Error: cannot parse line ", response["index"])
+        print("Error: cannot parse line ", response)
         return False, False
 
     # Index the "api_call" domain

--- a/eval/eval-scripts/ast_eval_th.py
+++ b/eval/eval-scripts/ast_eval_th.py
@@ -1,3 +1,17 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import json
 from codebleu.parser import (

--- a/eval/get_llm_responses.py
+++ b/eval/get_llm_responses.py
@@ -1,3 +1,17 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 import json

--- a/eval/get_llm_responses_retriever.py
+++ b/eval/get_llm_responses_retriever.py
@@ -1,3 +1,17 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 import json

--- a/eval/get_llm_responses_retriever.py
+++ b/eval/get_llm_responses_retriever.py
@@ -114,9 +114,9 @@ if __name__ == '__main__':
     parser.add_argument("--api_dataset", type=str, default=None, help="path to the api data")
     args = parser.parse_args()
 
-    assert args.retriever in ["bm25", "gpt_index"]
-    if args.retriever == "gpt_index":
-        retriever = GPTIndexRetriever(query_kwargs={"similarity_top_k": args.num_doc})
+    assert args.retriever in ["bm25", "gpt"]
+    if args.retriever == "gpt":
+        retriever = GPTRetriever(query_kwargs={"similarity_top_k": args.num_doc})
         if os.path.exists(args.retriever + '_dataset_index.json'):
             print('data index already saved')
             os.environ["OPENAI_API_KEY"] = args.api_key

--- a/eval/get_llm_responses_retriever.py
+++ b/eval/get_llm_responses_retriever.py
@@ -1,0 +1,151 @@
+import argparse
+import sys
+import json
+import openai
+import anthropic
+import multiprocessing as mp
+import os
+import time
+from retrievers import *
+from retrievers.build_json_index import JSONLReader
+
+def encode_question(question, api_name):
+    """Encode multiple prompt instructions into a single string."""
+    
+    prompts = []
+    if api_name == "torchhub":
+        domains = "1. $DOMAIN is inferred from the task description and should include one of {Classification, Semantic Segmentation, Object Detection, Audio Separation, Video Classification, Text-to-Speech}."
+    elif api_name == "huggingface":
+        domains = "1. $DOMAIN should include one of {Multimodal Feature Extraction, Multimodal Text-to-Image, Multimodal Image-to-Text, Multimodal Text-to-Video, \
+        Multimodal Visual Question Answering, Multimodal Document Question Answer, Multimodal Graph Machine Learning, Computer Vision Depth Estimation,\
+        Computer Vision Image Classification, Computer Vision Object Detection, Computer Vision Image Segmentation, Computer Vision Image-to-Image, \
+        Computer Vision Unconditional Image Generation, Computer Vision Video Classification, Computer Vision Zero-Shor Image Classification, \
+        Natural Language Processing Text Classification, Natural Language Processing Token Classification, Natural Language Processing Table Question Answering, \
+        Natural Language Processing Question Answering, Natural Language Processing Zero-Shot Classification, Natural Language Processing Translation, \
+        Natural Language Processing Summarization, Natural Language Processing Conversational, Natural Language Processing Text Generation, Natural Language Processing Fill-Mask,\
+        Natural Language Processing Text2Text Generation, Natural Language Processing Sentence Similarity, Audio Text-to-Speech, Audio Automatic Speech Recognition, \
+        Audio Audio-to-Audio, Audio Audio Classification, Audio Voice Activity Detection, Tabular Tabular Classification, Tabular Tabular Regression, \
+        Reinforcement Learning Reinforcement Learning, Reinforcement Learning Robotics }"
+    elif api_name == "tensorhub":
+        domains = "1. $DOMAIN is inferred from the task description and should include one of {text-sequence-alignment, text-embedding, text-language-model, text-preprocessing, text-classification, text-generation, text-question-answering, text-retrieval-question-answering, text-segmentation, text-to-mel, image-classification, image-feature-vector, image-object-detection, image-segmentation, image-generator, image-pose-detection, image-rnn-agent, image-augmentation, image-classifier, image-style-transfer, image-aesthetic-quality, image-depth-estimation, image-super-resolution, image-deblurring, image-extrapolation, image-text-recognition, image-dehazing, image-deraining, image-enhancemenmt, image-classification-logits, image-frame-interpolation, image-text-detection, image-denoising, image-others, video-classification, video-feature-extraction, video-generation, video-audio-text, video-text, audio-embedding, audio-event-classification, audio-command-detection, audio-paralinguists-classification, audio-speech-to-text, audio-speech-synthesis, audio-synthesis, audio-pitch-extraction}"
+    else:
+        print("Error: API name is not supported.")
+
+    prompt = question + "\nWrite a python program in 1 to 2 lines to call API in " + api_name + ".\n\nThe answer should follow the format: <<<domain>>> $DOMAIN, <<<api_call>>>: $API_CALL, <<<api_provider>>>: $API_PROVIDER, <<<explanation>>>: $EXPLANATION, <<<code>>>: $CODE}. Here are the requirements:\n" + domains + "\n2. The $API_CALL should have only 1 line of code that calls api.\n3. The $API_PROVIDER should be the programming framework used.\n4. $EXPLANATION should be a step-by-step explanation.\n5. The $CODE is the python code.\n6. Do not repeat the format in your answer."
+    prompts.append({"role": "system", "content": "You are a helpful API writer who can write APIs based on requirements."})
+    prompts.append({"role": "user", "content": prompt})
+    return prompts
+
+def get_response(get_response_input, api_key):
+    question, question_id, api_name, model, retrieved_doc = get_response_input
+    question = encode_question(question, api_name)
+    question[-1]["content"] = question[-1]["content"] + "\nHere are some reference docs:"
+    for i, doc in enumerate(retrieved_doc): 
+        question[-1]["content"] = question[-1]["content"] + "\nAPI " + str(i) + ": " + str(doc)
+    
+    try:
+        if "gpt" in model:
+            openai.api_key = api_key
+            responses = openai.ChatCompletion.create(
+                model=model,
+                messages=question,
+                n=1,
+                temperature=0,
+            )
+            response = responses['choices'][0]['message']['content']
+        elif "claude" in model:
+            client = anthropic.Client(api_key)
+            responses = client.completion(
+                prompt=f"{anthropic.HUMAN_PROMPT} {question[0]['content']}{question[1]['content']}{anthropic.AI_PROMPT}",
+                stop_sequences=[anthropic.HUMAN_PROMPT],
+                model="claude-v1",
+                max_tokens_to_sample=2048,
+            )
+            response = responses["completion"].strip()
+        else:
+            print("Error: Model is not supported.")
+    except Exception as e:
+        print("Error:", e)
+        return None
+        
+    print("=>",)
+    return {'text': response, "question_id": question_id, "answer_id": "None", "model_id": model, "metadata": {}}
+
+def process_entry(entry, api_key):
+    question, question_id, api_name, model, retriever = entry
+    retrieved_doc = retriever.get_relevant_documents(question)
+    result = get_response((question, question_id, api_name, model, retrieved_doc), api_key)
+    return result
+
+def write_result_to_file(result, output_file):
+    global file_write_lock
+    with file_write_lock:
+        with open(output_file, "a") as outfile:
+            json.dump(result, outfile)
+            outfile.write("\n")
+
+def callback_with_lock(result, output_file):
+    global file_write_lock
+    write_result_to_file(result, output_file, file_write_lock)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, default=None, help="which model you want to use for eval, only support ['gpt*', 'claude*'] now")
+    parser.add_argument("--api_key", type=str, default=None, help="the api key provided for calling")
+    parser.add_argument("--output_file", type=str, default=None, help="the output file this script writes to")
+    parser.add_argument("--question_data", type=str, default=None, help="path to the questions data file")
+    parser.add_argument("--api_name", type=str, default=None, help="this will be the api dataset name you are testing, only support ['torchhub', 'tensorhun', 'huggingface'] now")
+    parser.add_argument("--retriever", type=str, default="bm25", help="which retriever to use")
+    parser.add_argument("--num_doc", type=int, default=1, help="top k docs to use")
+    parser.add_argument("--api_dataset", type=str, default=None, help="path to the api data")
+    args = parser.parse_args()
+
+    assert args.retriever in ["bm25", "gpt_index"]
+    if args.retriever == "gpt_index":
+        retriever = GPTIndexRetriever(query_kwargs={"similarity_top_k": args.num_doc})
+        if os.path.exists(args.retriever + '_dataset_index.json'):
+            print('data index already saved')
+            os.environ["OPENAI_API_KEY"] = args.api_key
+            index = retriever.load_from_disk(args.retriever + '_dataset_index.json')
+        else:
+            print('data index being created')
+            os.environ["OPENAI_API_KEY"] = args.api_key
+            documents = JSONLReader().load_data(args.api_dataset)
+            index = retriever.from_documents(documents)
+            retriever.save_to_disk(index, args.retriever + '_dataset_index.json')
+    elif args.retriever == "bm25":
+        from rank_bm25 import BM25Okapi
+        corpus = []
+        with open(args.api_dataset, 'r') as f:
+            for line in f:
+                corpus.append(json.loads(line))
+        tokenized_corpus = [str(doc).split(" ") for doc in corpus]
+        bm25 = BM25Okapi(tokenized_corpus)
+        retriever = BM25Retriever(index=bm25, corpus=corpus, query_kwargs={"similarity_top_k": args.num_doc})
+    else:
+        assert False
+
+    start_time = time.time()
+    # Read the question file
+    questions = []
+    question_ids = []
+    with open(args.question_data, 'r') as f:
+        for idx, line in enumerate(f):
+            questions.append(json.loads(line)["text"])
+            question_ids.append(json.loads(line)["question_id"])
+
+    file_write_lock = mp.Lock()
+    with mp.Pool(1) as pool:
+        results = []
+        for idx, (question, question_id) in enumerate(zip(questions, question_ids)):
+            result = pool.apply_async(
+                process_entry,
+                args=((question, question_id, args.api_name, args.model, retriever), args.api_key),
+                callback=lambda result: write_result_to_file(result, args.output_file),
+            )
+            results.append(result)
+        pool.close()
+        pool.join()
+
+    end_time = time.time()
+    print("Total time used: ", end_time - start_time)

--- a/eval/retrievers/__init__.py
+++ b/eval/retrievers/__init__.py
@@ -1,0 +1,7 @@
+from retrievers.gpt import GPTRetriever
+from retrievers.bm25 import BM25Retriever
+
+__all__ = [
+    "GPTRetriever", 
+    "BM25Retriever",
+]

--- a/eval/retrievers/bm25.py
+++ b/eval/retrievers/bm25.py
@@ -1,0 +1,30 @@
+"""
+Thanks to llama-index for the template of this code.
+"""
+from pydantic import BaseModel, Field
+from retrievers.schema import BaseRetriever, Document
+from rank_bm25 import BM25Okapi
+from typing import Any, Dict, List, cast
+
+
+class BM25Retriever(BaseRetriever, BaseModel):
+
+    index: Any
+    corpus: Any
+    query_kwargs: Dict = dict(similarity_top_k = 5)
+
+    def get_relevant_documents(self, query: str) -> List[Document]:
+
+        tokenized_query = query.split(" ")
+        bm25_docs = self.index.get_top_n(tokenized_query, self.corpus, n=self.query_kwargs["similarity_top_k"])
+        docs = []
+        for source_node in bm25_docs:
+            metadata = {}
+            docs.append(
+                Document(page_content=str(source_node), metadata=metadata)
+            )
+        return docs
+
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        raise NotImplementedError("Does not support async")
+

--- a/eval/retrievers/build_json_index.py
+++ b/eval/retrievers/build_json_index.py
@@ -1,0 +1,31 @@
+import json
+import re
+from typing import Any, Generator, List, Optional
+import abc
+
+from retrievers.schema import Document
+
+class JSONLReader(abc.ABC):
+    def __init__(
+        self, levels_back: Optional[int] = None, collapse_length: Optional[int] = None
+    ) -> None:
+        """Initialize with arguments."""
+        super().__init__()
+        self.levels_back = levels_back
+        self.collapse_length = collapse_length
+
+    def load_data(self, input_file: str) -> List[Document]:
+        """Load data from the input file."""
+        data = []
+        with open(input_file, "r") as f:
+            for line in f:
+                data.append(str(json.loads(line)))
+        if self.levels_back is None:
+            return [Document(page_content=_data) for _data in data]
+        elif self.levels_back is not None:
+            lines = [
+                *_depth_first_yield(
+                    data, self.levels_back, self.collapse_length, []
+                )
+            ]
+            return [Document(page_content="\n".join(lines))]

--- a/eval/retrievers/build_json_index.py
+++ b/eval/retrievers/build_json_index.py
@@ -1,3 +1,17 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import re
 from typing import Any, Generator, List, Optional

--- a/eval/retrievers/gpt.py
+++ b/eval/retrievers/gpt.py
@@ -1,3 +1,17 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List, cast, Optional
 
 from pydantic import BaseModel, Field

--- a/eval/retrievers/gpt.py
+++ b/eval/retrievers/gpt.py
@@ -1,0 +1,70 @@
+from typing import Any, Dict, List, cast, Optional
+
+from pydantic import BaseModel, Field
+from tenacity import retry, stop_after_attempt, wait_random_exponential
+from retrievers.schema import BaseRetriever, Document
+import openai
+import numpy as np
+import os
+import copy
+import json
+
+class GPTRetriever(BaseRetriever, BaseModel):
+
+    index: Any
+    query_kwargs: Dict = dict(similarity_top_k = 5)
+
+    @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
+    def get_embeddings(
+        self,
+	list_of_text: List[str],
+	engine: Optional[str] = None,
+    ) -> List[List[float]]:
+        assert len(list_of_text) <= 2048, "The number of docs should be <= 2048"
+        list_of_text = [text.replace("\n", " ") for text in list_of_text]
+        openai.api_key = os.environ["OPENAI_API_KEY"]
+        data = openai.Embedding.create(input=list_of_text, engine="text-embedding-ada-002").data
+        data = sorted(data, key=lambda x: x["index"])  # maintain the same order as input.
+        return [d["embedding"] for d in data]
+  
+    def from_documents(self, documents: List):
+        contents = [document.page_content for document in documents]
+        embeddings = self.get_embeddings(list_of_text=contents)
+        self.index = []
+        for i, (embedding, document) in enumerate(zip(embeddings, documents)):
+            new_node = {}
+            new_node["embedding"] = embedding
+            new_node["text"] = document.page_content
+            self.index.append(new_node)
+        return self.index
+
+    def save_to_disk(self, index, save_path):
+        with open(save_path, "w") as outfile:
+            json.dump(self.index, outfile)
+
+    def load_from_disk(self, load_path):
+        with open(load_path, "r") as loadfile:
+            self.index = json.load(loadfile)
+        
+    def get_relevant_documents(self, query: str) -> List[Document]:
+        docs_embeddings = np.array([doc["embedding"] for doc in self.index])
+
+        query_embedding = np.array(self.get_embeddings([query])[0])
+
+        # get cos similarity
+        docs_embeddings = docs_embeddings / np.linalg.norm(docs_embeddings, axis=-1, keepdims=True)
+        query_embedding = query_embedding / np.linalg.norm(query_embedding, axis=-1, keepdims=True)
+        logits = np.sum(query_embedding[None, :] * docs_embeddings, axis=-1)
+        top_k = logits.argsort()[-self.query_kwargs["similarity_top_k"]:][::-1]
+        top_k_docs = [self.index[i]["text"] for i in top_k]
+
+        # parse source nodes
+        docs = []
+        for source_node in top_k_docs:
+            docs.append(
+                Document(page_content=source_node, metadata="")
+            )
+        return docs
+
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        raise NotImplementedError("LlamaIndexRetriever does not support async")

--- a/eval/retrievers/schema.py
+++ b/eval/retrievers/schema.py
@@ -1,0 +1,396 @@
+"""
+Thanks to llama-index for the template of this code.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Generic, List, NamedTuple, Optional, TypeVar, Union
+
+from pydantic import BaseModel, Extra, Field, root_validator
+
+
+def get_buffer_string(
+    messages: List[BaseMessage], human_prefix: str = "Human", ai_prefix: str = "AI"
+) -> str:
+    """Get buffer string of messages."""
+    string_messages = []
+    for m in messages:
+        if isinstance(m, HumanMessage):
+            role = human_prefix
+        elif isinstance(m, AIMessage):
+            role = ai_prefix
+        elif isinstance(m, SystemMessage):
+            role = "System"
+        elif isinstance(m, ChatMessage):
+            role = m.role
+        else:
+            raise ValueError(f"Got unsupported message type: {m}")
+        string_messages.append(f"{role}: {m.content}")
+    return "\n".join(string_messages)
+
+
+class AgentAction(NamedTuple):
+    """Agent's action to take."""
+
+    tool: str
+    tool_input: Union[str, dict]
+    log: str
+
+
+class AgentFinish(NamedTuple):
+    """Agent's return value."""
+
+    return_values: dict
+    log: str
+
+
+class Generation(BaseModel):
+    """Output of a single generation."""
+
+    text: str
+    """Generated text output."""
+
+    generation_info: Optional[Dict[str, Any]] = None
+    """Raw generation info response from the provider"""
+    """May include things like reason for finishing (e.g. in OpenAI)"""
+    # TODO: add log probs
+
+
+class BaseMessage(BaseModel):
+    """Message object."""
+
+    content: str
+    additional_kwargs: dict = Field(default_factory=dict)
+
+    @property
+    @abstractmethod
+    def type(self) -> str:
+        """Type of the message, used for serialization."""
+
+
+class HumanMessage(BaseMessage):
+    """Type of message that is spoken by the human."""
+
+    @property
+    def type(self) -> str:
+        """Type of the message, used for serialization."""
+        return "human"
+
+
+class AIMessage(BaseMessage):
+    """Type of message that is spoken by the AI."""
+
+    @property
+    def type(self) -> str:
+        """Type of the message, used for serialization."""
+        return "ai"
+
+
+class SystemMessage(BaseMessage):
+    """Type of message that is a system message."""
+
+    @property
+    def type(self) -> str:
+        """Type of the message, used for serialization."""
+        return "system"
+
+
+class ChatMessage(BaseMessage):
+    """Type of message with arbitrary speaker."""
+
+    role: str
+
+    @property
+    def type(self) -> str:
+        """Type of the message, used for serialization."""
+        return "chat"
+
+
+def _message_to_dict(message: BaseMessage) -> dict:
+    return {"type": message.type, "data": message.dict()}
+
+
+def messages_to_dict(messages: List[BaseMessage]) -> List[dict]:
+    return [_message_to_dict(m) for m in messages]
+
+
+def _message_from_dict(message: dict) -> BaseMessage:
+    _type = message["type"]
+    if _type == "human":
+        return HumanMessage(**message["data"])
+    elif _type == "ai":
+        return AIMessage(**message["data"])
+    elif _type == "system":
+        return SystemMessage(**message["data"])
+    elif _type == "chat":
+        return ChatMessage(**message["data"])
+    else:
+        raise ValueError(f"Got unexpected type: {_type}")
+
+
+def messages_from_dict(messages: List[dict]) -> List[BaseMessage]:
+    return [_message_from_dict(m) for m in messages]
+
+
+class ChatGeneration(Generation):
+    """Output of a single generation."""
+
+    text = ""
+    message: BaseMessage
+
+    @root_validator
+    def set_text(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        values["text"] = values["message"].content
+        return values
+
+
+class ChatResult(BaseModel):
+    """Class that contains all relevant information for a Chat Result."""
+
+    generations: List[ChatGeneration]
+    """List of the things generated."""
+    llm_output: Optional[dict] = None
+    """For arbitrary LLM provider specific output."""
+
+
+class LLMResult(BaseModel):
+    """Class that contains all relevant information for an LLM Result."""
+
+    generations: List[List[Generation]]
+    """List of the things generated. This is List[List[]] because
+    each input could have multiple generations."""
+    llm_output: Optional[dict] = None
+    """For arbitrary LLM provider specific output."""
+
+
+class PromptValue(BaseModel, ABC):
+    @abstractmethod
+    def to_string(self) -> str:
+        """Return prompt as string."""
+
+    @abstractmethod
+    def to_messages(self) -> List[BaseMessage]:
+        """Return prompt as messages."""
+
+
+class BaseLanguageModel(BaseModel, ABC):
+    @abstractmethod
+    def generate_prompt(
+        self, prompts: List[PromptValue], stop: Optional[List[str]] = None
+    ) -> LLMResult:
+        """Take in a list of prompt values and return an LLMResult."""
+
+    @abstractmethod
+    async def agenerate_prompt(
+        self, prompts: List[PromptValue], stop: Optional[List[str]] = None
+    ) -> LLMResult:
+        """Take in a list of prompt values and return an LLMResult."""
+
+    def get_num_tokens(self, text: str) -> int:
+        """Get the number of tokens present in the text."""
+        # TODO: this method may not be exact.
+        # TODO: this method may differ based on model (eg codex).
+        try:
+            from transformers import GPT2TokenizerFast
+        except ImportError:
+            raise ValueError(
+                "Could not import transformers python package. "
+                "This is needed in order to calculate get_num_tokens. "
+                "Please install it with `pip install transformers`."
+            )
+        # create a GPT-3 tokenizer instance
+        tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
+
+        # tokenize the text using the GPT-3 tokenizer
+        tokenized_text = tokenizer.tokenize(text)
+
+        # calculate the number of tokens in the tokenized text
+        return len(tokenized_text)
+
+    def get_num_tokens_from_messages(self, messages: List[BaseMessage]) -> int:
+        """Get the number of tokens in the message."""
+        return sum([self.get_num_tokens(get_buffer_string([m])) for m in messages])
+
+
+class BaseMemory(BaseModel, ABC):
+    """Base interface for memory in chains."""
+
+    class Config:
+        """Configuration for this pydantic object."""
+
+        extra = Extra.forbid
+        arbitrary_types_allowed = True
+
+    @property
+    @abstractmethod
+    def memory_variables(self) -> List[str]:
+        """Input keys this memory class will load dynamically."""
+
+    @abstractmethod
+    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Return key-value pairs given the text input to the chain.
+
+        If None, return all memories
+        """
+
+    @abstractmethod
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        """Save the context of this model run to memory."""
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Clear memory contents."""
+
+
+class BaseChatMessageHistory(ABC):
+    """Base interface for chat message history
+    See `ChatMessageHistory` for default implementation.
+    """
+
+    """
+    Example:
+        .. code-block:: python
+
+            class FileChatMessageHistory(BaseChatMessageHistory):
+                storage_path:  str
+                session_id: str
+               
+               @property
+               def messages(self):
+                   with open(os.path.join(storage_path, session_id), 'r:utf-8') as f:
+                       messages = json.loads(f.read())
+                    return messages_from_dict(messages)     
+                
+               def add_user_message(self, message: str):
+                   message_ = HumanMessage(content=message)
+                   messages = self.messages.append(_message_to_dict(_message))
+                   with open(os.path.join(storage_path, session_id), 'w') as f:
+                       json.dump(f, messages)
+               
+               def add_ai_message(self, message: str):
+                   message_ = AIMessage(content=message)
+                   messages = self.messages.append(_message_to_dict(_message))
+                   with open(os.path.join(storage_path, session_id), 'w') as f:
+                       json.dump(f, messages)
+                       
+               def clear(self):
+                   with open(os.path.join(storage_path, session_id), 'w') as f:
+                       f.write("[]")
+    """
+
+    messages: List[BaseMessage]
+
+    @abstractmethod
+    def add_user_message(self, message: str) -> None:
+        """Add a user message to the store"""
+
+    @abstractmethod
+    def add_ai_message(self, message: str) -> None:
+        """Add an AI message to the store"""
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Remove all messages from the store"""
+
+
+class Document(BaseModel):
+    """Interface for interacting with a document."""
+
+    page_content: str
+    metadata: dict = Field(default_factory=dict)
+
+
+class BaseRetriever(ABC):
+    @abstractmethod
+    def get_relevant_documents(self, query: str) -> List[Document]:
+        """Get documents relevant for a query.
+
+        Args:
+            query: string to find relevant documents for
+
+        Returns:
+            List of relevant documents
+        """
+
+    @abstractmethod
+    async def aget_relevant_documents(self, query: str) -> List[Document]:
+        """Get documents relevant for a query.
+
+        Args:
+            query: string to find relevant documents for
+
+        Returns:
+            List of relevant documents
+        """
+
+
+# For backwards compatibility
+
+
+Memory = BaseMemory
+
+T = TypeVar("T")
+
+
+class BaseOutputParser(BaseModel, ABC, Generic[T]):
+    """Class to parse the output of an LLM call.
+
+    Output parsers help structure language model responses.
+    """
+
+    @abstractmethod
+    def parse(self, text: str) -> T:
+        """Parse the output of an LLM call.
+
+        A method which takes in a string (assumed output of language model )
+        and parses it into some structure.
+
+        Args:
+            text: output of language model
+
+        Returns:
+            structured output
+        """
+
+    def parse_with_prompt(self, completion: str, prompt: PromptValue) -> Any:
+        """Optional method to parse the output of an LLM call with a prompt.
+
+        The prompt is largely provided in the event the OutputParser wants
+        to retry or fix the output in some way, and needs information from
+        the prompt to do so.
+
+        Args:
+            completion: output of language model
+            prompt: prompt value
+
+        Returns:
+            structured output
+        """
+        return self.parse(completion)
+
+    def get_format_instructions(self) -> str:
+        """Instructions on how the LLM output should be formatted."""
+        raise NotImplementedError
+
+    @property
+    def _type(self) -> str:
+        """Return the type key."""
+        raise NotImplementedError
+
+    def dict(self, **kwargs: Any) -> Dict:
+        """Return dictionary representation of output parser."""
+        output_parser_dict = super().dict()
+        output_parser_dict["_type"] = self._type
+        return output_parser_dict
+
+
+class OutputParserException(Exception):
+    """Exception that output parsers should raise to signify a parsing error.
+
+    This exists to differentiate parsing errors from other code or execution errors
+    that also may arise inside the output parser. OutputParserExceptions will be
+    available to catch and handle in ways to fix the parsing error, while other
+    errors will be raised.
+    """
+
+    pass

--- a/inference/gorilla_eval.py
+++ b/inference/gorilla_eval.py
@@ -1,3 +1,17 @@
+# Copyright 2023 https://github.com/ShishirPatil/gorilla
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import argparse
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 openai
 anthropic
 tree_sitter
+tenacity==8.2.2
+pydantic==1.10.7
+rank-bm25==0.2.2


### PR DESCRIPTION
Gorilla introduces Retriever Aware Training (RAT). Here we include the code for retrievers. Note that while you can use  {prompt + retrieved API} with the 0-shot trained Gorilla LLMs for inference, for optimal performance, we recommend you use {prompt + retrieved API} with RAT trained Gorilla LLM for inference. 

More precisely, BM25 refers to `BM25Okapi` and GPT refers to `text-embedding-ada-002-v2`

Directly relevant to #58 and might be useful for #32 

+ Removing unused legacy code from `ast_eval_*.py`
+ Updating Apache 2.0 license for all of Gorilla code