### PR TITLE
Fix issue #614: [BFCL] ModuleNotFoundError after commit 70d6722

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/model_handler/gorilla_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/gorilla_handler.py
@@ -5,7 +5,7 @@ from bfcl.model_handler.utils import (
     system_prompt_pre_processing_chat_model,
     func_doc_language_specific_pre_processing,
 )
-from model_handler.constant import DEFAULT_SYSTEM_PROMPT
+from bfcl.model_handler.constant import DEFAULT_SYSTEM_PROMPT
 import requests, json, re, time
 
 

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/oss_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/oss_handler.py
@@ -5,7 +5,7 @@ from bfcl.model_handler.utils import (
     system_prompt_pre_processing_chat_model,
     func_doc_language_specific_pre_processing,
 )
-from model_handler.constant import DEFAULT_SYSTEM_PROMPT
+from bfcl.model_handler.constant import DEFAULT_SYSTEM_PROMPT
 
 
 class OSSHandler(BaseHandler):


### PR DESCRIPTION
Bug fix of #614 [](url)

This pull request resolves the `ModuleNotFoundError` reported in issue #614 by updating the import paths affected by the directory restructuring in commit 70d6722. The adjustments ensure that the LLM inference functionality works as expected.

**Changes:**
- `oss_handler.py` and `gorilla_handler.py` import paths updated to include the new `bfcl` directory prefix.

**Testing:**
Run the following command to verify that the issue has been resolved:
`python openfunctions_evaluation.py --model gorilla-openfunctions-v2 --test-category multiple --num-threads 1
`
