### PR TITLE
Add openfunctionv2 model inference script and fix minor bug

### DIFF
--- a/berkeley-function-call-leaderboard/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/model_handler/handler_map.py
@@ -1,21 +1,23 @@
-from model_handler.gorilla_handler import GorillaHandler
-from model_handler.gpt_handler import OpenAIHandler
 from model_handler.claude_handler import ClaudeHandler
-from model_handler.mistral_handler import MistralHandler
+from model_handler.databricks_handler import DatabricksHandler
+from model_handler.deepseek_handler import DeepseekHandler
 from model_handler.firework_ai_handler import FireworkAIHandler
-from model_handler.nexus_handler import NexusHandler
+from model_handler.functionary_handler import FunctionaryHandler
 from model_handler.gemini_handler import GeminiHandler
-from model_handler.oss_handler import OSSHandler
 from model_handler.gemma_handler import GemmaHandler
 from model_handler.glaive_handler import GlaiveHandler
-from model_handler.deepseek_handler import DeepseekHandler
-from model_handler.functionary_handler import FunctionaryHandler
-from model_handler.databricks_handler import DatabricksHandler
+from model_handler.gorilla_handler import GorillaHandler
+from model_handler.gpt_handler import OpenAIHandler
 from model_handler.hermes_handler import HermesHandler
