### PR TITLE
Update google-cloud-aiplatform dependency

### DIFF
--- a/berkeley-function-call-leaderboard/pyproject.toml
+++ b/berkeley-function-call-leaderboard/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "mistralai==1.1.0",
     "anthropic==0.31.1",
     "cohere==5.5.8",
-    "google-cloud-aiplatform==1.65.0",
+    "google-cloud-aiplatform>=1.70.0",
     "pathlib",
 ]
 


### PR DESCRIPTION
When I tried to run `$ python openfunctions_evaluation.py --model gemini-1.5-pro-002-FC` I got a lot of 
```
Generating results for gemini-1.5-pro-002-FC:   2%|█▋                                                                                                    | 80/4751 [00:49<1:06:42,  1.17it/s]❗️Failed to write result: Object of type RepeatedComposite is not JSON serializable
Generating results for gemini-1.5-pro-002-FC:   2%|█▉                                                                                                      | 89/4751 [00:55<43:43,  1.78it/s]❗️Failed to write result: Object of type RepeatedComposite is not JSON serializable
Generating results for gemini-1.5-pro-002-FC:   2%|█▉                                                                                                    | 90/4751 [00:56<1:07:45,  1.15it/s]❗️Failed to write result: Object of type RepeatedComposite is not JSON serializable
Generating results for gemini-1.5-pro-002-FC:   2%|██                                                                                                      | 92/4751 [00:57<56:26,  1.38it/s]❗️Failed to write result: Object of type RepeatedComposite is not JSON serializable
❗️Failed to write result: Object of type RepeatedComposite is not JSON serializable
Generating results for gemini-1.5-pro-002-FC:   2%|██                                                                                                    | 94/4751 [01:04<2:05:32,  1.62s/it]❗️Failed to write result: Object of type RepeatedComposite is not JSON serializable
```

upgrading to the latest version seems to fix this issue.