### PR TITLE
Update 7_open_functions_v2.html with the right url

### DIFF
--- a/blogs/4_open_functions.html
+++ b/blogs/4_open_functions.html
@@ -118,7 +118,9 @@
                 <div class="body">
                     <p>Using Gorilla OpenFunctions is straightforward:
                         <ol>
-                        <li>Define Your Functions: Provide a JSON file containing descriptions of your custom functions. Each function should contain fields: <code>name</code> (the name of the API), <code>api_call</code> (how to invoke this API), <code>description</code> (which describes the functionality of the API), and lastly, <code>parameters</code> (a list of parameters pertaining to the API call). Below is an example of API documentation that can feed into OpenFunctions.</li>
+                        <li>Define Your Functions: Provide a JSON file containing descriptions of your custom functions. Each function should contain fields: <code>name</code> (the name of the API), <code>api_call</code> (how to invoke this API), <code>description</code> (which describes the functionality of the API), and lastly, <code>parameters</code> (a list of parameters pertaining to the API call). Below is an example of API documentation that can feed into OpenFunctions. 
+                        </li>
+                            <li>Install the openai client with <code>pip install openai==0.28</code></li>
                         <pre><code>
     function_documentation = {  
         "name" : "Order Food on Uber",

--- a/blogs/7_open_functions_v2.html
+++ b/blogs/7_open_functions_v2.html
@@ -155,7 +155,7 @@
 
 <span style="color: #d14;">def</span> <span style="color: #069;">get_gorilla_response</span>(prompt=<span style="color: #d14;">""</span>, model=<span style="color: #d14;">"gorilla-openfunctions-v2"</span>, functions=[]):
     openai.api_key = <span style="color: #d14;">"EMPTY"</span>  <span style="color: #60a0b0; font-style: italic;"># Hosted for free with</span> <span style="color:#ff0000;">❤️</span> <span style="color: #60a0b0; font-style: italic;">from UC Berkeley</span>
-    openai.api_base = <span style="color: #d14;">"http://luigi.millennium.berkeley.edu:8000/v1"</span>
+    openai.api_base = <span style="color: #d14;">"https://luigi.millennium.berkeley.edu/v1"</span>
     <span style="color: #d14;">try</span>:
         completion = openai.ChatCompletion.create(
             model=<span style="color: #d14;">"gorilla-openfunctions-v2"</span>,


### PR DESCRIPTION
The Openfunctions-v2 blog workflow was recommending the `http` endpoint on port `8000`. Since, we migrated to https, the end-point needs to be fixed.
Latest end-point: [https://luigi.millennium.berkeley.edu/v1](https://luigi.millennium.berkeley.edu/v1/chat/completions) 

This PR does not affect the BFCL Leaderboard. 