### PR TITLE
[BFCL] Apply Fix to Newly Introduced Model Handler Missed in Previous PR Merge

### DIFF
--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -208,7 +208,7 @@ Some companies have proposed some optimization strategies in their models' handl
 
 ## Changelog
 
-* [July 16, 2024] [#525](https://github.com/ShishirPatil/gorilla/pull/525): Add new model `ibm-granite/granite-20b-functioncalling` to the leaderboard.
+* [July 16, 2024] [#525](https://github.com/ShishirPatil/gorilla/pull/525), [#536](https://github.com/ShishirPatil/gorilla/pull/536): Add new model `ibm-granite/granite-20b-functioncalling` to the leaderboard.
 * [July 10, 2024] [#522](https://github.com/ShishirPatil/gorilla/pull/522): Bug fix in the evaluation dataset for Executable Parallel Multiple category. This includes updates to both prompts and function docs. 2 entries are affected.
 * [July 8, 2024] [#516](https://github.com/ShishirPatil/gorilla/pull/516): Fix double-casting issue in `model_handler` for Java and JavaScript test categories.
 * [July 7, 2024] [#504](https://github.com/ShishirPatil/gorilla/pull/504), [#505](https://github.com/ShishirPatil/gorilla/pull/505), [#506](https://github.com/ShishirPatil/gorilla/pull/506), [#508](https://github.com/ShishirPatil/gorilla/pull/508), [#510](https://github.com/ShishirPatil/gorilla/pull/510), [#512](https://github.com/ShishirPatil/gorilla/pull/512), [#517](https://github.com/ShishirPatil/gorilla/pull/517): Make BFCL user-friendly and easy to extend.

--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -208,6 +208,7 @@ Some companies have proposed some optimization strategies in their models' handl
 
 ## Changelog
 
+* [July 16, 2024] [#525](https://github.com/ShishirPatil/gorilla/pull/525): Add new model `ibm-granite/granite-20b-functioncalling` to the leaderboard.
 * [July 10, 2024] [#522](https://github.com/ShishirPatil/gorilla/pull/522): Bug fix in the evaluation dataset for Executable Parallel Multiple category. This includes updates to both prompts and function docs. 2 entries are affected.
 * [July 8, 2024] [#516](https://github.com/ShishirPatil/gorilla/pull/516): Fix double-casting issue in `model_handler` for Java and JavaScript test categories.
 * [July 7, 2024] [#504](https://github.com/ShishirPatil/gorilla/pull/504), [#505](https://github.com/ShishirPatil/gorilla/pull/505), [#506](https://github.com/ShishirPatil/gorilla/pull/506), [#508](https://github.com/ShishirPatil/gorilla/pull/508), [#510](https://github.com/ShishirPatil/gorilla/pull/510), [#512](https://github.com/ShishirPatil/gorilla/pull/512), [#517](https://github.com/ShishirPatil/gorilla/pull/517): Make BFCL user-friendly and easy to extend.

--- a/berkeley-function-call-leaderboard/model_handler/granite_handler.py
+++ b/berkeley-function-call-leaderboard/model_handler/granite_handler.py
@@ -49,10 +49,10 @@ class GraniteHandler(OSSHandler):
         return prompt
 
     def inference(
-        self, question_file, test_category, num_gpus, format_prompt_func=_format_prompt
+        self, test_question, test_category, num_gpus, format_prompt_func=_format_prompt
     ):
         return super().inference(
-            question_file, test_category, num_gpus, format_prompt_func
+            test_question, test_category, num_gpus, format_prompt_func
         )
 
     def decode_ast(self, result, language="Python"):

--- a/berkeley-function-call-leaderboard/model_handler/granite_handler.py
+++ b/berkeley-function-call-leaderboard/model_handler/granite_handler.py
@@ -76,9 +76,6 @@ class GraniteHandler(OSSHandler):
                     decoded_outputs.append("No function is called")
                     continue
 
-                if language != "Python":
-                    args = {k: str(v) for k, v in args.items()}
-
                 decoded_outputs.append({fnname: args})
 
         return decoded_outputs


### PR DESCRIPTION
On July 16th, PR #516 and PR #512 were merged first. They introduced fixes that should be applied to all model handlers. Shortly after, on the same day, PR #525 was merged. The new model handler introduced in PR #525 is missing the fixes from the previous two merged PRs (it wasn't synced accordingly). This PR addresses this issue by applying the necessary fixes to the new model handler.