### PR TITLE
Skip adding empty content from gemini

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Nov 17, 2024] [#767](https://github.com/ShishirPatil/gorilla/pull/767): Fix price and latency calculation. A merge conflict results in a duplicate line, and counting the input and output token for each entry multiple times.
 - [Nov 15, 2024] [#762](https://github.com/ShishirPatil/gorilla/pull/762): Supply `data_multi_turn.csv` for multi-turn evaluation results
 - [Nov 14, 2024] [#760](https://github.com/ShishirPatil/gorilla/pull/760), [#761](https://github.com/ShishirPatil/gorilla/pull/761): Upstream  `google-cloud-aiplatform` library fixed typecasting bugs in Function Calling. Updated to version `1.72.0` and remove the workaround patch introduced in [#648](https://github.com/ShishirPatil/gorilla/pull/648).
 - [Nov 14, 2024] [#747](https://github.com/ShishirPatil/gorilla/pull/747): Minor Grammatical Corrections to `DEFAULT_SYSTEM_PROMPT` that is supplied to all prompting models.

--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Nov 18, 2024] [#768](https://github.com/ShishirPatil/gorilla/pull/768), [#770](https://github.com/ShishirPatil/gorilla/pull/770): Resolve issues in Gemini models (FC mode) related to handling scenarios with no tools available and cases where the model output is empty.
 - [Nov 17, 2024] [#767](https://github.com/ShishirPatil/gorilla/pull/767): Fix price and latency calculation. A merge conflict results in a duplicate line, and counting the input and output token for each entry multiple times.
 - [Nov 15, 2024] [#762](https://github.com/ShishirPatil/gorilla/pull/762): Supply `data_multi_turn.csv` for multi-turn evaluation results
 - [Nov 14, 2024] [#760](https://github.com/ShishirPatil/gorilla/pull/760), [#761](https://github.com/ShishirPatil/gorilla/pull/761): Upstream  `google-cloud-aiplatform` library fixed typecasting bugs in Function Calling. Updated to version `1.72.0` and remove the workaround patch introduced in [#648](https://github.com/ShishirPatil/gorilla/pull/648).

--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/eval_runner_helper.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/eval_runner_helper.py
@@ -183,10 +183,9 @@ def record_cost_latency(leaderboard_table, model_name, model_output_data):
     output_token = []
     latency = []
     for data in model_output_data:
-        for data in model_output_data:
-            process_data("latency", data, latency)
-            process_data("input_token_count", data, input_token)
-            process_data("output_token_count", data, output_token)
+        process_data("latency", data, latency)
+        process_data("input_token_count", data, input_token)
+        process_data("output_token_count", data, output_token)
 
     leaderboard_table[model_name]["cost"]["input_data"].extend(input_token)
     leaderboard_table[model_name]["cost"]["output_data"].extend(output_token)

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
@@ -209,9 +209,10 @@ class GeminiHandler(BaseHandler):
     def _add_assistant_message_FC(
         self, inference_data: dict, model_response_data: dict
     ) -> dict:
-        inference_data["message"].append(
-            model_response_data["model_responses_message_for_chat_history"]
-        )
+        if len(model_response_data["model_responses_message_for_chat_history"].parts):
+            inference_data["message"].append(
+                model_response_data["model_responses_message_for_chat_history"]
+            )
         return inference_data
 
     def _add_execution_results_FC(


### PR DESCRIPTION
This PR fixes errors where the user adds an empty turn in a multi-turn conversation request, causing the following API error message:

```
InvalidArgument: 400 Please use a valid role: user, model.
```

Gemini sometimes returns an empty content during multi-turn conversations, particularly in response to a function result in the previous turn. 

As a workaround, we can just skip adding this turn and proceed with the next user turn, which should not affect the correctness of the example unless the missing turn was a function call. But generally, it seems that the missing turn is the optional natural language response to the function response.