### PR TITLE
[BFCL] Bug Fix parse_nested_value function for model_handler utils

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Sept 25, 2024] [#660](https://github.com/ShishirPatil/gorilla/pull/660): Bug fix in `parse_nested_value` function to handle nested dictionary values properly. 
 - [Sept 19, 2024] [#644](https://github.com/ShishirPatil/gorilla/pull/644): BFCL V3 release:
   - Introduce new multi-turn dataset and state-based evaluation metric
   - Separate ast_checker and executable_checker for readability

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/utils.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/utils.py
@@ -751,17 +751,23 @@ def parse_nested_value(value):
     Parse a potentially nested value from the AST output.
 
     Args:
-        value: The value to parse, which could be a nested dictionary or a simple value.
+        value: The value to parse, which could be a nested dictionary, which includes another function call, or a simple value.
 
     Returns:
-        str: A string representation of the value, handling nested function calls.
+        str: A string representation of the value, handling nested function calls and nested dictionary function arguments.
     """
     if isinstance(value, dict):
-        func_name = list(value.keys())[0]
-        args = value[func_name]
-        args_str = ", ".join(f"{k}={parse_nested_value(v)}" for k, v in args.items())
-        return f"{func_name}({args_str})"
+        # Check if the dictionary represents a function call (i.e., the value is another dictionary or complex structure)
+        if all(isinstance(v, dict) for v in value.values()):
+            func_name = list(value.keys())[0]
+            args = value[func_name]
+            args_str = ", ".join(f"{k}={parse_nested_value(v)}" for k, v in args.items())
+            return f"{func_name}({args_str})"
+        else:
+            # If it's a simple dictionary, treat it as key-value pairs
+            return "{" + ", ".join(f"{k}={parse_nested_value(v)}" for k, v in value.items()) + "}"
     return repr(value)
+
 
 
 def decoded_output_to_execution_list(decoded_output):

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/utils.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/utils.py
@@ -765,7 +765,7 @@ def parse_nested_value(value):
             return f"{func_name}({args_str})"
         else:
             # If it's a simple dictionary, treat it as key-value pairs
-            return "{" + ", ".join(f"{k}={parse_nested_value(v)}" for k, v in value.items()) + "}"
+            return "{" + ", ".join(f"'{k}': {parse_nested_value(v)}" for k, v in value.items()) + "}"
     return repr(value)
 
 
@@ -788,3 +788,4 @@ def decoded_output_to_execution_list(decoded_output):
             )
             execution_list.append(f"{key}({args_str})")
     return execution_list
+    


### PR DESCRIPTION
In the parse_nested_value function, added a check to determine whether we are dealing with another function call or if its a regular dictionary. Previous version of the code incorrectly assumed that this was always a function call and did not consider the case where the function argument is a dictionary. 

Fix https://github.com/ShishirPatil/gorilla/issues/652