### PR TITLE
Correction in BFCL README instruction, fixed path in instructions

### DIFF
--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -44,7 +44,7 @@ ln -s eval_checker/tree-sitter-javascript tree-sitter-javascript
 
 ## Prepare Evaluation Dataset
 
-To download the evaluation dataset from huggingface, from the current directory `./openfunctions/berkeley-function-call-leaderboard`, run the following command:
+To download the evaluation dataset from huggingface, from the current directory `./berkeley-function-call-leaderboard`, run the following command:
 
 ```bash
     huggingface-cli download gorilla-llm/Berkeley-Function-Calling-Leaderboard --local-dir ./data --repo-type dataset


### PR DESCRIPTION
- Corrected a legacy path to be consistent in berkeley-function-call-leaderboard folder README instruction.