### PR TITLE
[BFCL] Fix Irrelevance Category Performance for DeepSeek Coder Handler

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/__main__.py
+++ b/berkeley-function-call-leaderboard/bfcl/__main__.py
@@ -37,10 +37,22 @@ cli = typer.Typer(
 )
 
 
-# Input is like 'a,b,c,d', we need to transform it to ['a', 'b', 'c', 'd'] because that's the expected format in the actual main funciton
-handle_multiple_input = lambda x: [
-    item.strip() for item in ",".join(x).split(",") if item.strip()
-]
+def handle_multiple_input(input_str):
+    """
+    Input is like 'a,b,c,d', we need to transform it to ['a', 'b', 'c', 'd'] because that's the expected format in the actual main funciton
+    """
+    if input_str is None:
+        """
+        Cannot return None here, as typer will check the length of the return value and len(None) will raise an error
+        But when default is None, an empty list will be internally converted to None, and so the pipeline still works as expected
+        ```
+        if default_value is None and len(value) == 0:
+            return None
+        ```
+        """
+        return []
+
+    return [item.strip() for item in ",".join(input_str).split(",") if item.strip()]
 
 
 @cli.command()

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/deepseek_coder.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/deepseek_coder.py
@@ -21,10 +21,16 @@ class DeepseekCoderHandler(OSSHandler):
 
     @overrides
     def decode_ast(self, result, language="Python"):
+        # The input is already a list of dictionaries, so no need to decode
+        # `[{func1:{param1:val1,...}},{func2:{param2:val2,...}}]`
+        if type(result) != list:
+            return []
         return result
 
     @overrides
     def decode_execute(self, result):
+        if type(result) != list:
+            return []
         return convert_to_function_call(result)
 
     @overrides


### PR DESCRIPTION
This PR updates the decoding logic for DeepSeek-Coder handler to fix its performance issue in the irrelevance category. 
The irrelevance category metric we use is that, either the `decode_ast` should fail (error) or the decoded output is empty (eg, empty list or empty string). 

For the DeepSeek-Coder model, 
When it outputs a valid function call, the model response will be a list of dictionaries `[{func1:{param1:val1,...}},{func2:{param2:val2,...}}]`, so it's fine for `decode_ast` to just return it without any processing.
However, when the output is a message (not valid function call), under the `_parse_query_response_prompting` logic, the model response will be that message string, and in the current `decode_ast` implementation, that string will just be treated as the decoded output, and it would fail both the metric for the irrelevance category, which is not ideal.  