### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,45 @@ dist
 .editorconfig
 .DS_Store
 **/*.pyc
-./berkeley-function-call-leaderboard/function_credential_config.json
-./berkeley-function-call-leaderboard/eval_checker/tree-sitter-java
-./berkeley-function-call-leaderboard/eval_checker/tree-sitter-javascript
 goex/exec_engine/checkpoints/
 goex/exec_engine/credentials/*
 !goex/exec_engine/credentials/credentials_utils.py
 !goex/exec_engine/credentials/supported.txt
 goex/docker/*/requirements.txt
 goex/docker/misc/images.json
+
+################## Berkley Function Call Leaderboard ##########################
+
+# Ignore API keys
+berkeley-function-call-leaderboard/function_credential_config.json
+
+# Ignore tree-sitter
+berkeley-function-call-leaderboard/eval_checker/tree-sitter-java
+berkeley-function-call-leaderboard/eval_checker/tree-sitter-javascript
+berkeley-function-call-leaderboard/tree-sitter-java
+berkeley-function-call-leaderboard/tree-sitter-javascript
+
+# Ignore Evaluation Dataset files that we download from https://huggingface.co/datasets/gorilla-llm/Berkeley-Function-Calling-Leaderboard/tree/main
+berkeley-function-call-leaderboard/eval_data_total.json
+berkeley-function-call-leaderboard/data/.gitattributes
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_chatable.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_executable_multiple_function.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_executable_parallel_multiple_function.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_executable_simple.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_relevance.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_parallel_function.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_multiple_function.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_parallel_multiple_function.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_rest.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_javascript.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_simple.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_sql.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_java.json
+berkeley-function-call-leaderboard/data/gorilla_openfunctions_v1_test_executable_parallel_function.json
+berkeley-function-call-leaderboard/data/README.md
+
+# Ignore inference results
+berkeley-function-call-leaderboard/result/
+
+# Ignore leaderboard score
+berkeley-function-call-leaderboard/score/

--- a/berkeley-function-call-leaderboard/eval_checker/eval_runner_helper.py
+++ b/berkeley-function-call-leaderboard/eval_checker/eval_runner_helper.py
@@ -1,13 +1,13 @@
-import json
-from model_handler.handler_map import handler_map
-from custom_exception import BadAPIStatusError
-import os
 import glob
-import subprocess
+import json
+import os
 import statistics
-from tqdm import tqdm
+import subprocess
+
 import numpy as np
-from eval_runner_constant import FILENAME_INDEX_MAPPING
+from custom_exception import BadAPIStatusError
+from model_handler.handler_map import handler_map
+from tqdm import tqdm
 
 REST_API_GROUND_TRUTH_FILE_PATH = "api_status_ground_truth_function_calls.json"
 
@@ -476,14 +476,18 @@ def api_status_sanity_check():
     write_list_of_dicts_to_file(REST_API_GROUND_TRUTH_FILE_PATH, ground_truth_dummy)
 
     correct_count = 0
+    errors = []
     for idx, data in tqdm(
         enumerate(ground_truth_replaced), total=len(ground_truth_replaced)
     ):
         status = executable_checker_rest(data["ground_truth"], idx)
         if status["valid"]:
             correct_count += 1
+        else:
+            errors.append((data, status))
 
     if correct_count != len(ground_truth_replaced):
+        [print("Data:", data, "\nError:", status['error']) for data, status in errors]
         error_msg = f"API Status Test Failed. {len(ground_truth_replaced) - correct_count} out of {len(ground_truth_replaced)} API behaviors are not as expected. Be careful with executable test category results; they may be inaccurate."
         raise BadAPIStatusError(error_msg)
 


### PR DESCRIPTION
There are many files that are automatically generated when running BFCL that we should ignore. I update .gitignore to ignore:
1. the evaluation dataset that we download
2. the tree-sitter files in`berkeley-function-call-leaderboard/eval_checker` (right now we only ignore the symbolic link to the tree-sitter files in the `berkeley-function-call-leaderboard` directory)
3. The inference results in `berkeley-function-call-leaderboard/result/`
4. The evaluation results in `berkeley-function-call-leaderboard/score/`

