### PR TITLE
[BFCL] Speed Up Locally-hosted Model Inference Process

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Oct 4, 2024] [#671](https://github.com/ShishirPatil/gorilla/pull/671): Speed up locally-hosted model's inference process by parallelizing the inference requests.
 - [Sept 27, 2024] [#640](https://github.com/ShishirPatil/gorilla/pull/640): Add the following new models to the leaderboard:
   - `microsoft/Phi-3.5-mini-instruct`
   - `microsoft/Phi-3-medium-128k-instruct`


### PR DESCRIPTION
Fix #649 

Instead of send requests to the vllm server one by one in sequence, we should send all requests all at once to vllm to utiliza its batching and optimizaiton benefits. 

Tested on 8 x A100 (40G) with Llama 3.1 70B. The inference speed on single-turn entries are roughtly the same (within 1 minute difference) as when using `llm.generate` before the BFCL V3 release in #644]. The multi-turn entries still takes around 2 hours to complete, but that's largely due to the nature of the multi-turn dataset; it has been much faster than previously where it would take 2 days to finish.

This PR **will not** affect the leaderboard score. 