### PR TITLE
Update gemini_handler.py to better handle NL+FC model output

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/model_handler/gemini_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/gemini_handler.py
@@ -79,14 +79,15 @@ class GeminiHandler(BaseHandler):
                 "processed_tool": functions,
             }
         try:
-            parts = []
+            fc_parts = []
+            text_parts = []
             for part in result["candidates"][0]["content"]["parts"]:
                 if "functionCall" in part:
                     if (
                         "name" in part["functionCall"]
                         and "args" in part["functionCall"]
                     ):
-                        parts.append(
+                        fc_parts.append(
                             {
                                 part["functionCall"]["name"]: json.dumps(
                                     part["functionCall"]["args"]
@@ -94,12 +95,15 @@ class GeminiHandler(BaseHandler):
                             }
                         )
                     else:
-                        parts.append(
+                        text_parts.append(
                             "Parsing error: " + json.dumps(part["functionCall"])
                         )
                 else:
-                    parts.append(part["text"])
-            result = parts
+                    text_parts.append(part["text"])
+            if fc_parts:
+                result = fc_parts
+            else:
+                result = text_parts
             metatdata = {}
             metatdata["input_token_count"] = json.loads(response.content)["usageMetadata"][
                 "promptTokenCount"


### PR DESCRIPTION
Gemini model is capable of outputting NL/text (for reasoning or verbosity) for the corresponding FC as different parts. Simply concatenation of text with FC will result in decode failures. So we should only extract FC parts for decoding and eval when it exists in the content. 

See below example:

OUTPUT:  ["Okay, I can help you with that. Let's calculate the future value for each investment option:\n\n\n**Bond:**\n\n", {"calculate_future_value": "{\"present_value\": 5000, \"periods\": 10, \"interest_rate\": 0.05}"}, "\n\n**Mutual Fund:**\n\n", {"calculate_future_value": "{\"periods\": 15, \"interest_rate\": 0.07, \"present_value\": 2000}"}, "\n\n\n**Stocks:**\n\n", {"calculate_future_value": "{\"periods\": 20, \"interest_rate\": 0.1, \"present_value\": 1000}"}"]

