### PR TITLE
[RAFT] Edit encode prompt to include `<ANSWER>:` tag in label

### DIFF
--- a/raft/raft.py
+++ b/raft/raft.py
@@ -188,7 +188,7 @@ def encode_question_gen(question: str, chunk: Any) -> list[str]:
         - First provide step-by-step reasoning on how to answer the question. 
         - In the reasoning, if you need to copy paste some sentences from the context, include them in ##begin_quote## and ##end_quote##. This would mean that things outside of ##begin_quote## and ##end_quote## are not directly copy paste from the context. 
         - End your response with final answer in the form <ANSWER>: $answer, the answer should be succinct.
-        You MUST being your final answer with the tag "<ANSWER>:".
+        You MUST begin your final answer with the tag "<ANSWER>:".
     """.format(question=question, context=str(chunk))
     prompts.append({"role": "system", "content": "You are a helpful question answerer who can provide an answer given a question and relevant context."})
     prompts.append({"role": "user", "content": prompt})

--- a/raft/raft.py
+++ b/raft/raft.py
@@ -188,7 +188,7 @@ def encode_question_gen(question: str, chunk: Any) -> list[str]:
         - First provide step-by-step reasoning on how to answer the question. 
         - In the reasoning, if you need to copy paste some sentences from the context, include them in ##begin_quote## and ##end_quote##. This would mean that things outside of ##begin_quote## and ##end_quote## are not directly copy paste from the context. 
         - End your response with final answer in the form <ANSWER>: $answer, the answer should be succinct.
-        You MUST begin your final answer with the tag "<ANSWER>:".
+        You MUST being your final answer with the tag "<ANSWER>:".
     """.format(question=question, context=str(chunk))
     prompts.append({"role": "system", "content": "You are a helpful question answerer who can provide an answer given a question and relevant context."})
     prompts.append({"role": "user", "content": prompt})
@@ -367,12 +367,6 @@ def main():
         format_params['system_prompt'] = args.output_chat_system_prompt
 
     formatter.convert(ds=ds, format=args.output_format, output_path=args.output, output_type=args.output_type, params=format_params)
-
-    if not args.fast:
-        os.remove("checkpoint.txt")
-        for filename in os.listdir(os.path.dirname(args.output)):
-            if "-checkpoints-" in filename:
-                shutil.rmtree(os.path.dirname(args.output) + "/" + filename)
 
     if not args.fast:
         os.remove("checkpoint.txt")

--- a/raft/raft.py
+++ b/raft/raft.py
@@ -188,6 +188,7 @@ def encode_question_gen(question: str, chunk: Any) -> list[str]:
         - First provide step-by-step reasoning on how to answer the question. 
         - In the reasoning, if you need to copy paste some sentences from the context, include them in ##begin_quote## and ##end_quote##. This would mean that things outside of ##begin_quote## and ##end_quote## are not directly copy paste from the context. 
         - End your response with final answer in the form <ANSWER>: $answer, the answer should be succinct.
+        You MUST being your final answer with the tag "<ANSWER>:".
     """.format(question=question, context=str(chunk))
     prompts.append({"role": "system", "content": "You are a helpful question answerer who can provide an answer given a question and relevant context."})
     prompts.append({"role": "user", "content": prompt})
@@ -366,6 +367,12 @@ def main():
         format_params['system_prompt'] = args.output_chat_system_prompt
 
     formatter.convert(ds=ds, format=args.output_format, output_path=args.output, output_type=args.output_type, params=format_params)
+
+    if not args.fast:
+        os.remove("checkpoint.txt")
+        for filename in os.listdir(os.path.dirname(args.output)):
+            if "-checkpoints-" in filename:
+                shutil.rmtree(os.path.dirname(args.output) + "/" + filename)
 
     if not args.fast:
         os.remove("checkpoint.txt")


### PR DESCRIPTION
Added line `You MUST begin your final answer with the tag "<ANSWER>:".` in `encode_question_gen`'s prompt to ensure the `<ANSWER>:` tag is included in the label.