### PR TITLE
Patch: Updating the overall column of the leaderboard numbers to reflect #237

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -121,7 +121,7 @@
                     <tbody>
                         <tr>
                             <td>1</td>
-                            <td>83.55</td>
+                            <td>85.24/td>
                             <td>
                                 <a href=''>GPT-4-1106-Preview</a>
                             </td>
@@ -142,7 +142,7 @@
                         </tr>
                         <tr>
                             <td>2</td>
-                            <td>83.80</td>
+                            <td>85.12</td>
                             <td>
                                 <a href=''>GPT-4-0125-Preview</a>
                             </td>
@@ -163,7 +163,7 @@
                         </tr>
                         <tr>
                             <td>3</td>
-                            <td>83.55</td>
+                            <td>83.67</td>
                             <td>
                                 <a href=''>Gorilla-OpenFunctions-v2</a>
                             </td>
@@ -184,7 +184,7 @@
                         </tr>
                         <tr>
                             <td>4</td>
-                            <td>81.63</td>
+                            <td>82.23</td>
                             <td>
                                 <a href=''>GPT-3.5-Turbo</a>
                             </td>
@@ -205,7 +205,7 @@
                         </tr>
                         <tr>
                             <td>5</td>
-                            <td>79.46</td>
+                            <td>79.70</td>
                             <td>
                                 <a href=''>Mistral-medium</a>
                             </td>
@@ -226,7 +226,7 @@
                         </tr>
                         <tr>
                             <td>6</td>
-                            <td>75.78</td>
+                            <td>76.02</td>
                             <td>
                                 <a href=''>Claude-2.1</a>
                             </td>
@@ -247,7 +247,7 @@
                         </tr>
                         <tr>
                             <td>7</td>
-                            <td>59.52</td>
+                            <td>60.06</td>
                             <td>
                                 <a href=''>Mistral-tiny</a>
                             </td>
@@ -268,7 +268,7 @@
                         </tr>
                         <tr>
                             <td>8</td>
-                            <td>59.22</td>
+                            <td>59.70</td>
                             <td>
                                 <a href=''>Claude-instant</a>
                             </td>
@@ -289,7 +289,7 @@
                         </tr>
                         <tr>
                             <td>9</td>
-                            <td>54.99</td>
+                            <td>56.79</td>
                             <td>
                                 <a href=''>Gemini-1.0-Pro</a>
                             </td>
@@ -310,7 +310,7 @@
                         </tr>
                         <tr>
                             <td>10</td>
-                            <td>55.84</td>
+                            <td>56.39</td>
                             <td>
                                 <a href=''>Mistral-large-2402</a>
                             </td>
@@ -331,7 +331,7 @@
                         </tr>
                         <tr>
                             <td>11</td>
-                            <td>53.86</td>
+                            <td>55.72</td>
                             <td>
                                 <a href=''>Mistral-small</a>
                             </td>
@@ -352,7 +352,7 @@
                         </tr>
                         <tr>
                             <td>12</td>
-                            <td>54.46</td>
+                            <td>55.72</td>
                             <td>
                                 <a href=''>Nexusflow-Raven-v2</a>
                             </td>
@@ -373,7 +373,7 @@
                         </tr>
                         <tr>
                             <td>13</td>
-                            <td>53.95</td>
+                            <td>55.33</td>
                             <td>
                                 <a href=''>Firefunction-v1</a>
                             </td>
@@ -394,7 +394,7 @@
                         </tr>
                         <tr>
                             <td>14</td>
-                            <td>53.49</td>
+                            <td>54.16</td>
                             <td>
                                 <a href=''>GPT-4-0613</a>
                             </td>
@@ -415,7 +415,7 @@
                         </tr>
                         <tr>
                             <td>15</td>
-                            <td>43.19</td>
+                            <td>45.18</td>
                             <td>
                                 <a href=''>Deepseek-v1.5</a>
                             </td>
@@ -436,7 +436,7 @@
                         </tr>
                         <tr>
                             <td>16</td>
-                            <td>44.46</td>
+                            <td>44.34</td>
                             <td>
                                 <a href=''>Gemma</a>
                             </td>


### PR DESCRIPTION
Update the `overall` accuracy columns for the leaderboard, as the new rest API evaluation result changed those values. 
Note, this change is not reflected in the previous pr #237 .