### PR TITLE
Small corrections to possible_answers for simple test category

### DIFF
--- a/berkeley-function-call-leaderboard/data/possible_answer/gorilla_openfunctions_v1_test_simple.json
+++ b/berkeley-function-call-leaderboard/data/possible_answer/gorilla_openfunctions_v1_test_simple.json
@@ -78,7 +78,7 @@
 {"restaurant.find_nearby":{"location":["Los Angeles, CA"],"dietary_preference":[["Vegan"]]}}
 {"average_temperature":{"location":["Austin"],"days":[3],"temp_unit":["Celsius"]}}
 {"create_histogram":{"data":[[85,90,88,92,86,89,91]],"bins":[5]}}
-{"find_restaurants":{"location":["Manhattan, New York City", "Manhattan", "Manhattan, New York"],"food_type":["Thai"],"number":[5],"dietary_requirements":[["vegan"],["Vegan"]]}}
+{"find_restaurants":{"location":["Manhattan, New York City", "Manhattan", "Manhattan, New York", "Manhattan, NY", "Manhattan, NYC"],"food_type":["Thai"],"number":[5],"dietary_requirements":[["vegan"],["Vegan"]]}}
 {"map_routing.fastest_route":{"start_location":["San Francisco","SF"],"end_location":["Los Angeles","LA"],"avoid_tolls":[true]}}
 {"calculate_average":{"numbers":[[12.0,15.0,18.0,20.0,21.0,26.0,30.0]]}}
 {"calculate_distance":{"coord1":[[33.4484,-112.074]],"coord2":[[34.0522,-118.2437]],"unit":["miles"]}}
@@ -233,7 +233,7 @@
 {"monarch.getMonarchOfYear":{"location":["England","ENG"],"year":[1800],"fullName":[true]}}
 {"european_history.get_event_date":{"event_name":["Treaty of Tordesillas"],"format":["YYYY"]}}
 {"history_eu.fetch_events":{"century":[19],"region":["Northern","Southern","Eastern","Western"],"category":["Wars"]}}
-{"get_event_date":{"event":["Treaty of Lisbon","Signing of the Treaty of Lisbon"],"location":[""]}}
+{"get_event_date":{"event":["Treaty of Lisbon","Signing of the Treaty of Lisbon", "The signing of the Treaty of Lisbon"],"location":[""]}}
 {"us_history.get_event_info":{"event_name":["American Civil War","Civil War"],"specific_info":["Start Date"]}}
 {"get_historical_GDP":{"country":["United States","US"],"start_year":[1960],"end_year":[2000]}}
 {"us_history.get_president":{"event":["American Civil War"],"year":[1861]}}
@@ -321,7 +321,7 @@
 {"sports_ranking.get_team_position":{"team":["Golden State Warriors","GSW"],"season":["2022-2023"],"detailed":[true]}}
 {"sports_ranking":{"team":["Barcelona","FC Barcelona"],"league":["La Liga"],"season":["2021"]}}
 {"sports_ranking.get_current":{"team":["Liverpool Football Club","Liverpool","LFC"],"league":["Premier League","EPL","English Premier League"],"season":[""]}}
-{"sports_ranking.get_top_player":{"sport":["tennis"],"gender":["woman"]}}
+{"sports_ranking.get_top_player":{"sport":["tennis"],"gender":["women"]}}
 {"team_score.get_latest":{"team":["Los Angeles Lakers","Lakers"],"include_opponent":[true]}}
 {"sports.match_results":{"team1":["Chicago Bulls"],"team2":["Los Angeles Lakers"],"season":[""]}}
 {"get_team_score":{"team_name":["Los Angeles Lakers","Lakers"],"league":["NBA"],"include_player_stats":["",true,false]}}


### PR DESCRIPTION
I’m redoing the leaderboard results and scores for some models in the `simple` test category. I’ve noticed the model is marked down for answers that seem correct to me. Here are my suggestions for the corrections.

This PR DOES change the leaderboard scores, which will be updated later. 