### PR TITLE
Remove stop condition in gemini retry logic

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
@@ -80,7 +80,6 @@ class GeminiHandler(BaseHandler):
 
     @retry(
         wait=wait_random_exponential(min=6, max=120),
-        stop=stop_after_attempt(10),
         retry=retry_if_exception_type(ResourceExhausted),
         before_sleep=lambda retry_state: print(
             f"Attempt {retry_state.attempt_number} failed. Sleeping for {float(round(retry_state.next_action.sleep, 2))} seconds before retrying..."

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
@@ -18,7 +18,6 @@ from google.api_core.exceptions import ResourceExhausted
 from tenacity import (
     retry,
     retry_if_exception_type,
-    stop_after_attempt,
     wait_random_exponential,
 )
 from vertexai.generative_models import (


### PR DESCRIPTION
Even with the current retry logic, I was still facing ResourceExhaustion errors during the multi_turn_long_context cases. I have removed the stop condition in the retry logic to allow the code to continue trying until the tokens per minute quota allows for new requests. This potentially could increase the duration of the test, but it will allow all examples to finish.