### PR TITLE
Leaderboard update: mistral-large-2402, gemini-1.0-pro and gemma 7-b; Update REST eval. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ const data = {
     datasets: [
         {
             label: 'GPT-4-0125',
-            data: [87.50, 82.18, 90.00, 90.00, 91.00, 54.12, 76.00, 70.00, 55.00],
+            data: [87.50, 82.18, 90.00, 90.00, 91.00, 67.06, 76.00, 70.00, 55.00],
             fill: true,
             backgroundColor: 'rgba(255, 206, 86, 0.1)',
             borderColor: 'rgb(255, 206, 86)',
@@ -152,7 +152,7 @@ const data = {
             pointHoverBorderColor: 'rgb(255, 206, 86)'
         }, {
             label: 'GPT-4-1106',
-            data: [88.75, 81.64, 92.00, 89.50, 92.00, 53.53, 72.00, 62.00, 50.00],
+            data: [88.75, 81.64, 92.00, 89.50, 92.00, 70.00, 72.00, 62.00, 50.00],
             fill: true,
             backgroundColor: 'rgba(75, 192, 192, 0.1)',
             borderColor: 'rgb(75, 192, 192)',
@@ -163,7 +163,7 @@ const data = {
             hidden: true
         }, {
             label: 'OpenFunctions-v2',
-            data: [71.67, 88.73, 79.50, 89.50, 78.00, 78.82, 76.00, 74.00, 60.00],
+            data: [71.67, 88.73, 79.50, 89.50, 78.00, 80.00, 76.00, 74.00, 60.00],
             fill: true,
             backgroundColor: 'rgba(153, 102, 255, 0.1)',
             borderColor: 'rgb(153, 102, 255)',
@@ -173,7 +173,7 @@ const data = {
             pointHoverBorderColor: 'rgb(153, 102, 255)'
         }, {
             label: 'GPT-3.5-Turbo',
-            data: [68.33, 81.27, 87.50, 88.00, 88.00, 74.12, 70.00, 74.00, 47.50],
+            data: [68.33, 81.27, 87.50, 88.00, 88.00, 80.00, 70.00, 74.00, 47.50],
             fill: true,
             backgroundColor: 'rgba(255, 159, 64, 0.1)',
             borderColor: 'rgb(255, 159, 64)',
@@ -184,7 +184,7 @@ const data = {
             hidden: true
         }, {
             label: 'Mistral-medium',
-            data: [90.00, 80.18, 71.00, 84.50, 68.00, 75.88, 62.00, 72.00, 47.50],
+            data: [90.00, 80.18, 71.00, 84.50, 68.00, 78.24, 62.00, 72.00, 47.50],
             fill: true,
             backgroundColor: 'rgba(54, 162, 235, 0.1)',
             borderColor: 'rgb(54, 162, 235)',
@@ -195,7 +195,7 @@ const data = {
             hidden: true
         }, {
             label: 'Claude-2.1',
-            data: [78.33, 85.64, 72.00, 83.00, 56.50, 61.18, 60.00, 48.00, 45.00],
+            data: [78.33, 85.64, 72.00, 83.00, 56.50, 63.53, 60.00, 48.00, 45.00],
             fill: true,
             backgroundColor: 'rgba(163, 73, 164, 0.1)',
             borderColor: 'rgb(163, 73, 164)',
@@ -206,7 +206,7 @@ const data = {
             hidden: true
         }, {
             label: 'Mistral-tiny',
-            data: [77.08, 59.27, 53.50, 59.50, 41.50, 58.24, 42.00, 64.00, 40.00],
+            data: [77.08, 59.27, 53.50, 59.50, 41.50, 63.53, 42.00, 64.00, 40.00],
             fill: true,
             backgroundColor: 'rgba(255, 105, 180, 0.1)',
             borderColor: 'rgb(255, 105, 180)',
@@ -217,7 +217,7 @@ const data = {
             hidden: true
         }, {
             label: 'Claude-instant',
-            data: [61.67, 68.73, 53.00, 59.00, 39.50, 51.76, 50.00, 52.00, 37.50],
+            data: [61.67, 68.73, 53.00, 59.00, 39.50, 56.47, 50.00, 52.00, 37.50],
             fill: true,
             backgroundColor: 'rgba(255, 165, 0, 0.1)',
             borderColor: 'rgb(255, 165, 0)',
@@ -228,7 +228,7 @@ const data = {
             hidden: true
         }, {
             label: 'Nexusflow-Raven-v2',
-            data: [0.00, 76.55, 39.50, 83.50, 34.00, 45.88, 68.00, 78.00, 45.00],
+            data: [0.00, 76.55, 39.50, 83.50, 34.00, 58.24, 68.00, 78.00, 45.00],
             fill: true,
             backgroundColor: 'rgba(60, 179, 113, 0.1)',
             borderColor: 'rgb(60, 179, 113)',
@@ -239,7 +239,7 @@ const data = {
             hidden: true
         }, {
             label: 'Mistral-small',
-            data: [89.58, 46.55, 48.50, 68.00, 58.00, 14.12, 40.00, 30.00, 37.50],
+            data: [89.58, 46.55, 48.50, 68.00, 58.00, 32.35, 40.00, 30.00, 37.50],
             fill: true,
             backgroundColor: 'rgba(0, 0, 255, 0.1)',
             borderColor: 'rgb(0, 0, 255)',
@@ -250,7 +250,7 @@ const data = {
             hidden: true
         }, {
             label: 'GPT-4-0613',
-            data: [87.08, 74.55, 4.00, 86.00, 0.00, 37.65, 0.00, 50.00, 0.00],
+            data: [87.08, 74.55, 4.00, 86.00, 0.00, 44.12, 0.00, 50.00, 0.00],
             fill: true,
             backgroundColor: 'rgba(128, 0, 0, 0.1)',
             borderColor: 'rgb(128, 0, 0)',
@@ -261,7 +261,7 @@ const data = {
             hidden: true
         }, {
             label: 'Deepseek-v1.5',
-            data: [66.25, 48.36, 35.00, 61.00, 43.50, 5.29, 0.00, 2.00, 7.50],
+            data: [66.25, 48.36, 35.00, 61.00, 43.50, 24.70, 0.00, 2.00, 7.50],
             fill: true,
             backgroundColor: 'rgba(255, 215, 0, 0.1)',
             borderColor: 'rgb(255, 215, 0)',
@@ -292,7 +292,52 @@ const data = {
             pointHoverBackgroundColor: '#fff',
             pointHoverBorderColor: 'rgb(255, 99, 132)',
             hidden: true
+        },  {
+            label: 'Gemini-1.0-Pro',
+            data: [77.50, 78.43, 89, 4.00, 0.00, 63.77, 62.00, 0.00, 0.00],
+            fill: true,
+            backgroundColor: 'rgba(218, 112, 214, 0.1)',
+            borderColor: 'rgb(218, 112, 214)',
+            pointBackgroundColor: 'rgb(218, 112, 214)',
+            pointBorderColor: '#fff',
+            pointHoverBackgroundColor: '#fff',
+            pointHoverBorderColor: 'rgb(218, 112, 214)',
+            hidden: true
+        }, {
+            label: 'Mistral-large-2402',
+            data: [84.58, 71.82, 90.50, 4.00, 0.00, 67.06, 66.00, 0.00, 5.00],
+            fill: true,
+            backgroundColor: 'rgba(65, 105, 225, 0.1)',
+            borderColor: 'rgb(65, 105, 225)',
+            pointBackgroundColor: 'rgb(65, 105, 225)',
+            pointBorderColor: '#fff',
+            pointHoverBackgroundColor: '#fff',
+            pointHoverBorderColor: 'rgb(65, 105, 225)',
+            hidden: true
+        }, {
+            label: 'Firefunction-v1',
+            data: [81.25, 73.19, 87.00, 4.00, 0.00, 61.76, 64.00, 0.00, 5.00],
+            fill: true,
+            backgroundColor: 'rgba(0, 255, 255, 0.1)',
+            borderColor: 'rgb(0, 255, 255)',
+            pointBackgroundColor: 'rgb(0, 255, 255)',
+            pointBorderColor: '#fff',
+            pointHoverBackgroundColor: '#fff',
+            pointHoverBorderColor: 'rgb(0, 255, 255)',
+            hidden: true
+        }, {
+            label: 'Gemma',
+            data: [0.42, 61.45, 60.00, 41.00, 32.50, 44.71, 46.00, 44.00, 25.50],
+            fill: true,
+            backgroundColor: 'rgba(85, 107, 47, 0.1)',
+            borderColor: 'rgb(85, 107, 47)',
+            pointBackgroundColor: 'rgb(85, 107, 47)',
+            pointBorderColor: '#fff',
+            pointHoverBackgroundColor: '#fff',
+            pointHoverBorderColor: 'rgb(85, 107, 47)',
+            hidden: true
         },
+
 
     ]
 };

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -581,8 +581,7 @@
                 </div>
                 <div class="output-section">
                     <div class="output" id="code-output">Output will be shown here:</div>
-                    <div class="output" id="json-output" style="white-space: pre-wrap;">OpenAI compatible format output
-                        here:</div>
+                    <div class="output" id="json-output" style="white-space: pre-wrap;">OpenAI compatible format output here:</div>
 
                     <div class="button-container">
                             <button class="thumbs" id="thumbs-up-btn" onclick="sendFeedbackPositive()" style="display: none;">👍</button>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -121,27 +121,6 @@
                     <tbody>
                         <tr>
                             <td>1</td>
-                            <td>83.80</td>
-                            <td>
-                                <a href=''>GPT-4-0125-Preview</a>
-                            </td>
-                            <td>OpenAI</td>
-                            <td>Proprietary</td>
-                            <td class="summary-row">88.30</td>
-                            <td class="summary-row">63.78</td>
-                            <td class="summary-row">87.50</td>
-                            <td class="detail-row">82.18</td>
-                            <td class="detail-row">90.00</td>
-                            <td class="detail-row">90.00</td>
-                            <td class="detail-row">91.00</td>
-                            <td class="detail-row">54.12</td>
-                            <td class="detail-row">70.00</td>
-                            <td class="detail-row">76.00</td>
-                            <td class="detail-row">55.00</td>
-                            <td class="detail-row">87.50</td>
-                        </tr>
-                        <tr>
-                            <td>2</td>
                             <td>83.55</td>
                             <td>
                                 <a href=''>GPT-4-1106-Preview</a>
@@ -149,17 +128,38 @@
                             <td>OpenAI</td>
                             <td>Proprietary</td>
                             <td class="summary-row">88.78</td>
-                            <td class="summary-row">59.38</td>
+                            <td class="summary-row">63.50</td>
                             <td class="summary-row">88.75</td>
                             <td class="detail-row">81.64</td>
                             <td class="detail-row">89.50</td>
                             <td class="detail-row">92.00</td>
                             <td class="detail-row">92.00</td>
-                            <td class="detail-row">53.53</td>
+                            <td class="detail-row">70.00</td>
                             <td class="detail-row">62.00</td>
                             <td class="detail-row">72.00</td>
                             <td class="detail-row">50.00</td>
                             <td class="detail-row">88.75</td>
+                        </tr>
+                        <tr>
+                            <td>2</td>
+                            <td>83.80</td>
+                            <td>
+                                <a href=''>GPT-4-0125-Preview</a>
+                            </td>
+                            <td>OpenAI</td>
+                            <td>Proprietary</td>
+                            <td class="summary-row">88.30</td>
+                            <td class="summary-row">67.02</td>
+                            <td class="summary-row">87.50</td>
+                            <td class="detail-row">82.18</td>
+                            <td class="detail-row">90.00</td>
+                            <td class="detail-row">90.00</td>
+                            <td class="detail-row">91.00</td>
+                            <td class="detail-row">67.06</td>
+                            <td class="detail-row">70.00</td>
+                            <td class="detail-row">76.00</td>
+                            <td class="detail-row">55.00</td>
+                            <td class="detail-row">87.50</td>
                         </tr>
                         <tr>
                             <td>3</td>
@@ -170,13 +170,13 @@
                             <td>Gorilla LLM</td>
                             <td>Apache 2.0</td>
                             <td class="summary-row">83.93</td>
-                            <td class="summary-row">72.20</td>
+                            <td class="summary-row">72.50</td>
                             <td class="summary-row">71.67</td>
                             <td class="detail-row">88.73</td>
                             <td class="detail-row">89.50</td>
                             <td class="detail-row">79.50</td>
                             <td class="detail-row">78.00</td>
-                            <td class="detail-row">78.82</td>
+                            <td class="detail-row">80.00</td>
                             <td class="detail-row">74.00</td>
                             <td class="detail-row">76.00</td>
                             <td class="detail-row">60.00</td>
@@ -191,13 +191,13 @@
                             <td>OpenAI</td>
                             <td>Proprietary</td>
                             <td class="summary-row">86.19</td>
-                            <td class="summary-row">66.41</td>
+                            <td class="summary-row">67.88</td>
                             <td class="summary-row">68.33</td>
                             <td class="detail-row">81.27</td>
                             <td class="detail-row">88.00</td>
                             <td class="detail-row">87.50</td>
                             <td class="detail-row">88.00</td>
-                            <td class="detail-row">74.12</td>
+                            <td class="detail-row">80.00</td>
                             <td class="detail-row">74.00</td>
                             <td class="detail-row">70.00</td>
                             <td class="detail-row">47.50</td>
@@ -212,13 +212,13 @@
                             <td>Mistral AI</td>
                             <td>Proprietary</td>
                             <td class="summary-row">75.92</td>
-                            <td class="summary-row">64.34</td>
+                            <td class="summary-row">64.94</td>
                             <td class="summary-row">90.00</td>
                             <td class="detail-row">80.18</td>
                             <td class="detail-row">84.50</td>
                             <td class="detail-row">71.00</td>
                             <td class="detail-row">68.00</td>
-                            <td class="detail-row">75.88</td>
+                            <td class="detail-row">78.24</td>
                             <td class="detail-row">72.00</td>
                             <td class="detail-row">62.00</td>
                             <td class="detail-row">47.50</td>
@@ -233,13 +233,13 @@
                             <td>Anthropic</td>
                             <td>Proprietary</td>
                             <td class="summary-row">74.28</td>
-                            <td class="summary-row">53.55</td>
+                            <td class="summary-row">54.13</td>
                             <td class="summary-row">78.33</td>
                             <td class="detail-row">85.64</td>
                             <td class="detail-row">83.00</td>
                             <td class="detail-row">72.00</td>
                             <td class="detail-row">56.50</td>
-                            <td class="detail-row">61.18</td>
+                            <td class="detail-row">63.53</td>
                             <td class="detail-row">48.00</td>
                             <td class="detail-row">60.00</td>
                             <td class="detail-row">45.00</td>
@@ -254,13 +254,13 @@
                             <td>Mistral AI</td>
                             <td>Proprietary</td>
                             <td class="summary-row">53.44</td>
-                            <td class="summary-row">51.06</td>
+                            <td class="summary-row">52.38</td>
                             <td class="summary-row">77.08</td>
                             <td class="detail-row">59.27</td>
                             <td class="detail-row">59.50</td>
                             <td class="detail-row">53.50</td>
                             <td class="detail-row">41.50</td>
-                            <td class="detail-row">58.24</td>
+                            <td class="detail-row">63.53</td>
                             <td class="detail-row">64.00</td>
                             <td class="detail-row">42.00</td>
                             <td class="detail-row">40.00</td>
@@ -275,13 +275,13 @@
                             <td>Anthropic</td>
                             <td>Proprietary</td>
                             <td class="summary-row">55.06</td>
-                            <td class="summary-row">47.81</td>
+                            <td class="summary-row">48.99</td>
                             <td class="summary-row">61.67</td>
                             <td class="detail-row">68.73</td>
                             <td class="detail-row">59.00</td>
                             <td class="detail-row">53.00</td>
                             <td class="detail-row">39.50</td>
-                            <td class="detail-row">51.76</td>
+                            <td class="detail-row">56.47</td>
                             <td class="detail-row">52.00</td>
                             <td class="detail-row">50.00</td>
                             <td class="detail-row">37.50</td>
@@ -289,27 +289,6 @@
                         </tr>
                         <tr>
                             <td>9</td>
-                            <td>55.84</td>
-                            <td>
-                                <a href=''>Mistral-large</a>
-                            </td>
-                            <td>Mistral AI</td>
-                            <td>Proprietary</td>
-                            <td class="summary-row">41.58</td>
-                            <td class="summary-row">33.19</td>
-                            <td class="summary-row">84.58</td>
-                            <td class="detail-row">71.82</td>
-                            <td class="detail-row">90.50</td>
-                            <td class="detail-row">4.00</td>
-                            <td class="detail-row">0.00</td>
-                            <td class="detail-row">61.76</td>
-                            <td class="detail-row">66.00</td>
-                            <td class="detail-row">0.00</td>
-                            <td class="detail-row">5.00</td>
-                            <td class="detail-row">84.58</td>
-                        </tr>
-                        <tr>
-                            <td>10</td>
                             <td>54.99</td>
                             <td>
                                 <a href=''>Gemini-1.0-Pro</a>
@@ -317,62 +296,41 @@
                             <td>Google</td>
                             <td>Proprietary</td>
                             <td class="summary-row">42.86</td>
-                            <td class="summary-row">27.03</td>
+                            <td class="summary-row">31.44</td>
                             <td class="summary-row">77.50</td>
                             <td class="detail-row">78.43</td>
                             <td class="detail-row">89</td>
                             <td class="detail-row">4.00</td>
                             <td class="detail-row">0.00</td>
-                            <td class="detail-row">46.12</td>
+                            <td class="detail-row">63.77</td>
                             <td class="detail-row">62.00</td>
                             <td class="detail-row">0.00</td>
                             <td class="detail-row">0.00</td>
                             <td class="detail-row">77.50</td>
                         </tr>
                         <tr>
-                            <td>11</td>
-                            <td>54.46</td>
+                            <td>10</td>
+                            <td>55.84</td>
                             <td>
-                                <a href=''>Nexusflow-Raven-v2</a>
+                                <a href=''>Mistral-large-2402</a>
                             </td>
-                            <td>Nexusflow</td>
-                            <td>Apache 2.0</td>
-                            <td class="summary-row">58.39</td>
-                            <td class="summary-row">59.22</td>
-                            <td class="summary-row">0.00</td>
-                            <td class="detail-row">76.55</td>
-                            <td class="detail-row">83.50</td>
-                            <td class="detail-row">39.50</td>
-                            <td class="detail-row">34.00</td>
-                            <td class="detail-row">45.88</td>
-                            <td class="detail-row">78.00</td>
-                            <td class="detail-row">68.00</td>
-                            <td class="detail-row">45.00</td>
-                            <td class="detail-row">0.00</td>
-                        </tr>
-                        <tr>
-                            <td>12</td>
-                            <td>53.95</td>
-                            <td>
-                                <a href=''>Firefunction-v1</a>
-                            </td>
-                            <td>Fireworks-ai</td>
-                            <td>Apache 2.0</td>
-                            <td class="summary-row">41.05</td>
-                            <td class="summary-row">29.31</td>
-                            <td class="summary-row">81.25</td>
-                            <td class="detail-row">73.19</td>
-                            <td class="detail-row">87.00</td>
+                            <td>Mistral AI</td>
+                            <td>Proprietary</td>
+                            <td class="summary-row">41.58</td>
+                            <td class="summary-row">34.52</td>
+                            <td class="summary-row">84.58</td>
+                            <td class="detail-row">71.82</td>
+                            <td class="detail-row">90.50</td>
                             <td class="detail-row">4.00</td>
                             <td class="detail-row">0.00</td>
-                            <td class="detail-row">48.24</td>
-                            <td class="detail-row">64.00</td>
+                            <td class="detail-row">67.06</td>
+                            <td class="detail-row">66.00</td>
                             <td class="detail-row">0.00</td>
                             <td class="detail-row">5.00</td>
-                            <td class="detail-row">81.25</td>
+                            <td class="detail-row">84.58</td>
                         </tr>
                         <tr>
-                            <td>13</td>
+                            <td>11</td>
                             <td>53.86</td>
                             <td>
                                 <a href=''>Mistral-small</a>
@@ -380,17 +338,59 @@
                             <td>Mistral AI</td>
                             <td>Proprietary</td>
                             <td class="summary-row">55.26</td>
-                            <td class="summary-row">30.41</td>
+                            <td class="summary-row">34.96</td>
                             <td class="summary-row">89.58</td>
                             <td class="detail-row">46.55</td>
                             <td class="detail-row">68.00</td>
                             <td class="detail-row">48.50</td>
                             <td class="detail-row">58.00</td>
-                            <td class="detail-row">14.12</td>
+                            <td class="detail-row">32.35</td>
                             <td class="detail-row">30.00</td>
                             <td class="detail-row">40.00</td>
                             <td class="detail-row">37.50</td>
                             <td class="detail-row">89.58</td>
+                        </tr>
+                        <tr>
+                            <td>12</td>
+                            <td>54.46</td>
+                            <td>
+                                <a href=''>Nexusflow-Raven-v2</a>
+                            </td>
+                            <td>Nexusflow</td>
+                            <td>Apache 2.0</td>
+                            <td class="summary-row">58.39</td>
+                            <td class="summary-row">62.31</td>
+                            <td class="summary-row">0.00</td>
+                            <td class="detail-row">76.55</td>
+                            <td class="detail-row">83.50</td>
+                            <td class="detail-row">39.50</td>
+                            <td class="detail-row">34.00</td>
+                            <td class="detail-row">58.24</td>
+                            <td class="detail-row">78.00</td>
+                            <td class="detail-row">68.00</td>
+                            <td class="detail-row">45.00</td>
+                            <td class="detail-row">0.00</td>
+                        </tr>
+                        <tr>
+                            <td>13</td>
+                            <td>53.95</td>
+                            <td>
+                                <a href=''>Firefunction-v1</a>
+                            </td>
+                            <td>Fireworks-ai</td>
+                            <td>Apache 2.0</td>
+                            <td class="summary-row">41.05</td>
+                            <td class="summary-row">32.69</td>
+                            <td class="summary-row">81.25</td>
+                            <td class="detail-row">73.19</td>
+                            <td class="detail-row">87.00</td>
+                            <td class="detail-row">4.00</td>
+                            <td class="detail-row">0.00</td>
+                            <td class="detail-row">61.76</td>
+                            <td class="detail-row">64.00</td>
+                            <td class="detail-row">0.00</td>
+                            <td class="detail-row">5.00</td>
+                            <td class="detail-row">81.25</td>
                         </tr>
                         <tr>
                             <td>14</td>
@@ -401,13 +401,13 @@
                             <td>OpenAI</td>
                             <td>Proprietary</td>
                             <td class="summary-row">41.14</td>
-                            <td class="summary-row">21.91</td>
+                            <td class="summary-row">23.53</td>
                             <td class="summary-row">87.08</td>
                             <td class="detail-row">74.55</td>
                             <td class="detail-row">86.00</td>
                             <td class="detail-row">4.00</td>
                             <td class="detail-row">0.00</td>
-                            <td class="detail-row">37.65</td>
+                            <td class="detail-row">44.12</td>
                             <td class="detail-row">50.00</td>
                             <td class="detail-row">0.00</td>
                             <td class="detail-row">0.00</td>
@@ -415,27 +415,6 @@
                         </tr>
                         <tr>
                             <td>15</td>
-                            <td>44.46</td>
-                            <td>
-                                <a href=''>Gemma</a>
-                            </td>
-                            <td>Google</td>
-                            <td>gemma-term-of-use</td>
-                            <td class="summary-row">48.74</td>
-                            <td class="summary-row">40.34</td>
-                            <td class="summary-row">0.42</td>
-                            <td class="detail-row">61.45</td>
-                            <td class="detail-row">60.00</td>
-                            <td class="detail-row">41.00</td>
-                            <td class="detail-row">32.50</td>
-                            <td class="detail-row">45.88</td>
-                            <td class="detail-row">46.00</td>
-                            <td class="detail-row">44.00</td>
-                            <td class="detail-row">25.50</td>
-                            <td class="detail-row">0.42</td>
-                        </tr>
-                        <tr>
-                            <td>16</td>
                             <td>43.19</td>
                             <td>
                                 <a href=''>Deepseek-v1.5</a>
@@ -443,17 +422,38 @@
                             <td>Deepseek</td>
                             <td>Deepseek License</td>
                             <td class="summary-row">46.97</td>
-                            <td class="summary-row">3.7</td>
+                            <td class="summary-row">8.55</td>
                             <td class="summary-row">66.25</td>
                             <td class="detail-row">48.36</td>
                             <td class="detail-row">61.00</td>
                             <td class="detail-row">35.00</td>
                             <td class="detail-row">43.50</td>
-                            <td class="detail-row">5.29</td>
+                            <td class="detail-row">24.70</td>
                             <td class="detail-row">2.00</td>
                             <td class="detail-row">0.00</td>
                             <td class="detail-row">7.50</td>
                             <td class="detail-row">66.25</td>
+                        </tr>
+                        <tr>
+                            <td>16</td>
+                            <td>44.46</td>
+                            <td>
+                                <a href=''>Gemma</a>
+                            </td>
+                            <td>Google</td>
+                            <td>gemma-term-of-use</td>
+                            <td class="summary-row">48.74</td>
+                            <td class="summary-row">40.05</td>
+                            <td class="summary-row">0.42</td>
+                            <td class="detail-row">61.45</td>
+                            <td class="detail-row">60.00</td>
+                            <td class="detail-row">41.00</td>
+                            <td class="detail-row">32.50</td>
+                            <td class="detail-row">44.71</td>
+                            <td class="detail-row">46.00</td>
+                            <td class="detail-row">44.00</td>
+                            <td class="detail-row">25.50</td>
+                            <td class="detail-row">0.42</td>
                         </tr>
                         <tr>
                             <td>17</td>


### PR DESCRIPTION
Update leaderboard data and wagon wheel data to reflect new models and the updated rest API eval result.

Change leaderboard to include `mistral-large-2402`, `gemini-1.0-pro`, and `gemma-7b`.
Change leaderboard evals to be consistent with #234 