### PR TITLE
Rename models on leaderboard. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ const data = {
             pointHoverBackgroundColor: '#fff',
             pointHoverBorderColor: 'rgb(153, 102, 255)'
         }, {
-            label: 'GPT-3.5-Turbo',
+            label: 'GPT-3.5-Turbo-0125',
             data: [68.33, 81.27, 87.50, 88.00, 88.00, 80.00, 70.00, 74.00, 47.50],
             fill: true,
             backgroundColor: 'rgba(255, 159, 64, 0.1)',

--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ const data = {
             pointHoverBorderColor: 'rgb(218, 112, 214)',
             hidden: true
         }, {
-            label: 'Mistral-large-2402 (FC)',
+            label: 'Mistral-large-2402',
             data: [84.58, 71.82, 90.50, 4.00, 0.00, 67.06, 66.00, 0.00, 5.00],
             fill: true,
             backgroundColor: 'rgba(65, 105, 225, 0.1)',

--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ const data = {
             pointHoverBorderColor: 'rgb(255, 159, 64)',
             hidden: true
         }, {
-            label: 'Mistral-medium',
+            label: 'Mistral-medium-2312',
             data: [90.00, 80.18, 71.00, 84.50, 68.00, 78.24, 62.00, 72.00, 47.50],
             fill: true,
             backgroundColor: 'rgba(54, 162, 235, 0.1)',
@@ -205,7 +205,7 @@ const data = {
             pointHoverBorderColor: 'rgb(163, 73, 164)',
             hidden: true
         }, {
-            label: 'Mistral-tiny',
+            label: 'Mistral-tiny-2312',
             data: [77.08, 59.27, 53.50, 59.50, 41.50, 63.53, 42.00, 64.00, 40.00],
             fill: true,
             backgroundColor: 'rgba(255, 105, 180, 0.1)',
@@ -216,7 +216,7 @@ const data = {
             pointHoverBorderColor: 'rgb(255, 105, 180)',
             hidden: true
         }, {
-            label: 'Claude-instant',
+            label: 'Claude-instant-1.2',
             data: [61.67, 68.73, 53.00, 59.00, 39.50, 56.47, 50.00, 52.00, 37.50],
             fill: true,
             backgroundColor: 'rgba(255, 165, 0, 0.1)',
@@ -238,7 +238,7 @@ const data = {
             pointHoverBorderColor: 'rgb(60, 179, 113)',
             hidden: true
         }, {
-            label: 'Mistral-small',
+            label: 'Mistral-small-2312',
             data: [89.58, 46.55, 48.50, 68.00, 58.00, 32.35, 40.00, 30.00, 37.50],
             fill: true,
             backgroundColor: 'rgba(0, 0, 255, 0.1)',
@@ -304,7 +304,7 @@ const data = {
             pointHoverBorderColor: 'rgb(218, 112, 214)',
             hidden: true
         }, {
-            label: 'Mistral-large-2402',
+            label: 'Mistral-large-2402 (FC)',
             data: [84.58, 71.82, 90.50, 4.00, 0.00, 67.06, 66.00, 0.00, 5.00],
             fill: true,
             backgroundColor: 'rgba(65, 105, 225, 0.1)',

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -207,7 +207,7 @@
                             <td>5</td>
                             <td>79.70</td>
                             <td>
-                                <a href=''>Mistral-medium</a>
+                                <a href=''>Mistral-medium-2312</a>
                             </td>
                             <td>Mistral AI</td>
                             <td>Proprietary</td>
@@ -249,7 +249,7 @@
                             <td>7</td>
                             <td>60.06</td>
                             <td>
-                                <a href=''>Mistral-tiny</a>
+                                <a href=''>Mistral-tiny-2312</a>
                             </td>
                             <td>Mistral AI</td>
                             <td>Proprietary</td>
@@ -270,7 +270,7 @@
                             <td>8</td>
                             <td>59.70</td>
                             <td>
-                                <a href=''>Claude-instant</a>
+                                <a href=''>Claude-instant-1.2</a>
                             </td>
                             <td>Anthropic</td>
                             <td>Proprietary</td>
@@ -291,7 +291,7 @@
                             <td>9</td>
                             <td>56.39</td>
                             <td>
-                                <a href=''>Mistral-large-2402</a>
+                                <a href=''>Mistral-large-2402 (FC)</a>
                             </td>
                             <td>Mistral AI</td>
                             <td>Proprietary</td>
@@ -312,7 +312,7 @@
                             <td>10</td>
                             <td>55.72</td>
                             <td>
-                                <a href=''>Mistral-small</a>
+                                <a href=''>Mistral-small-2312</a>
                             </td>
                             <td>Mistral AI</td>
                             <td>Proprietary</td>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -291,7 +291,7 @@
                             <td>9</td>
                             <td>56.39</td>
                             <td>
-                                <a href=''>Mistral-large-2402 (FC)</a>
+                                <a href=''>Mistral-large-2402</a>
                             </td>
                             <td>Mistral AI</td>
                             <td>Proprietary</td>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -186,7 +186,7 @@
                             <td>4</td>
                             <td>82.23</td>
                             <td>
-                                <a href=''>GPT-3.5-Turbo</a>
+                                <a href=''>GPT-3.5-Turbo-0125</a>
                             </td>
                             <td>OpenAI</td>
                             <td>Proprietary</td>


### PR DESCRIPTION
This PR renamed the following models to be more precise.

1. GPT-3.5-Turbo to GPT-3.5-Turbo-0125
2. claude-instant to claude-instant-1.2
3. mistral-tiny to mistral-tiny-2312
4. mistral-small to mistral-small-2312
5. mistral-medium to mistral-medium-2312
6. mistral-large-2402 to mistral-large-2402