### PR TITLE
[BFCL] Handling rate limits

### DIFF
--- a/berkeley-function-call-leaderboard/openfunctions_evaluation.py
+++ b/berkeley-function-call-leaderboard/openfunctions_evaluation.py
@@ -133,7 +133,6 @@ def generate_results(args, model_name, test_cases_total):
                         and (
                             e.status_code == 429
                             or e.status_code == 503
-                            or e.status_code == 403
                             or e.status_code == 500
                         )
                     ):

--- a/berkeley-function-call-leaderboard/openfunctions_evaluation.py
+++ b/berkeley-function-call-leaderboard/openfunctions_evaluation.py
@@ -92,6 +92,7 @@ def collect_test_cases(test_filename_total, model_name):
 
 def generate_results(args, model_name, test_cases_total):
     RETRY_LIMIT = 3
+    # 60s for the timer to complete. But often we find that even with 60 there is a conflict. So 65 is a safe no.
     RETRY_DELAY = 65  # Delay in seconds
     
     handler = build_handler(model_name, args.temperature, args.top_p, args.max_tokens)

--- a/berkeley-function-call-leaderboard/openfunctions_evaluation.py
+++ b/berkeley-function-call-leaderboard/openfunctions_evaluation.py
@@ -1,4 +1,4 @@
-import argparse, json, os
+import argparse, json, os, time
 from tqdm import tqdm
 from model_handler.handler_map import handler_map
 from model_handler.model_style import ModelStyle
@@ -114,9 +114,19 @@ def generate_results(args, model_name, test_cases_total):
             if type(functions) is dict or type(functions) is str:
                 functions = [functions]
 
-            result, metadata = handler.inference(
-                user_question, functions, test_category
-            )
+            try:
+                result, metadata = handler.inference(
+                    user_question, functions, test_category
+                )
+            except Exception as e:
+                if "Rate limit reached" in str(e):
+                    print("Rate limit reached. Sleeping for 65 seconds.")
+                    time.sleep(65)
+                    result, metadata = handler.inference(
+                        user_question, functions, test_category
+                    )  # Retry
+                else:
+                   raise e
             result_to_write = {
                 "id": test_case["id"],
                 "result": result,

--- a/berkeley-function-call-leaderboard/openfunctions_evaluation.py
+++ b/berkeley-function-call-leaderboard/openfunctions_evaluation.py
@@ -134,6 +134,7 @@ def generate_results(args, model_name, test_cases_total):
                             e.status_code == 429
                             or e.status_code == 503
                             or e.status_code == 403
+                            or e.status_code == 500
                         )
                     ):
                         print(f"Rate limit reached. Sleeping for 65 seconds. Retry {retry_count + 1}/{RETRY_LIMIT}")


### PR DESCRIPTION
For BFCL generations of hosted models, this will check for rate limit errors and retry thrice. We can choose to include an exponential back-off as is usually recommended, but I think in the interest of keeping it simple this should perhaps be sufficient?

This does NOT affect the leaderboard values. 