### PR TITLE
[BFCL] PR#407 Evaluation Pipeline Robustness Patch

### DIFF
--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -234,7 +234,7 @@ For inferencing `Databrick-DBRX-instruct`, you need to create a Databrick Azure 
 
 
 ## Changelog
-* [June 7, 2024] [#459](https://github.com/ShishirPatil/gorilla/pull/459), [#407](https://github.com/ShishirPatil/gorilla/pull/407): Update the BFCL Python AST evaluation logic, loosen the type restriction in Python to accommodate the auto-conversion from `int` to `float` and allow the use of `int` values for Python parameters expecting `float` values.
+* [June 7, 2024] [#407](https://github.com/ShishirPatil/gorilla/pull/407), [#459](https://github.com/ShishirPatil/gorilla/pull/459): Update the BFCL Python AST evaluation logic, loosen the type restriction in Python to accommodate the auto-conversion from `int` to `float` and allow the use of `int` values for Python parameters expecting `float` values.
 * [May 14, 2024] [#426](https://github.com/ShishirPatil/gorilla/pull/426):
     - Add the following new models to the leaderboard:
         + `gpt-4o-2024-05-13`

--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -234,7 +234,8 @@ For inferencing `Databrick-DBRX-instruct`, you need to create a Databrick Azure 
 
 
 ## Changelog
-* [June 7, 2024] [#407](https://github.com/ShishirPatil/gorilla/pull/407), [#459](https://github.com/ShishirPatil/gorilla/pull/459): Update the BFCL Python AST evaluation logic, loosen the type restriction in Python to accommodate the auto-conversion from `int` to `float` and allow the use of `int` values for Python parameters expecting `float` values.
+
+* [June 7, 2024] [#407](https://github.com/ShishirPatil/gorilla/pull/407), [#462](https://github.com/ShishirPatil/gorilla/pull/462): Update the AST evaluation logic to allow the use of `int` values for Python parameters expecting `float` values. This is to accommodate the Python auto-conversion feature from `int` to `float`.
 * [May 14, 2024] [#426](https://github.com/ShishirPatil/gorilla/pull/426):
     - Add the following new models to the leaderboard:
         + `gpt-4o-2024-05-13`

--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -234,7 +234,7 @@ For inferencing `Databrick-DBRX-instruct`, you need to create a Databrick Azure 
 
 
 ## Changelog
-
+* [June 7, 2024] [#459](https://github.com/ShishirPatil/gorilla/pull/459), [#407](https://github.com/ShishirPatil/gorilla/pull/407): Update the BFCL Python AST evaluation logic, loosen the type restriction in Python to accommodate the auto-conversion from `int` to `float` and allow the use of `int` values for Python parameters expecting `float` values.
 * [May 14, 2024] [#426](https://github.com/ShishirPatil/gorilla/pull/426):
     - Add the following new models to the leaderboard:
         + `gpt-4o-2024-05-13`

--- a/berkeley-function-call-leaderboard/eval_checker/checker.py
+++ b/berkeley-function-call-leaderboard/eval_checker/checker.py
@@ -393,10 +393,18 @@ def simple_function_checker(
                 nested_type = param_details[param]["items"]["type"]
                 nested_type_converted = PYTHON_TYPE_MAPPING[nested_type]
 
-        if expected_type_description == "tuple":
+        # We convert all tuple value to list when the expected type is tuple.
+        # The conversion is necessary because any tuple in the possible answer would become a list after being processed through json.dump() and json.load().
+        # This does introduce some false positive (eg, when the model provides a list value instead of tuple), but it's necessary to make the checker work.
+        if expected_type_description == "tuple" and type(value) == tuple:
             value = list(value)
 
-        if expected_type_description == "float":
+        # Allow python auto conversion from int to float
+        if (
+            language == "Python"
+            and expected_type_description == "float"
+            and type(value) == int
+        ):
             value = float(value)
 
         # Type checking

--- a/berkeley-function-call-leaderboard/eval_checker/checker.py
+++ b/berkeley-function-call-leaderboard/eval_checker/checker.py
@@ -395,7 +395,7 @@ def simple_function_checker(
 
         # We convert all tuple value to list when the expected type is tuple.
         # The conversion is necessary because any tuple in the possible answer would become a list after being processed through json.dump() and json.load().
-        # This does introduce some false positive (eg, when the model provides a list value instead of tuple), but it's necessary to make the checker work.
+        # This does introduce some false positive (eg, when the model provides a list value instead of tuple). We hope to find a better solution in the future.
         if expected_type_description == "tuple" and type(value) == tuple:
             value = list(value)
 


### PR DESCRIPTION
This PR makes the BFCL evaluation pipeline more robust to the changes introduced in #407: When the parameter is of type `float`, less-capable models sometimes output a `string` or other types that might not be suitable to be converted to a `float`, which will cause the evaluation pipeline to error in `float(value)`. To prevent this, the pipeline now verifies the `value` type before attempting conversion to `float`.
This PR **DOES NOT** change the leaderboard evaluation score.