### PR TITLE
Fix handling of examples with no tools in Gemini

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
@@ -105,7 +105,10 @@ class GeminiHandler(BaseHandler):
                 )
             )
 
-        tools = [Tool(function_declarations=func_declarations)]
+        if func_declarations:
+            tools = [Tool(function_declarations=func_declarations)]
+        else:
+            tools = []
 
         inference_data["inference_input_log"] = {
             "message": repr(inference_data["message"]),

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
@@ -108,7 +108,7 @@ class GeminiHandler(BaseHandler):
         if func_declarations:
             tools = [Tool(function_declarations=func_declarations)]
         else:
-            tools = []
+            tools = None
 
         inference_data["inference_input_log"] = {
             "message": repr(inference_data["message"]),
@@ -133,7 +133,7 @@ class GeminiHandler(BaseHandler):
             generation_config=GenerationConfig(
                 temperature=self.temperature,
             ),
-            tools=tools if len(tools) > 0 else None,
+            tools=tools
         )
         return api_response
 


### PR DESCRIPTION
There is a bug in handling examples with no tools / function definitions. Because the tools array is created like this:

```
tools = [Tool(function_declarations=func_declarations)]
```

the following conditional would always submit a tool, since the array has a single element:

```
        api_response = self.generate_with_backoff(
            client=client,
            contents=inference_data["message"],
            generation_config=GenerationConfig(
                temperature=self.temperature,
            ),
            tools=tools if len(tools) > 0 else None,  # conditional will always resolve to True
        )
```

This led to the following Gemini API error when a Tool was submitted with no function declarations:

```
400 Request contains an invalid argument. [detail: "[ORIGINAL ERROR] generic::invalid_argument: The GenerateContentRequest proto is invalid:\n  * tools[0].tool_type: required one_of \'tool_type\' must have one initialized field"
```

The fix moves the conditional to the creation of the tools array:

```
        if func_declarations:
            tools = [Tool(function_declarations=func_declarations)]
        else:
            tools = None
```
