### PR TITLE
[BFCL] Minor Fix to Claude Handler for Better Prompt Caching

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/claude.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/claude.py
@@ -328,7 +328,10 @@ class ClaudeHandler(BaseHandler):
             inference_data, execution_results, model_response_data
         )
         inference_data["message"].append(
-            {"role": "user", "content": formatted_results_message}
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": formatted_results_message}],
+            }
         )
 
         return inference_data


### PR DESCRIPTION
This PR updates the `_add_execution_results_prompting` method in Claude handler to have the `content` field in the message be a list of one dictionary `"content": [{"type": "text", "text": "abcd"}]` instead of a string `"content": "abcd"`. Prompt caching expects it in this format. 
