### PR TITLE
[Fix] java, javascript parsers in openfunctions-v2

### DIFF
--- a/openfunctions/utils/java_parser.py
+++ b/openfunctions/utils/java_parser.py
@@ -5,9 +5,7 @@ from tree_sitter import Language, Parser
 from tree_sitter import Language, Parser
 
 Language.build_library(
-    # Store the library in the `build` directory
     "build/tree_sitter.so",
-    # Include one or more languages
     ["./tree-sitter-java"],
 )
 JAVA_LANGUAGE = Language("build/tree_sitter.so", "java")
@@ -15,9 +13,21 @@ parser = Parser()
 parser.set_language(JAVA_LANGUAGE)
 
 def parse_java_function_call(source_code):
+    """
+    Parses the given Java function call code and extracts information about method invocations.
+
+    Args:
+        source_code (str): The Java source code to parse.
+
+    Returns:
+        dict: A dictionary containing information about the method invocation, including the function name and its parameters.
+              If there is an error during parsing, None is returned.
+    """
     tree = parser.parse(bytes(source_code, "utf8"))
     root_node = tree.root_node
     sexp_result = root_node.sexp()
+    print("S-expression result: ")
+    print(sexp_result)
     
     if "ERROR" in sexp_result:
         return None
@@ -53,7 +63,12 @@ def parse_java_function_call(source_code):
             arguments_node = node.child_by_field_name('arguments')
             type_text = traverse_node(type_node, True)
             if arguments_node:
-                arguments_text = traverse_node(arguments_node, True)
+                argument_texts = []
+                for child in arguments_node.children:
+                    if child.type not in [',', '(', ')']:  # Exclude commas and parentheses
+                        argument_text = traverse_node(child, True)
+                        argument_texts.append(argument_text)
+                arguments_text = ', '.join(argument_texts)
                 return f"new {type_text}({arguments_text})"
             else:
                 return f"new {type_text}()"
@@ -68,6 +83,16 @@ def parse_java_function_call(source_code):
             return get_text(node)
 
     def extract_arguments(args_node):
+        """
+        Extracts the arguments from the given args_node and returns a dictionary of arguments.
+
+        Args:
+            args_node (Node): The node representing the arguments.
+
+        Returns:
+            dict: A dictionary containing the extracted arguments, where the keys are the argument names
+                  and the values are the corresponding argument values.
+        """
         arguments = {}
         for child in args_node.children:
             if child.type == 'assignment_expression':
@@ -81,7 +106,6 @@ def parse_java_function_call(source_code):
                     arguments[name].append(value)
                 else:
                     arguments[name] = value
-                # arguments.append({'name': name, 'value': value})
             elif child.type in ['identifier', 'class_literal', 'set']:
                 # For unnamed parameters and handling sets
                 value = traverse_node(child)
@@ -94,9 +118,24 @@ def parse_java_function_call(source_code):
         return arguments
 
     def traverse(node):
+        """
+        Traverses the given AST node and extracts information about method invocations.
+
+        Args:
+            node (ASTNode): The AST node to traverse.
+
+        Returns:
+            dict: A dictionary containing information about the method invocation, including the function name and its parameters.
+        """
         if node.type == 'method_invocation':
             # Extract the function name and its arguments
-            function_name = get_text(node.child_by_field_name('name'))
+            method_name = get_text(node.child_by_field_name('name'))
+            class_name_node = node.child_by_field_name('object')
+            if class_name_node:
+                class_name = get_text(class_name_node)
+                function_name = f"{class_name}.{method_name}"
+            else:
+                function_name = method_name
             arguments_node = node.child_by_field_name('arguments')
             if arguments_node:
                 arguments = extract_arguments(arguments_node)
@@ -106,6 +145,7 @@ def parse_java_function_call(source_code):
                 result = traverse(child)
                 if result:
                     return result
+
 
     result = traverse(root_node)
     return result if result else {}
@@ -121,7 +161,7 @@ if __name__ == "__main__":
     """
         {
             "function": {
-                "name": "execute",
+                "name": "FileSystemsTest.execute",
                 "parameters": {
                 "null": [
                     "a",
@@ -131,7 +171,7 @@ if __name__ == "__main__":
                 "env": "testEnv",
                 "contextArguments": "new Object[]{'local','/home/user',false,true,true}",
                 "frameArguments": "new Object[]{}",
-                "arraylist": "new ArrayList<>((Arrays.asList(\"include_defaults\", true, \"TOXCONTENT_SKIP_RUNTIME\", true)))"
+                "arraylist": "new ArrayList<>(Arrays.asList(\"include_defaults\", true, \"TOXCONTENT_SKIP_RUNTIME\", true))"
                 }
             }
         }

--- a/openfunctions/utils/js_parser.py
+++ b/openfunctions/utils/js_parser.py
@@ -26,6 +26,8 @@ def parse_javascript_function_call(source_code):
                 # Extract left (name) and right (value) parts of the assignment
                 name = child.children[0].text.decode('utf-8')
                 value = child.children[2].text.decode('utf-8')
+                if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+                    value = value[1:-1]  # Trim the quotation marks
                 if name in args:
                     if not isinstance(args[name], list):
                         args[name] = [args[name]]
@@ -65,7 +67,25 @@ def parse_javascript_function_call(source_code):
 if __name__ == "__main__":
     # Assuming parser setup and language loading are done earlier
     
-    source_code = """markdownRenderComplete(a, b, elem=document.getElementById('contentArea'), elem=b, rendered=true)"""
+    source_code = """markdownRenderComplete(elem=document.getElementById('contentArea'), rendered=true, array=[1,2,3], array2=new Array(1,2,3), dictionary={'key':'value'})"""
+    
+    # Expected output:
+    """
+    {
+        "function": {
+            "name": "markdownRenderComplete",
+            "parameters": {
+            "elem": "document.getElementById('contentArea')",
+            "rendered": "true",
+            "array": "[1,2,3]",
+            "array2": "new Array(1,2,3)",
+            "dictionary": "{'key':'value'}"
+            }
+        }
+    }
+    """
+    
+    
     result = parse_javascript_function_call(source_code)
     print(source_code)
     print(json.dumps(result, indent=2))


### PR DESCRIPTION
**Context**: Parser is used to convert model response str -> OpenAI compatible `function_call`
- Corrected edge cases with `new` keyword
- Corrected `[Class.]method` optionally include Class in method. 
- Add recursive logic in `traverse_node` java parser, to special handle strings
- Corrected initialization with `ArrayList`, `Array` keywords formatting.
- Additional comments, example usage and expected outputs included.

**Example:** `PmsProductServiceImpl.updateNewStatus(ids=new ArrayList<Long>(Arrays.asList(101L, 202L, 303L)), newStatus=2)` -> `{'function': {'name': 'PmsProductServiceImpl.updateNewStatus', 'parameters': {'ids': 'new ArrayList<Long>(Arrays.asList(101L, 202L, 303L))', 'newStatus': '2'}}}`
