### PR TITLE
Update raft.py with default `p` to match paper

### DIFF
--- a/raft/raft.py
+++ b/raft/raft.py
@@ -185,7 +185,7 @@ def add_chunk_to_dataset(
     doctype: DocType = "api", 
     x: int = 5, 
     num_distract: int = 3, 
-    p: float = 1.0
+    p: float = 0.8
 ) -> None:
     """
     Given a chunk, create {Q, A, D} triplets and add them to the dataset.


### PR DESCRIPTION
Change `p` which dictates the fraction of dataset with golden documents in them (vs) no golden documents. 

So, p = 0.8 means, for 80% of the train data set, `A* = Q + D* + D1 .. Dn` and for 20% of the train data set `A* = Q + D1 .. Dn` where `D*` are/is the golden document with the answer `A*`.

Close #325 