### PR TITLE
Sandbox to execute gorilla output code

### DIFF
--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.8-slim
+
+COPY  ./sandbox .
+COPY ./requirements.txt ./requirements.txt
+RUN pip install --upgrade pip
+RUN apt-get update -y && apt-get install -y gcc
+RUN pip install -r requirements.txt
+
+
+CMD ["python3", "test.py"]

--- a/inference/sandbox/sandbox.py
+++ b/inference/sandbox/sandbox.py
@@ -1,0 +1,69 @@
+class Sandbox(object):
+
+    # language level sandboxed execute method
+    def execute(self, code_string):
+        import sys
+
+        # minimal blacklist at the moment - can be expanded / chagned to a whitelist approach
+        keyword_blacklist = ['file', 'quit', 'eval', 'exec']
+        
+        for keyword in keyword_blacklist:
+            if keyword in code_string:
+                raise ValueError("blacklisted")
+
+        # make built-ins read only to prevent users from messing up the expected behaviour of python itself
+        main = sys.modules["__main__"].__dict__
+        orig_builtins = main["__builtins__"].__dict__
+
+        safe_builtins = ReadOnlyBuiltins(orig_builtins)
+        main["__builtins__"] = safe_builtins
+
+
+        # libraries to modify the underlying CPython structure and allow us to delete attributes that can't otherwise be modified
+        from ctypes import pythonapi, POINTER, py_object
+        from types import FunctionType
+
+        # don't expose base classes and subclasses (could be sensitive references)
+        _get_dict = pythonapi._PyObject_GetDictPtr
+        _get_dict.restype = POINTER(py_object)
+        _get_dict.argtypes = [py_object]
+        del pythonapi, POINTER, py_object
+
+        def dictionary_of(ob):
+            dptr = _get_dict(ob)
+            return dptr.contents.value
+        
+
+        #these features work however pytorch and hugging face do need to use the base and sub classes as well as the code attribute. Disabling these language level protections for now
+        type_dict = dictionary_of(type)
+        # del type_dict["__bases__"] #prevents accessing base classes of an object
+        # del type_dict["__subclasses__"] #prevents accessing sub classes of an object
+
+        # don't expose import function attributes
+        function_dict = dictionary_of(FunctionType)
+        # del function_dict["__code__"] #prevents modifying the underlying function
+
+        # execute the final code string with these limited features
+        exec(code_string)
+
+
+# Read-only version of a dictionary used for the builtins. Raises a ValueError whenever a modifiction of the built-ins is attempted
+class ReadOnlyBuiltins(dict):
+    def __delitem__(self, key):
+        raise ValueError("Built-ins are read only")
+    
+    def pop(self, key, default=None):
+        raise ValueError("Built-ins are read only")
+    
+    def popitem(self):
+        raise ValueError("Built-ins are read only")
+    
+    def setdefault(self, key, value):
+        raise ValueError("Built-ins are read only")
+    
+    def __setitem__(self, key, value):
+        raise ValueError("Built-ins are read only")
+    
+    def update(self, dict, **kw):
+        raise ValueError("Built-ins are read only")
+    

--- a/inference/sandbox/spawn_docker_sandbox.py
+++ b/inference/sandbox/spawn_docker_sandbox.py
@@ -1,0 +1,16 @@
+import docker
+
+client = docker.from_env()
+
+#build a new image from the Dockerfile
+image, build_logs = client.images.build(path = '../', quiet=False)
+
+# uncomment for debugging the build logs
+# for chunk in build_logs:
+#     if 'stream' in chunk:
+#         for line in chunk['stream'].splitlines():
+#             print(line)
+
+# run a new container using the image built above and run the code produced by the llm. Print the stdout for the user to see
+output = client.containers.run(image) #read_only=True, , remove=True, privileged=False
+print(output)

--- a/inference/sandbox/test.py
+++ b/inference/sandbox/test.py
@@ -1,0 +1,27 @@
+from sandbox import Sandbox
+
+# create an instance of our langauge level sandbox
+s = Sandbox()
+
+# code output - would be from LLM. Currently used the language translation example from colab notebook
+code = """
+print("Hello world")
+
+from transformers import pipeline
+
+def process_data(text, translation):
+    response = translation(text)[0]['translation_text']
+    return response
+
+text = 'I feel very good today.'
+
+# Load the translation model
+translation = pipeline('translation_en_to_zh', model='Helsinki-NLP/opus-mt-en-zh')
+
+# Process the data
+response = process_data(text, translation)
+print(response)
+"""
+
+# execute the code by the LLM
+s.execute(code)


### PR DESCRIPTION
The goal of this feature is to allow the user to run the code outputted by Gorilla (Row #26 on the spreadsheet)

Current progress: The program spawns a docker container to run the code generated with some language-level sandboxing restrictions. Since it is currently raw docker, it is not fully secure as a sandbox but the container structure should handle typical cases of code generation. 

Todo: Integrate a virtualization layer to make it more secure and also implement a few more language-level sandboxing features.

How to test:
The sandboxing code is stored inside the `/inference/sandbox` folder. To test it, simply navigate into this folder and run `python3 spawn_docker_sandbox.py`. The code to be run can be changed in `test.py`. The current test is the language translation example from the colab notebook.

Credits:
Language-level sandboxing inspiration taken from Jessica McKellar's presentation at PyCon.