### PR TITLE
Add Sticky Effect for the First Three Columns on Leaderboard

### DIFF
--- a/assets/css/leaderboard.css
+++ b/assets/css/leaderboard.css
@@ -8,6 +8,8 @@
     border: 1px solid #ddd;
     padding: 8px;
     text-align: center;
+    position: relative;
+    /* Add relative positioning for the sticky effect */
 }
 
 #leaderboard tbody tr:nth-child(1) {
@@ -23,6 +25,19 @@
 #leaderboard tbody tr:nth-child(3) {
     background-color: #fff9c4;
     /* Darker yellow for rank 3 */
+}
+
+/* Fix the first three columns */
+#leaderboard th:nth-child(1),
+#leaderboard th:nth-child(2),
+#leaderboard th:nth-child(3),
+#leaderboard td:nth-child(1),
+#leaderboard td:nth-child(2),
+#leaderboard td:nth-child(3) {
+    position: sticky;
+    /* Use the same background color to cover content from other floating columns */
+    background: #e5effc;
+    z-index: 3;
 }
 
 #leaderboard td:nth-child(2) {
@@ -59,14 +74,12 @@
     background-color: #8f8fff;
 }
 
-
 #leaderboard td:nth-child(13),
 #leaderboard td:nth-child(14),
 #leaderboard td:nth-child(15),
 #leaderboard td:nth-child(16) {
     background-color: #75f1ff;
 }
-
 
 #leaderboard td:nth-child(17),
 #leaderboard td:nth-child(18),
@@ -79,84 +92,67 @@
     background-color: #ffdf75;
 }
 
-
 /* Ensure the table uses the full width of its container */
 table {
     table-layout: auto;
-    border-collapse: collapse; 
-    width: auto; /* Allows the table to expand naturally based on content */
     border-collapse: collapse;
-    table-layout: auto; /* Default layout for the table */
+    width: auto;
     align-items: center;
     justify-content: center;
 }
 
-
-
-#leaderboard td, #leaderboard th {
-    word-wrap: break-word; /* Allows words to break and wrap to the next line */
-    overflow-wrap: break-word; /* Ensures wrapping at break points */
-    padding: 8px; /* Adjust padding as needed */
-    text-align: center; /* Keeps text centered, adjust as needed */
-    border: 1px solid #ddd; 
+#leaderboard td,
+#leaderboard th {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    padding: 8px;
+    text-align: center;
+    border: 1px solid #ddd;
 }
 
-
-th:not(.detail-header)  {
+th:not(.detail-header) {
     cursor: pointer;
 }
 
-
-
 .table-container {
-    overflow-x: auto; /* Enable horizontal scrolling */
-    overflow-y: auto; /* Enable vertical scrolling */
-    -webkit-overflow-scrolling: touch; /* Smooth scrolling for iOS devices */
-    width: 100%; /* Full width of the parent */
-    max-width: 100%; /* Ensure the container does not exceed the width of the parent */
-    max-height: 600px; /* Set the maximum height of the table to 8 rows */
+    overflow-x: auto;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    width: 100%;
+    max-width: 100%;
+    max-height: 600px;
+    /* Set the maximum height of the table to 8 rows */
     display: block;
-    border: 1px solid #ddd; /* Optional: Adds a border for better visibility */
+    border: 1px solid #ddd;
+    /* Optional: Adds a border for better visibility */
     align-items: center;
     justify-content: center;
 }
 
-
-
-
-
-.group1 col {
-    width: 5px; 
-}
-
-
-.group2 col, .group3 col, .group4 col, .group5 col, .group6 col, .group7 col, .group8 col {
-    width: auto; 
-}
-
-
-
 #myChart {
     display: block;
-    margin: auto; 
-    width: 100%; 
-    height: auto; /* This will maintain the aspect ratio */
+    margin: auto;
+    width: 100%;
+    height: auto;
+    /* This will maintain the aspect ratio */
     max-height: 100vh;
     align-items: center;
     justify-content: center;
 }
 
