### PR TITLE
Add exponential retry logic for gemini models

### DIFF
--- a/berkeley-function-call-leaderboard/pyproject.toml
+++ b/berkeley-function-call-leaderboard/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "tabulate>=0.9.0",
     "google-cloud-aiplatform==1.72.0",
     "mpmath==1.3.0",
+    "tenacity==9.0.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
This is to avoid the following error with long context on Gemini models due to insufficient quota:

```
Error: 429 Resource exhausted. Please try again later. Please refer to https://cloud.google.com/vertex-ai/generative-ai/docs/quotas#error-code-429 for more details.
```

This approach uses exponential backoff retries when encountering a ResourceExhausted error.