### PR TITLE
[Bug fix] Add Hermes-2-Pro-Mistral-7B model to UNDERSCORE_TO_DOT to parse API properly 

### DIFF
--- a/berkeley-function-call-leaderboard/model_handler/constant.py
+++ b/berkeley-function-call-leaderboard/model_handler/constant.py
@@ -128,6 +128,7 @@ UNDERSCORE_TO_DOT = [
     "meetkai/functionary-medium-v2.2-FC",
     "meetkai/functionary-small-v2.4-FC",
     "meetkai/functionary-medium-v2.4-FC",
+    "NousResearch/Hermes-2-Pro-Mistral-7B"
 ]
 
 TEST_CATEGORIES = {


### PR DESCRIPTION
## Summary 

Hermes-2-Pro-Mistral-7B is the newly added OS model handler, the function definition is OpenAI compatible, so the API call like request.get will be modified to request_get in prompt. We should add this to UNDERSCORE_TO_DOT list to do the correct conversion of the label as well otherwise it will lead to very low scores which didn't match what has shown on leaderboard.

## Test

After adding the model, the score improves significantly:
| Overall ACC | Summary AST | Simple AST | Python AST | Multiple | Parallel | Parallel Multiple | Relevance |
|-------------|-------------|------------|------------|----------|----------|------------------|-----------|
|     0.55    |     0.47    |    0.33    |  0.33     |   0.345  |       0.69       |    0.52   | 1.0 |