-
 .detail-row {
-    display: none; /* Hide detail rows initially */
+    display: none;
+    /* Hide detail rows initially */
 }
 
 .detail-small-header {
-    display: none; /* Hide detail headers initially */
+    display: none;
+    /* Hide detail headers initially */
 }
 
 .detail-header {
-    display: none; /* Hide detail headers initially */
+    display: none;
+    /* Hide detail headers initially */
 }
 
 .summary-small-header {
@@ -167,21 +163,13 @@ th:not(.detail-header)  {
     display: "";
 }
 
-
 #expand-btn {
     font-size: 14px;
-    /* Adjust the font size as needed */
     color: white;
-    /* Text color */
     background-color: #6c757d;
-    /* Background color */
     border: none;
     border-radius: 5px;
-    /* Rounded corners */
     padding: 5px 5px;
     cursor: pointer;
-    /* Changes the cursor to a pointer on hover */
     transition: background-color 0.3s ease;
-    /* Smooth transition for hover effect */
 }
-

--- a/index.js
+++ b/index.js
@@ -946,3 +946,41 @@ document.querySelectorAll("th:not(.detail-header)").forEach(function (header) {
 });
 
 document.getElementById("rank-col").click(); // Sort by rank by default
+
+
+// Code to make the first three columns sticky
+function adjustStickyColumns() {
+    const table = document.getElementById("leaderboard-table");
+    const headers = table.querySelectorAll("th");
+    const firstColumn = table.querySelectorAll("th:nth-child(1), td:nth-child(1)");
+    const secondColumn = table.querySelectorAll("th:nth-child(2), td:nth-child(2)");
+    const thirdColumn = table.querySelectorAll("th:nth-child(3), td:nth-child(3)");
+    // Reset left values
+    headers.forEach(header => header.style.left = '');
+    firstColumn.forEach(cell => cell.style.left = '');
+    secondColumn.forEach(cell => cell.style.left = '');
+    thirdColumn.forEach(cell => cell.style.left = '');
+    // Calculate widths
+    let firstColumnWidth = firstColumn[0].offsetWidth;
+    let secondColumnWidth = secondColumn[0].offsetWidth;
+    let thirdColumnWidth = thirdColumn[0].offsetWidth;
+    // Set left for the first column
+    firstColumn.forEach(cell => {
+        cell.style.left = "0px";
+    });
+    // Set left for the second column
+    secondColumn.forEach(cell => {
+        cell.style.left = `${firstColumnWidth}px`;
+    });
+    // Set left for the third column
+    thirdColumn.forEach(cell => {
+        cell.style.left = `${firstColumnWidth + secondColumnWidth}px`;
+    });
+}
+// Initial adjustment
+adjustStickyColumns();
+// Adjust on window resize
+window.addEventListener("resize", adjustStickyColumns);
+// Re-adjust on table content load (if table content is loaded dynamically)
+const observer = new MutationObserver(adjustStickyColumns);
+observer.observe(document.getElementById('leaderboard-table'), { childList: true, subtree: true });

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -149,7 +149,7 @@
             </p>
             <p>
                 <b>Cost</b> is calculated as an estimate of the cost per 1000 function calls, in USD.
-                <b>Latency</b> is measured in seconds.
+                <b>Latency</b> is measured in seconds, per each function call.
                 For <b>Open-Source Models</b>, the cost and latency are calculated when serving with <a
                     href="https://github.com/vllm-project/vllm">vLLM</a> using 8 V100 GPUs. The formula can be found in
                 the <a href="https://gorilla.cs.berkeley.edu/blogs/8_berkeley_function_calling_leaderboard.html#cost">blog</a>.

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -102,7 +102,9 @@
                 <table id="leaderboard-table">
                     <thead>
                         <tr>
-                            <th class="detail-header" colspan="3"></th>
+                            <th class="detail-header" colspan="1"></th>
+                            <th class="detail-header" colspan="1"></th>
+                            <th class="detail-header" colspan="1"></th>
                             <th class="detail-header" colspan="1"></th>
                             <th class="detail-header" colspan="3">Latency (s)</th>
                             <th class="detail-header" colspan="4">


### PR DESCRIPTION
This PR adds a sticky effect for the first three columns (rank, overall accuracy and model name) on the leaderboard. This feature is handy when viewing the leaderboard on small screen devices as it helps the user to know which model they are looking at when scrolling to the far right. 
This PR **DOES NOT** change the leaderboard score/ranking; this is just a styling update. 