### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere, Replicate Models - using litellm

### DIFF
--- a/eval/get_llm_responses.py
+++ b/eval/get_llm_responses.py
@@ -17,8 +17,11 @@ import sys
 import json
 import openai
 import anthropic
+import litellm
+from litellm import completion
 import multiprocessing as mp
 import time
+import os
 
 def encode_question(question, api_name):
     """Encode multiple prompt instructions into a single string."""
@@ -52,24 +55,15 @@ def get_response(get_response_input, api_key):
     question = encode_question(question, api_name)
     
     try:
-        if "gpt" in model:
+        if model in litellm.model_list:
             openai.api_key = api_key
-            responses = openai.ChatCompletion.create(
+            responses = completion(
                 model=model,
                 messages=question,
                 n=1,
                 temperature=0,
             )
             response = responses['choices'][0]['message']['content']
-        elif "claude" in model:
-            client = anthropic.Anthropic(api_key=api_key)
-            responses = client.completions.create(
-                prompt=f"{anthropic.HUMAN_PROMPT} {question[0]['content']}{question[1]['content']}{anthropic.AI_PROMPT}",
-                stop_sequences=[anthropic.HUMAN_PROMPT],
-                model="claude-v1",
-                max_tokens_to_sample=2048,
-            )
-            response = responses.completion.strip()
         else:
             print("Error: Model is not supported.")
     except Exception as e:

--- a/eval/get_llm_responses_retriever.py
+++ b/eval/get_llm_responses_retriever.py
@@ -17,6 +17,8 @@ import sys
 import json
 import openai
 import anthropic
+import litellm
+from litellm import completion
 import multiprocessing as mp
 import os
 import time
@@ -58,24 +60,15 @@ def get_response(get_response_input, api_key):
         question[-1]["content"] = question[-1]["content"] + "\nAPI " + str(i) + ": " + str(doc)
     
     try:
-        if "gpt" in model:
+        if model in litellm.model_list:
             openai.api_key = api_key
-            responses = openai.ChatCompletion.create(
+            responses = completion(
                 model=model,
                 messages=question,
                 n=1,
                 temperature=0,
             )
             response = responses['choices'][0]['message']['content']
-        elif "claude" in model:
-            client = anthropic.Anthropic(api_key=api_key)
-            responses = client.completions.create(
-                prompt=f"{anthropic.HUMAN_PROMPT} {question[0]['content']}{question[1]['content']}{anthropic.AI_PROMPT}",
-                stop_sequences=[anthropic.HUMAN_PROMPT],
-                model="claude-v1",
-                max_tokens_to_sample=2048,
-            )
-            response = responses.completion.strip()
         else:
             print("Error: Model is not supported.")
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 openai
+litellm
 anthropic
 tree_sitter
 tenacity==8.2.2


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using litellm https://github.com/BerriAI/litellm

TLDR: gorilla gets:
- more models out of the box, everything litellm integrates with
- instant integration of new models by modifying the `model` param (Easy to add models in the future, just change the model param)

Here's a sample of how it's used:
```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```