### PR TITLE
add transformers to pyproject.toml

### DIFF
--- a/berkeley-function-call-leaderboard/pyproject.toml
+++ b/berkeley-function-call-leaderboard/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "tabulate>=0.9.0",
     "google-cloud-aiplatform==1.72.0",
     "mpmath==1.3.0",
-    "tenacity==9.0.0"
+    "tenacity==9.0.0",
+    "transformers==4.46.3"
 ]
 
 [project.scripts]


### PR DESCRIPTION
After installing the repo:

```
cd berkeley-function-call-leaderboard/
python3 -m pip install -e .
```

When trying to run on OSS models, I run into the following error -

```
ModuleNotFoundError: No module named 'transformers'
```

This PR adds transformers library into the pyproject.toml

