### PR TITLE
[BFCL Blog] Leaderboard Naming Typo 8_berkeley_function_calling_leaderboard.html

### DIFF
--- a/blogs/8_berkeley_function_calling_leaderboard.html
+++ b/blogs/8_berkeley_function_calling_leaderboard.html
@@ -1716,7 +1716,7 @@ Gorilla-Openfunctions-v2 output:
                         <h4 id="conclusion">Conclusion</h4>
                         <div class="body">
                             <p>We provide a comprehensive and systematic evaluation of LLMs for function calling with
-                                Gorilla Open Functions Leaderboard. The studies here suggest that in terms of simple
+                                Berkeley Function Calling Leaderboard. The studies here suggest that in terms of simple
                                 function calling (without complex planning and chained function calling), finetuning an
                                 open-source can be as effective as propriety models. Furthermore, we provide Gorilla
                                 Open Functions v2, an open-source model that can help users with building AI


### PR DESCRIPTION
Minor typo fix in BFCL blog