### PR TITLE
GoEX DevContainer for GitHub Codespaces

### DIFF
--- a/.devcontainer/goex/Dockerfile
+++ b/.devcontainer/goex/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.10
+
+RUN apt-get update && apt-get install -y \
+    mkcert \
+    sqlite3
+
+RUN curl -sfL https://direnv.net/install.sh | bash && \
+    echo 'eval "$(direnv hook bash)"' >> /etc/bash.bashrc

--- a/.devcontainer/goex/devcontainer.json
+++ b/.devcontainer/goex/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "GoEX",
+
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+        // Path is relative to the devcontainer.json file.
+        "dockerfile": "Dockerfile"
+    },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sh ${containerWorkspaceFolder}/.devcontainer/goex/post-create.sh",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"codespaces": {
+			"openFiles": [
+				"goex/README.md"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/goex/post-create.sh
+++ b/.devcontainer/goex/post-create.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cd goex
+
+echo "Installing mkcert"
+mkcert -install
+
+echo "Creating certificate for localhost"
+mkcert localhost
+
+echo "Allowing goex direnv"
+direnv allow
+
+echo "Creating virtual environment"
+python3 -m venv goex-env
+. ./goex-env/bin/activate
+
+echo "Installing requirements"
+pip install -e .

--- a/goex/.envrc
+++ b/goex/.envrc
@@ -1,0 +1,3 @@
+# Tell direnv to use pre configured venv
+export VIRTUAL_ENV=./goex-env
+layout python

--- a/goex/.gitignore
+++ b/goex/.gitignore
@@ -1,0 +1,4 @@
+goex-env
+*.pem
+.direnv/
+user_config.json

--- a/goex/README.md
+++ b/goex/README.md
@@ -13,6 +13,19 @@ GoEx provides a new way to interact with your favorite APIs! Powered by LLMs, Go
   - [Filesystem](#filesystem)
 - [Credentials \& Authorization Token](#credentials--authorization-token)
 
+## Dev environment with Codespaces
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/cedricvidal/gorilla/tree/codespaces?devcontainer_path=.devcontainer%2Fgoex%2Fdevcontainer.json)
+
+Everything is setup automatically in the dev container, open a terminal into the `goex` folder and run GoEX:
+
+```sh
+goex -h
+```
+
+Note: The `goex` virtual env will also be activated in your shell when entering into the `goex` folder.
+
+
 ## Install
 
 1.) Navigate inside the goex folder and set up a clean environment with **Conda** or **Python venv**


### PR DESCRIPTION
This PR adds support for a GitHub Codespaces Dev Container for the `goex` sub-project:
- Dev Container config `GoEX` with `mkcert` and `sqlite3`
- Also installs `direnv` with shell hooks to allow automatically activating the venv when opening a shell in the `goex` sub-folder.
- Adds `Open in GitHub Codespaces` badge to README.md pre-configured with `GoEX` config
- Adds documentation to README.md
- post-create script creates env using the python venv module and points direnv at it as opposed to delegating creation to direnv, which for some reason doesn't work as expected
- Installs requirements and builds goex

Note: The Dev Container configuration can also be used locally in VS Code in addition to remotely in GitHub Codespaces.

