### PR TITLE
[Agent-Arena] Navigate the blog link of LmSys to Elo Blog.

### DIFF
--- a/blogs/14_agent_arena.html
+++ b/blogs/14_agent_arena.html
@@ -580,7 +580,7 @@
                             <div class="body">
                               <h3>The Extended Bradley-Terry Model</h3>
                               <p>
-                                Agent Arena uses the <a href="https://blog.lmarena.ai/blog/2024/redteam-arena/">Bradley-Terry extension</a>, which allows us to compare different agents based on their subcomponents, including tools, models, and frameworks. Instead of just evaluating the agents atomically, we also assess the performance of each individual subcomponent. This allows us to more accurately pinpoint where an agent's strength lies. For example, our first agent could be a combination of LangChain, Brave-Search, and GPT-4o-2024-08-06, while the second agent could be LlamaIndex, Wikipedia, and Claude-3-5-Sonnet-20240620.
+                                Agent Arena uses the <a href="https://blog.lmarena.ai/blog/2024/extended-arena/">Bradley-Terry extension</a>, which allows us to compare different agents based on their subcomponents, including tools, models, and frameworks. Instead of just evaluating the agents atomically, we also assess the performance of each individual subcomponent. This allows us to more accurately pinpoint where an agent's strength lies. For example, our first agent could be a combination of LangChain, Brave-Search, and GPT-4o-2024-08-06, while the second agent could be LlamaIndex, Wikipedia, and Claude-3-5-Sonnet-20240620.
 
                                 Therefore, we propose the following observation model for the Extended Bradley-Terry Model. Given <code>P_1</code>, 
 


### PR DESCRIPTION
This is a change made to the blog of Agent Arena - where we redirect users to a different LMSys blog in our Elo section. 