### PR TITLE
[BFCL] Fix JS type converter to handle dictionaries with array values

### DIFF
--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -214,6 +214,15 @@ Some companies have proposed some optimization strategies in their models' handl
 
 ## Changelog
 
+* [July 26, 2024] [#549](https://github.com/ShishirPatil/gorilla/pull/549): Fix js_type_converter.py to properly handle JavaScript array value inside dictionary. 
+* [July 25, 2024] [#532](https://github.com/ShishirPatil/gorilla/pull/532), [#543](https://github.com/ShishirPatil/gorilla/pull/543), [#556](https://github.com/ShishirPatil/gorilla/pull/556), [#542](https://github.com/ShishirPatil/gorilla/pull/542): Add the following new models to the leaderboard:
+    - `Salesforce/xLAM-7b-fc-r`
+    - `Salesforce/xLAM-1b-fc-r`
+    - `yi-large-fc`
+    - `NousResearch/Hermes-2-Pro-Llama-3-8B`
+    - `NousResearch/Hermes-2-Pro-Llama-3-70B`
+    - `NousResearch/Hermes-2-Theta-Llama-3-8B`
+    - `NousResearch/Hermes-2-Theta-Llama-3-70B`
 * [July 22, 2024] [#540](https://github.com/ShishirPatil/gorilla/pull/540): Chore: Improve handling of vLLM's cleanup phase error by combining all selected test categories into one single task to submit to the vLLM server.
 * [July 21, 2024] [#538](https://github.com/ShishirPatil/gorilla/pull/538), [#545](https://github.com/ShishirPatil/gorilla/pull/545): Fix `language_specific_pre_processing` and `convert_to_tool` function to properly handle pre-processing for prompts and function docs in Java and JavaScript test categories. All entries in these categories are affected.
 * [July 20, 2024] [#537](https://github.com/ShishirPatil/gorilla/pull/537): Update generation script for locally-hosted OSS model to use single-node multi-GPU inference method (tensor parallel). Ray is not used anymore.

--- a/berkeley-function-call-leaderboard/model_handler/functionary_handler.py
+++ b/berkeley-function-call-leaderboard/model_handler/functionary_handler.py
@@ -13,14 +13,3 @@ class FunctionaryHandler(OpenAIHandler):
         self.model_style = ModelStyle.OpenAI
 
         self.client = OpenAI(base_url="http://localhost:8000/v1", api_key="functionary")
-
-    def write(self, result, file_to_open):
-        model_name = self.model_name
-        if not os.path.exists("./result"):
-            os.mkdir("./result")
-        if not os.path.exists("./result/" + model_name.replace("/", "_")):
-            os.mkdir("./result/" + model_name.replace("/", "_"))
-        with open(
-            "./result/" + model_name.replace("/", "_") + "/" + file_to_open, "a+"
-        ) as f:
-            f.write(json.dumps(result) + "\n")

--- a/berkeley-function-call-leaderboard/model_handler/nvidia_handler.py
+++ b/berkeley-function-call-leaderboard/model_handler/nvidia_handler.py
@@ -53,16 +53,6 @@ class NvidiaHandler(BaseHandler):
         output_token = response.usage.completion_tokens
         metadata = {"input_tokens": input_token, "output_tokens": output_token, "latency": latency}
         return result, metadata
-    
-    def write(self, result, file_to_open):
-        if not os.path.exists("./result"):
-            os.mkdir("./result")
-        if not os.path.exists("./result/" + self.model_name.replace("/", "_")):
-            os.mkdir("./result/" + self.model_name.replace("/", "_"))
-        with open(
-            "./result/" + self.model_name.replace("/", "_") + "/" + file_to_open.replace(".json", "_result.json"), "a+"
-        ) as f:
-            f.write(json.dumps(result) + "\n")
 
     def decode_ast(self, result, language="Python"):
         result = result.replace("\n", "")


### PR DESCRIPTION
**Issue**: 
Javascript, id: 6 presents a parameter where the js type converter doesn't properly handles, i.e. converting js parameter into python data type,

```javascript
{"initialState": initialStateObject, "reducers": reducersMap, "middlewares": ["loggerMiddleware"], "enhancers": ["applyMiddleware", "myMiddleWare"]}
```

**Solution**:
This PR addresses the proper handling of a dictionary with array values appearing in BFCL. An additional unit test has been added. 

This PR **will** change the leaderboard score.