### PR TITLE
BFCL April 28th Release (New Model: snowflake/arctic)

### DIFF
--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -215,6 +215,7 @@ Below is *a table of models we support* to run our leaderboard evaluation agains
 |mistral-tiny-2312 | Prompt|
 |Nexusflow-Raven-v2 | Function Calling|
 |NousResearch/Hermes-2-Pro-Mistral-7B 💻| Function Calling|
+|snowflake/arctic | Prompt| 
 
 Here {MODEL} 💻 means the model needs to be hosted locally and called by vllm, {MODEL} means the models that are called API calls. For models with a trailing `-FC`, it means that the model supports function-calling feature. You can check out the table summarizing feature supports among different models [here](https://gorilla.cs.berkeley.edu/blogs/8_berkeley_function_calling_leaderboard.html#prompt).
 
@@ -229,7 +230,7 @@ For inferencing `Databrick-DBRX-instruct`, you need to create a Databrick Azure 
 
 
 ## Changelog
-
+* [April 28, 2024] [#397](https://github.com/ShishirPatil/gorilla/pull/397): Add inference support for `snowflake/arctic` via Nvidia API catalog and update statistics to the leaderboard. 
 * [April 27, 2024] [#390](https://github.com/ShishirPatil/gorilla/pull/390): Bug fix in cost and latency calculation for open-source models, which are now all calculated when serving the model with [vLLM](https://github.com/vllm-project/vllm) using 8 V100 GPUs for consistency. $$\text{Cost} = \text{Latency per 1000 function call} * (\text{8xV100 azure-pay-as-you-go-price per hour / 3600})$$
 * [April 25, 2024] [#386](https://github.com/ShishirPatil/gorilla/pull/386): Add 5 new models to the leaderboard: `meta-llama/Meta-Llama-3-8B-Instruct`, `meta-llama/Meta-Llama-3-70B-Instruct`, `gemini-1.5-pro-preview-0409`, `command-r-plus`, `command-r-plus-FC`.
 * [April 19, 2024] [#377](https://github.com/ShishirPatil/gorilla/pull/377): 

--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -231,7 +231,7 @@ For inferencing `Databrick-DBRX-instruct`, you need to create a Databrick Azure 
 
 
 ## Changelog
-* [April 28, 2024] [#397](https://github.com/ShishirPatil/gorilla/pull/397): Add inference support for `snowflake/arctic` via Nvidia API catalog and update statistics to the leaderboard. 
+* [April 28, 2024] [#397](https://github.com/ShishirPatil/gorilla/pull/397): Add new model `snowflake/arctic` to the leaderboard. Note that there are multiple ways to inference the model, and we choose to do it via Nvidia API catalog. 
 * [April 27, 2024] [#390](https://github.com/ShishirPatil/gorilla/pull/390): Bug fix in cost and latency calculation for open-source models, which are now all calculated when serving the model with [vLLM](https://github.com/vllm-project/vllm) using 8 V100 GPUs for consistency. $$\text{Cost} = \text{Latency per 1000 function call} * (\text{8xV100 azure-pay-as-you-go-price per hour / 3600})$$
 * [April 25, 2024] [#386](https://github.com/ShishirPatil/gorilla/pull/386): Add 5 new models to the leaderboard: `meta-llama/Meta-Llama-3-8B-Instruct`, `meta-llama/Meta-Llama-3-70B-Instruct`, `gemini-1.5-pro-preview-0409`, `command-r-plus`, `command-r-plus-FC`.
 * [April 19, 2024] [#377](https://github.com/ShishirPatil/gorilla/pull/377): 

--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -100,6 +100,7 @@ Also provide your API keys in your environment variables.
     export FIRE_WORKS_API_KEY=XXXXXX
     export ANTHROPIC_API_KEY=XXXXXX
     export COHERE_API_KEY=XXXXXX
+    export NVIDIA_API_KEY=nvapi-XXXXXX
 ```
 
 To generate leaderboard statistics, there are two steps:

--- a/berkeley-function-call-leaderboard/eval_checker/eval_runner_helper.py
+++ b/berkeley-function-call-leaderboard/eval_checker/eval_runner_helper.py
@@ -320,6 +320,12 @@ MODEL_METADATA_MAPPING = {
         "Cohere For AI",
         "cc-by-nc-4.0",
     ],
+    "snowflake_arctic": [
+        "Snowflake/snowflake-arctic-instruct (Prompt)",
+        "https://huggingface.co/Snowflake/snowflake-arctic-instruct",
+        "Snowflake",
+        "apache-2.0",
+    ]
 }
 
 INPUT_PRICE_PER_MILLION_TOKEN = {
@@ -411,6 +417,7 @@ NO_COST_MODELS = [
     "meetkai/functionary-medium-v2.4-FC",
     "meetkai/functionary-small-v2.2-FC",
     "meetkai/functionary-small-v2.4-FC",
+    "snowflake/arctic",
 ]
 
 # Price got from AZure, 22.032 per hour for 8 V100, Pay As You Go Total Price

--- a/berkeley-function-call-leaderboard/model_handler/arctic_handler.py
+++ b/berkeley-function-call-leaderboard/model_handler/arctic_handler.py
@@ -1,0 +1,41 @@
+from model_handler.nvidia_handler import NvidiaHandler
+from model_handler.utils import ast_parse
+
+class ArcticHandler(NvidiaHandler):
+    def __init__(self, model_name, temperature=0.7, top_p=1, max_tokens=1000) -> None:
+        super().__init__(model_name, temperature, top_p, max_tokens)
+    def decode_ast(self, result, language="Python"):
+        result = result.replace("\n", "")
+        if not result.startswith("["):
+            result = "[ " + result
+        if not result.endswith("]"):
+            result = result + " ]"
+        if result.startswith("['"):
+            result = result.replace("['", "[")
+            result = result.replace("', '", ", ")
+            result = result.replace("','", ", ")
+        if result.endswith("']"):
+            result = result.replace("']", "]")
+        decode_output = ast_parse(result, language)
+        return decode_output
+        
+    def decode_execute(self, result, language="Python"):
+        result = result.replace("\n", "")
+        if not result.startswith("["):
+            result = "[ " + result
+        if not result.endswith("]"):
+            result = result + " ]"
+        if result.startswith("['"):
+            result = result.replace("['", "[")
+            result = result.replace("', '", ", ")
+            result = result.replace("','", ", ")
+        if result.endswith("']"):
+            result = result.replace("']", "]")
+        decode_output = ast_parse(result, language)
+        execution_list = []
+        for function_call in decode_output:
+            for key, value in function_call.items():
+                execution_list.append(
+                    f"{key}({','.join([f'{k}={repr(v)}' for k, v in value.items()])})"
+                )
+        return execution_list

--- a/berkeley-function-call-leaderboard/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/model_handler/handler_map.py
@@ -15,6 +15,7 @@ from model_handler.mistral_handler import MistralHandler
 from model_handler.nexus_handler import NexusHandler
 from model_handler.oss_handler import OSSHandler
 from model_handler.cohere_handler import CohereHandler
+from model_handler.arctic_handler import ArcticHandler
 
 handler_map = {
     "gorilla-openfunctions-v0": GorillaHandler,
@@ -65,4 +66,5 @@ handler_map = {
     "command-r-plus": CohereHandler,
     "command-r-plus-FC-optimized": CohereHandler,
     "command-r-plus-optimized": CohereHandler,
+    "snowflake/arctic": ArcticHandler,
 }

--- a/berkeley-function-call-leaderboard/model_handler/nvidia_handler.py
+++ b/berkeley-function-call-leaderboard/model_handler/nvidia_handler.py
@@ -1,6 +1,6 @@
 import time,os,json
 from openai import OpenAI
-from model_handler.gpt_handler import OpenAIHandler
+from model_handler.handler import BaseHandler
 from model_handler.model_style import ModelStyle
 from model_handler.utils import (
     augment_prompt_by_languge,
@@ -11,7 +11,7 @@ from model_handler.constant import (
     SYSTEM_PROMPT_FOR_CHAT_MODEL,
 )
 
-class NvidiaHandler(OpenAIHandler):
+class NvidiaHandler(BaseHandler):
     def __init__(self, model_name, temperature=0.7, top_p=1, max_tokens=1000) -> None:
         self.model_name = model_name
         self.temperature = temperature

--- a/berkeley-function-call-leaderboard/model_handler/nvidia_handler.py
+++ b/berkeley-function-call-leaderboard/model_handler/nvidia_handler.py
@@ -1,0 +1,64 @@
+import time,os,json
+from openai import OpenAI
+from model_handler.gpt_handler import OpenAIHandler
+from model_handler.model_style import ModelStyle
+from model_handler.utils import (
+    augment_prompt_by_languge,
+    language_specific_pre_processing,
+)
+from model_handler.constant import (
+    USER_PROMPT_FOR_CHAT_MODEL,
+    SYSTEM_PROMPT_FOR_CHAT_MODEL,
+)
+
+class NvidiaHandler(OpenAIHandler):
+    def __init__(self, model_name, temperature=0.7, top_p=1, max_tokens=1000) -> None:
+        self.model_name = model_name
+        self.temperature = temperature
+        self.top_p = top_p
+        self.max_tokens = max_tokens
+        self.model_style = ModelStyle.OpenAI
+        self.client = OpenAI(
+            base_url = "https://integrate.api.nvidia.com/v1",
+            api_key = os.getenv("NVIDIA_API_KEY")
+        )
+    def inference(self, prompt, functions, test_category):
+        prompt = augment_prompt_by_languge(prompt,test_category)
+        functions = language_specific_pre_processing(functions,test_category,False)
+        message = [
+            {
+                "role": "system",
+                "content": SYSTEM_PROMPT_FOR_CHAT_MODEL,
+            },
+            {
+                "role": "user",
+                "content": "Questions:"
+                + USER_PROMPT_FOR_CHAT_MODEL.format(
+                    user_prompt=prompt, functions=str(functions)
+                ),
+            },
+        ]
+        start_time = time.time()
+        response = self.client.chat.completions.create(
+            messages=message,
+            model=self.model_name,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+            top_p=self.top_p,
+        )
+        latency = time.time() - start_time
+        result = response.choices[0].message.content
+        input_token = response.usage.prompt_tokens
+        output_token = response.usage.completion_tokens
+        metadata = {"input_tokens": input_token, "output_tokens": output_token, "latency": latency}
+        return result, metadata
+    
+    def write(self, result, file_to_open):
+        if not os.path.exists("./result"):
+            os.mkdir("./result")
+        if not os.path.exists("./result/" + self.model_name.replace("/", "_")):
+            os.mkdir("./result/" + self.model_name.replace("/", "_"))
+        with open(
+            "./result/" + self.model_name.replace("/", "_") + "/" + file_to_open.replace(".json", "_result.json"), "a+"
+        ) as f:
+            f.write(json.dumps(result) + "\n")

--- a/berkeley-function-call-leaderboard/openfunctions_evaluation.py
+++ b/berkeley-function-call-leaderboard/openfunctions_evaluation.py
@@ -79,13 +79,13 @@ if __name__ == "__main__":
             num_existing_result = 0  # if the result file already exists, skip the test cases that have been tested.
             if os.path.exists(
                 "./result/"
-                + args.model
+                + args.model.replace("/", "_")
                 + "/"
                 + file_to_open.replace(".json", "_result.json")
             ):
                 with open(
                     "./result/"
-                    + args.model
+                    + args.model.replace("/", "_")
                     + "/"
                     + file_to_open.replace(".json", "_result.json")
                 ) as f:


### PR DESCRIPTION
In this PR, we have added `snowflake/arctic` to leaderboard:

- The inference was done through [Nvidia API catalog](https://build.nvidia.com/explore/discover#arctic) endpoint. Latencies are recorded and the cost is marked as "N/A" as the inference consumed Nvidia credits which were provided free upon registration.
- The leaderboard website will be updated shortly to reflect these new entries, in a different PR.

Notes on Nvidia API catalog: We didn't have enough compute resources to host full precision Arctic inference locally and therefore looked for third-party hosting. Out of Snowflake Cortex, Together.ai, and Nvidia API catalog, we decided to use Nvidia's service as it does not have context length limit and has detailed documentation of Python usage.