+from model_handler.mistral_handler import MistralHandler
+from model_handler.nexus_handler import NexusHandler
+from model_handler.openfunctions_handler import OpenfunctionsHandler
+from model_handler.oss_handler import OSSHandler
 
 handler_map = {
     "gorilla-openfunctions-v0": GorillaHandler,
     "gorilla-openfunctions-v2": GorillaHandler,
+    "gorilla-llm/gorilla-openfunctions-v2": OpenfunctionsHandler,
     "gpt-4-1106-preview-FC": OpenAIHandler,
     "gpt-4-1106-preview": OpenAIHandler,
     "gpt-4-0125-preview-FC": OpenAIHandler,

--- a/berkeley-function-call-leaderboard/model_handler/handler_runner.py
+++ b/berkeley-function-call-leaderboard/model_handler/handler_runner.py
@@ -1,0 +1,46 @@
+import argparse
+from model_handler.handler_map import handler_map
+
+from tqdm import tqdm
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run model inference with model handler to generate result for evaluation.")
+
+    # Add arguments for two lists of strings
+    parser.add_argument(
+        "--data-path", type=str, help="Input data path for inference"
+    )
+    parser.add_argument(
+        "--model-path", type=str, help="Local model path for inference, e.g. /path_to_model/gorilla-llm/gorilla-openfunctions-v2"
+    )
+    parser.add_argument(
+        "--model-name", type=str, help="Model name registered in handler map, e.g. gorilla-llm/gorilla-openfunctions-v2"
+    )
+    parser.add_argument(
+        "--test-category",
+        nargs="+",
+        type=str,
+        help="A list of test categories to run the evaluation on",
+    )
+    parser.add_argument(
+        "--num-gpus", default=4, type=int, help="Number of total GPUs used for all vLLM instances"
+    )
+
+    args = parser.parse_args()
+
+    if args.model_name not in handler_map:
+        raise ValueError(
+            f"Model name {args.model_name} is not in handler map.")
+
+    model_handler = handler_map[args.model_name](args.model_path)
+    result_json, _ = model_handler.inference(
+        args.data_path, args.test_category, args.num_gpus)
+
+    for index in tqdm(range(len(result_json))):
+        model_handler.write(result_json[index], "result.json")
+
+
+if __name__ == '__main__':
+    main()

--- a/berkeley-function-call-leaderboard/model_handler/openfunctions_handler.py
+++ b/berkeley-function-call-leaderboard/model_handler/openfunctions_handler.py
@@ -1,0 +1,64 @@
+import argparse
+import json
+
+from model_handler.oss_handler import OSSHandler
+from model_handler.utils import ast_parse
+
+FN_CALL_DELIMITER = "<<function>>"
+
+
+def strip_function_calls(content: str) -> list[str]:
+    """
+    Split the content by the function call delimiter and remove empty strings
+    """
+    return [element.strip() for element in content.split(FN_CALL_DELIMITER)[1:] if element.strip()]
+
+
+class OpenfunctionsHandler(OSSHandler):
+
+    def __init__(self, model_name, temperature=0.7, top_p=1, max_tokens=1000) -> None:
+        super().__init__(model_name, temperature, top_p, max_tokens)
+
+    def _format_prompt(user_query: str, functions: list, test_category: str) -> str:
+        """
+        Generates a conversation prompt based on the user's query and a list of functions.
+
+        Parameters:
+        - user_query (str): The user's query.
+        - functions (list): A list of functions to include in the prompt.
+        - test_category (str): selected test category
+
+
+        Returns:
+        - str: The formatted conversation prompt.
+        """
+        system = "You are an AI programming assistant, utilizing the Gorilla LLM model, developed by Gorilla LLM, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer."
+        if len(functions) == 0:
+            return f"{system}\n### Instruction: <<question>> {user_query}\n### Response: "
+        functions_string = json.dumps(functions)
+        return f"{system}\n### Instruction: <<function>>{functions_string}\n<<question>>{user_query}\n### Response: "
+
+    def decode_ast(self, result, language="Python"):
+        extracted_funcs = strip_function_calls(result)
+        func = "[" + ",".join(extracted_funcs) + "]"
+        decoded_output = ast_parse(func, language)
+        return decoded_output
+
+    def decode_execute(self, result):
+        result = strip_function_calls(result)[0]
+        func = "[" + result + "]"
+        decoded_output = ast_parse(func)
+        execution_list = []
+        for function_call in decoded_output:
+            for key, value in function_call.items():
+                execution_list.append(
+                    f"{key}({','.join([f'{k}={repr(v)}' for k, v in value.items()])})"
+                )
+        return execution_list
+
+    def inference(
+        self, question_file, test_category, num_gpus, format_prompt_func=_format_prompt
+    ):
+        return super().inference(
+            question_file, test_category, num_gpus, format_prompt_func
+        )

--- a/berkeley-function-call-leaderboard/model_handler/utils.py
+++ b/berkeley-function-call-leaderboard/model_handler/utils.py
@@ -1,4 +1,8 @@
-import re, ast, builtins, ast, json
+import re
+import ast
+import builtins
+import ast
+import json
 from model_handler.model_style import ModelStyle
 from model_handler.constant import JAVA_TYPE_CONVERSION, JS_TYPE_CONVERSION
 from model_handler.java_parser import parse_java_function_call
@@ -103,7 +107,8 @@ def convert_to_tool(
                 if "maximum" in params:
                     del params["maximum"]
                 if "additionalProperties" in params:
-                    params["description"] += str(params["additionalProperties"])
+                    params["description"] += str(
+                        params["additionalProperties"])
                     del params["additionalProperties"]
         if model_style in [
             ModelStyle.Anthropic,
@@ -270,7 +275,8 @@ def language_specific_pre_processing(function, test_category, string_param):
                         "description"
                     ] += "This parameter can be of any type of Java object."
                     properties[key]["description"] += (
-                        "This is Java" + value["type"] + " in string representation."
+                        "This is Java" + value["type"] +
+                        " in string representation."
                     )
         elif test_category == "javascript":
             for key, value in properties.items():
@@ -286,7 +292,7 @@ def language_specific_pre_processing(function, test_category, string_param):
                         + value["type"]
                         + " in string representation."
                     )
-        return function
+    return function
 
 
 def construct_tool_use_system_prompt(tools):


### PR DESCRIPTION
# Summary

This PR introduces a new model handler [openfunctions_handler.py](https://github.com/ShishirPatil/gorilla/compare/main...JasonZhu1313:gorilla:jaszhu/add_openfunctions_handler?expand=1#diff-3af430d47eb913aec657f3bad6dcbae4e39ee152dcb8b1699e65614fdd87e10d) to run inference on OS model gorilla-llm/gorilla-openfunctions-v2 and reproduce the results on leaderboard


# Changes 

* Merge the input data into a single file since that's what the evaluation script is expecting, data is under /gorilla/berkeley-function-call-leaderboard/data/BFCL/questions.json
* Fixed a minor bug in [utils.py](https://github.com/ShishirPatil/gorilla/compare/main...JasonZhu1313:gorilla:jaszhu/add_openfunctions_handler?expand=1#diff-e8935e967caa4bf517c6cff20cfa51ad8db1f2dd429e048a8f871f1e286b46dc), the returned object `function` is mistakenly put inside the for loop, instead it should be put outside loop
* Added a new OpenfunctionsHandler in handler map
* openfunctions_handler.py with prompt template and decoding step compatible with openfunctions_v2 model
* A simple [handler_runner.py](https://github.com/ShishirPatil/gorilla/compare/main...JasonZhu1313:gorilla:jaszhu/add_openfunctions_handler?expand=1#diff-f7751f6f6d57d038bce4231c60989523a1967beed408821f3868743a3b2fe13a) to run the inference and save the result for evaluation
* TODO: Add usage in readme


# Test
1. Generates the inference result with vLLM
2. Generate eval result with eval_runner



 