### PR TITLE
Add the option to log to WandB during bfcl evaluate

### DIFF
--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -309,6 +309,12 @@ If you want to run `live_simple` and `javascript` tests for a few models and `go
 bfcl evaluate --model gorilla-openfunctions-v2 claude-3-5-sonnet-20240620 gpt-4-0125-preview gemini-1.5-pro-preview-0514 --test-category live_simple javascript
 ```
 
+If you want to log the evaluation results as WandB artifacts to a specific WandB entity and project, you can use the following argument:
+```bash
+bfcl evaluate --model gpt-3.5-turbo-0125  
+--wandb-project <wandb_entity:wandb_project>
+```
+
 ### Model-Specific Optimization
 
 Some companies have proposed some optimization strategies in their models' handler, which we (BFCL) think is unfair to other models, as those optimizations are not generalizable to all models. Therefore, we have disabled those optimizations during the evaluation process by default. You can enable those optimizations by setting the `USE_{COMPANY}_OPTIMIZATION` flag to `True` in the `.env` file.

--- a/berkeley-function-call-leaderboard/bfcl/__main__.py
+++ b/berkeley-function-call-leaderboard/bfcl/__main__.py
@@ -185,13 +185,17 @@ def evaluate(
         "-c",
         help="Perform the REST API status sanity check before running the evaluation.",
     ),
+    wandb_project: str = typer.Option(
+        None,
+        help="The entity and project to which to log the generated .csv in the format 'entity:project'"
+    )
 ):
     """
     Evaluate results from run of one or more models on a test-category (same as eval_runner.py).
     """
 
     load_dotenv(dotenv_path=DOTENV_PATH, verbose=True, override=True)  # Load the .env file
-    eval_runner.main(model, test_category, api_sanity_check)
+    eval_runner.main(model, test_category, api_sanity_check,wandb_project)
 
 
 @cli.command()


### PR DESCRIPTION
In our internal use of BFCL at Valence Labs, we use WandB extensively to centralize the results of our benchmarking.
This PR adds a `--wandb-project` CLI argument to the `bfcl evaluate` command to upload the generated `.csv` files to wandb.

Here is an example command:
```bash
bfcl evaluate --model gpt-3.5-turbo-0125  
--wandb-project <wandb_entity:wandb_project>
```

This will log the `data_live.csv`, `data_non_live.csv` and `data_overall.csv` as dataframe artifacts on the WandB `wandb_project` under the `wandb_entity`.