### PR TITLE
Fixed the warning message "Setting `pad_token_id` to `eos_token_id`:1…

### DIFF
--- a/inference/serve/gorilla_falcon_cli.py
+++ b/inference/serve/gorilla_falcon_cli.py
@@ -105,6 +105,7 @@ def get_response(prompt, model, tokenizer, device):
         do_sample=True,
         temperature=0.7,
         max_new_tokens=1024,
+        pad_token_id=tokenizer.eos_token_id
     )
     output_ids = output_ids[0][len(input_ids[0]) :]
     outputs = tokenizer.decode(output_ids, skip_special_tokens=True).strip()


### PR DESCRIPTION
When running the falcon model, after the user prompt, the model response is prefixed with this warning.
```
The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results. Setting `pad_token_id` to `eos_token_id`:11 for open-end generation. Fix for this issue
```

So Provided a fix.