### PR TITLE
[BFCL] Improve Latency Measurement Accuracy and Enable Default State Logging

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Dec 2, 2024] [#808](https://github.com/ShishirPatil/gorilla/pull/808): Improve latency measurement accuracy.
 - [Nov 26, 2024] [#755](https://github.com/ShishirPatil/gorilla/pull/755): Add new model `palmyra-x-004` to the leaderboard.
 - [Nov 25, 2024] [#718](https://github.com/ShishirPatil/gorilla/pull/718): Add new model `openbmb/MiniCPM3-4B-FC` to the leaderboard.
 - [Nov 25, 2024] [#697](https://github.com/ShishirPatil/gorilla/pull/697): Add the following new models to the leaderboard:
@@ -29,7 +30,8 @@ All notable changes to the Berkeley Function Calling Leaderboard will be documen
 - [Nov 15, 2024] [#762](https://github.com/ShishirPatil/gorilla/pull/762): Supply `data_multi_turn.csv` for multi-turn evaluation results
 - [Nov 14, 2024] [#760](https://github.com/ShishirPatil/gorilla/pull/760), [#761](https://github.com/ShishirPatil/gorilla/pull/761): Upstream  `google-cloud-aiplatform` library fixed typecasting bugs in Function Calling. Updated to version `1.72.0` and remove the workaround patch introduced in [#648](https://github.com/ShishirPatil/gorilla/pull/648).
 - [Nov 14, 2024] [#747](https://github.com/ShishirPatil/gorilla/pull/747): Minor Grammatical Corrections to `DEFAULT_SYSTEM_PROMPT` that is supplied to all prompting models.
-- [Nov 13, 2024] [#737](https://github.com/ShishirPatil/gorilla/pull/737), [#739](https://github.com/ShishirPatil/gorilla/pull/739), [#740](https://github.com/ShishirPatil/gorilla/pull/740), [#763](https://github.com/ShishirPatil/gorilla/pull/763), [#772](https://github.com/ShishirPatil/gorilla/pull/772): Bug fix in the dataset and possible answers for the live and multi-turn categories.
+- [Nov 13, 2024] [#737](https://github.com/ShishirPatil/gorilla/pull/737), [#739](https://github.com/ShishirPatil/gorilla/pull/739), [#740](https://github.com/ShishirPatil/gorilla/pull/740), [#763](https://github.com/ShishirPatil/gorilla/pull/763), [#772](https://github.com/ShishirPatil/gorilla/pull/772), [#789](https://github.com/ShishirPatil/gorilla/pull/789), [#804](https://github.com/ShishirPatil/gorilla/pull/804): Bug fix in the dataset and possible answers for the live and multi-turn categories.
+- [Nov 11, 2024] [#746](https://github.com/ShishirPatil/gorilla/pull/746): Improve inference log readability; inference log is now included as part of the model result file. For details on how to interpret the inference log, please refer to the [LOG_GUIDE.md](https://github.com/ShishirPatil/gorilla/blob/main/berkeley-function-call-leaderboard/LOG_GUIDE.md).
 - [Nov 9, 2024] [#749](https://github.com/ShishirPatil/gorilla/pull/749): Remove `Llama-3.2-3B-Instruct-FC` and `Llama-3.2-1B-Instruct-FC` from the leaderboard. According to the [official Llama documentation](https://www.llama.com/docs/model-cards-and-prompt-formats/llama3_2#-tool-calling-(1b/3b)-), these models perform function calling using the prompt-style chat template rather than the specialized function-calling format.
 - [Nov 8, 2024] [#720](https://github.com/ShishirPatil/gorilla/pull/720): Add new model `BitAgent/GoGoAgent` to the leaderboard.
 - [Oct 30, 2024] [#725](https://github.com/ShishirPatil/gorilla/pull/725), [#733](https://github.com/ShishirPatil/gorilla/pull/733): Update evaluation metric for multi-turn categories:

--- a/berkeley-function-call-leaderboard/LOG_GUIDE.md
+++ b/berkeley-function-call-leaderboard/LOG_GUIDE.md
@@ -1,6 +1,6 @@
 # Guide to Inference Logs
 
-> An inference log is included along with the llm response in the results file to help you analyze and debug the model's performance, and to better understand the model behavior. To enable a more detailed log, use the `--include-state-log` flag and/or the `--include-input-log` flag in the generation command.
+> An inference log is included along with the llm response in the results file to help you analyze and debug the model's performance, and to better understand the model behavior. To enable a more detailed log, use the `--include-input-log` flag in the generation command.
 
 ## Log Structure
 
@@ -9,7 +9,7 @@ The log is structured as a list, representing a conversational interaction betwe
 1. **`user`**: Represents the user's input or query.
 2. **`assistant`**: Represents the model's raw response.
 3. **`tool`**: Represents the output of a function execution, if the model makes a valid function call. Each function call results in a separate `tool` entry.
-4. **`state_info`**: Represents the state of the backend API system at the end of each turn. The initial state is also included at the beginning of the log. This entry is available only if the `--include-state-log` flag is set in the generation command.
+4. **`state_info`**: Represents the state of the backend API system at the end of each turn. The initial state is also included at the beginning of the log. You can exclude this entry by using the `--exclude-state-log` flag in the generation command.
 5. **`inference_input`**: Snapshot of the fully-transformed input just before it's sent to the model API endpoint. Useful for debugging input integrity and format.
 
    - Available only if the `--include-input-log` flag is set  in the generation command.

--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -127,7 +127,7 @@ To generate the model response for multiple models or test categories at once, y
 bfcl generate --model claude-3-5-sonnet-20241022-FC,gpt-4o-2024-08-06-FC --test-category parallel,multiple,exec_simple
 ```
 
-> An inference log will be included along with the llm response to help you analyze and debug the model's performance, and to better understand the model behavior. To see a more verbose log, you can set the `--include-state-log` and/or the `--include-input-log` flag in the generation command.
+> An inference log will be included along with the llm response to help you analyze and debug the model's performance, and to better understand the model behavior. To see a more verbose log, you can set the `--include-input-log` flag in the generation command.
 > Please refer to the `LOG_GUIDE.md` file for more information on how to interpret the inference logs and what each flag does.
 
 #### For API-hosted models:

--- a/berkeley-function-call-leaderboard/bfcl/__main__.py
+++ b/berkeley-function-call-leaderboard/bfcl/__main__.py
@@ -104,10 +104,10 @@ def generate(
         "--include-input-log",
         help="Include the fully-transformed input to the model inference endpoint in the inference log; only relevant for debugging input integrity and format.",
     ),
-    include_state_log: bool = typer.Option(
-        False,
-        "--include-state-log",
-        help="Include info about the state of each API system after each turn in the inference log; only relevant for multi-turn categories.",
+    exclude_state_log: bool = typer.Option(
+        True,
+        "--exclude-state-log",
+        help="Exclude info about the state of each API system after each turn in the inference log; only relevant for multi-turn categories.",
     ),
     num_gpus: int = typer.Option(1, help="The number of GPUs to use."),
     num_threads: int = typer.Option(1, help="The number of threads to use."),
@@ -139,7 +139,7 @@ def generate(
         test_category=test_category,
         temperature=temperature,
         include_input_log=include_input_log,
-        include_state_log=include_state_log,
+        exclude_state_log=exclude_state_log,
         num_gpus=num_gpus,
         num_threads=num_threads,
         gpu_memory_utilization=gpu_memory_utilization,

--- a/berkeley-function-call-leaderboard/bfcl/__main__.py
+++ b/berkeley-function-call-leaderboard/bfcl/__main__.py
@@ -105,7 +105,7 @@ def generate(
         help="Include the fully-transformed input to the model inference endpoint in the inference log; only relevant for debugging input integrity and format.",
     ),
     exclude_state_log: bool = typer.Option(
-        True,
+        False,
         "--exclude-state-log",
         help="Exclude info about the state of each API system after each turn in the inference log; only relevant for multi-turn categories.",
     ),

--- a/berkeley-function-call-leaderboard/bfcl/_llm_response_generation.py
+++ b/berkeley-function-call-leaderboard/bfcl/_llm_response_generation.py
@@ -41,7 +41,7 @@ def get_args():
     # Parameters for the model that you want to test.
     parser.add_argument("--temperature", type=float, default=0.001)
     parser.add_argument("--include-input-log", action="store_true", default=False)
-    parser.add_argument("--exclude-state-log", action="store_false", default=True)
+    parser.add_argument("--exclude-state-log", action="store_true", default=False)
     parser.add_argument("--num-threads", default=1, type=int)
     parser.add_argument("--num-gpus", default=1, type=int)
     parser.add_argument("--backend", default="vllm", type=str, choices=["vllm", "sglang"])

--- a/berkeley-function-call-leaderboard/bfcl/_llm_response_generation.py
+++ b/berkeley-function-call-leaderboard/bfcl/_llm_response_generation.py
@@ -41,7 +41,7 @@ def get_args():
     # Parameters for the model that you want to test.
     parser.add_argument("--temperature", type=float, default=0.001)
     parser.add_argument("--include-input-log", action="store_true", default=False)
-    parser.add_argument("--include-state-log", action="store_true", default=False)
+    parser.add_argument("--exclude-state-log", action="store_false", default=True)
     parser.add_argument("--num-threads", default=1, type=int)
     parser.add_argument("--num-gpus", default=1, type=int)
     parser.add_argument("--backend", default="vllm", type=str, choices=["vllm", "sglang"])
@@ -162,7 +162,7 @@ def process_multi_turn_test_case(test_cases):
     return test_cases
 
 
-def multi_threaded_inference(handler, test_case, include_input_log, include_state_log):
+def multi_threaded_inference(handler, test_case, include_input_log, exclude_state_log):
 
     assert type(test_case["function"]) is list
 
@@ -171,7 +171,7 @@ def multi_threaded_inference(handler, test_case, include_input_log, include_stat
     while True:
         try:
             result, metadata = handler.inference(
-                deepcopy(test_case), include_input_log, include_state_log
+                deepcopy(test_case), include_input_log, exclude_state_log
             )
             break  # Success, exit the loop
         except Exception as e:
@@ -225,7 +225,7 @@ def generate_results(args, model_name, test_cases_total):
             gpu_memory_utilization=args.gpu_memory_utilization,
             backend=args.backend,
             include_input_log=args.include_input_log,
-            include_state_log=args.include_state_log,
+            exclude_state_log=args.exclude_state_log,
             result_dir=args.result_dir,
             update_mode=update_mode,
         )
@@ -243,7 +243,7 @@ def generate_results(args, model_name, test_cases_total):
                         handler,
                         test_case,
                         args.include_input_log,
-                        args.include_state_log,
+                        args.exclude_state_log,
                     )
                     futures.append(future)
 

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/base_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/base_handler.py
@@ -155,9 +155,7 @@ class BaseHandler:
                 # Add to the current_turn_inference_log at beginning of each step so that we don't need to bother dealing with the break statements
                 current_turn_inference_log[f"step_{count}"] = current_step_inference_log
 
-                start_time = time.time()
-                api_response = self._query_FC(inference_data)
-                query_latency = time.time() - start_time
+                api_response, query_latency = self._query_FC(inference_data)
 
                 # This part of logging is disabled by default because it is too verbose and will make the result file extremely large
                 # It is only useful to see if the inference pipeline is working as expected (eg, does it convert all the inputs correctly)
@@ -397,9 +395,7 @@ class BaseHandler:
                 # Add to the current_turn_inference_log at beginning of each step so that we don't need to bother dealing with the break statements
                 current_turn_inference_log[f"step_{count}"] = current_step_inference_log
 
-                start_time = time.time()
-                api_response = self._query_prompting(inference_data)
-                query_latency = time.time() - start_time
+                api_response, query_latency = self._query_prompting(inference_data)
 
                 # This part of logging is disabled by default because it is too verbose and will make the result file extremely large
                 # It is only useful to see if the inference pipeline is working as expected (eg, does it convert all the inputs correctly)
@@ -551,9 +547,7 @@ class BaseHandler:
             inference_data, test_entry["question"][0]
         )
 
-        start_time = time.time()
-        api_response = self._query_FC(inference_data)
-        query_latency = time.time() - start_time
+        api_response, query_latency = self._query_FC(inference_data)
 
         # Try parsing the model response
         model_response_data = self._parse_query_response_FC(api_response)
@@ -582,9 +576,7 @@ class BaseHandler:
             inference_data, test_entry["question"][0]
         )
 
-        start_time = time.time()
-        api_response = self._query_prompting(inference_data)
-        query_latency = time.time() - start_time
+        api_response, query_latency = self._query_prompting(inference_data)
 
         # Try parsing the model response
         model_response_data = self._parse_query_response_prompting(api_response)

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/base_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/base_handler.py
@@ -32,21 +32,21 @@ class BaseHandler:
         self.temperature = temperature
         self.is_fc_model = False  # Whether the model is a function calling model
 
-    def inference(self, test_entry: dict, include_input_log: bool, include_state_log: bool):
+    def inference(self, test_entry: dict, include_input_log: bool, exclude_state_log: bool):
         # This method is used to retrive model response for each model.
 
         # FC model
         # TODO: Let all models have the is_fc_model attribute and remove the "FC" check
         if "FC" in self.model_name or self.is_fc_model:
             if "multi_turn" in test_entry["id"]:
-                return self.inference_multi_turn_FC(test_entry, include_input_log, include_state_log)
+                return self.inference_multi_turn_FC(test_entry, include_input_log, exclude_state_log)
             else:
                 return self.inference_single_turn_FC(test_entry, include_input_log)
         # Prompting model
         else:
             if "multi_turn" in test_entry["id"]:
                 return self.inference_multi_turn_prompting(
-                    test_entry, include_input_log, include_state_log
+                    test_entry, include_input_log, exclude_state_log
                 )
             else:
                 return self.inference_single_turn_prompting(
@@ -55,7 +55,7 @@ class BaseHandler:
 
     @final
     def inference_multi_turn_FC(
-        self, test_entry: dict, include_input_log: bool, include_state_log: bool
+        self, test_entry: dict, include_input_log: bool, exclude_state_log: bool
     ) -> tuple[list[list], dict]:
         initial_config: dict = test_entry["initial_config"]
         involved_classes: list = test_entry["involved_classes"]
@@ -78,7 +78,7 @@ class BaseHandler:
         force_quit = False  # Whether the model has been forced to quit. If True, this whole entry will be failed.
 
         # Execute no function call, but just to get a reference to all the instances to get the initial state for logging purpose
-        if include_state_log:
+        if not exclude_state_log:
             _, involved_instances = execute_multi_turn_func_call(
                 [],
                 initial_config,
@@ -265,7 +265,7 @@ class BaseHandler:
             total_output_token_count.append(current_turn_output_token_count)
             total_latency.append(current_turn_latency)
 
-            if include_state_log:
+            if not exclude_state_log:
                 state_log = []
                 for class_name, class_instance in involved_instances.items():
                     if class_name in STATELESS_CLASSES:
@@ -298,7 +298,7 @@ class BaseHandler:
 
     @final
     def inference_multi_turn_prompting(
-        self, test_entry: dict, include_input_log: bool, include_state_log: bool
+        self, test_entry: dict, include_input_log: bool, exclude_state_log: bool
     ) -> tuple[list[list], dict]:
         initial_config: dict = test_entry["initial_config"]
         involved_classes: list = test_entry["involved_classes"]
@@ -321,7 +321,7 @@ class BaseHandler:
         force_quit = False  # Whether the model has been forced to quit. If True, this whole entry will be failed.
 
         # Execute no function call, but just to get a reference to all the instances to get the initial state for logging purpose
-        if include_state_log:
+        if not exclude_state_log:
             _, involved_instances = execute_multi_turn_func_call(
                 [],
                 initial_config,
@@ -505,7 +505,7 @@ class BaseHandler:
             total_output_token_count.append(current_turn_output_token_count)
             total_latency.append(current_turn_latency)
 
-            if include_state_log:
+            if not exclude_state_log:
                 state_log = []
                 for class_name, class_instance in involved_instances.items():
                     if class_name in STATELESS_CLASSES:

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/base_oss_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/base_oss_handler.py
@@ -285,6 +285,7 @@ class OSSHandler(BaseHandler, EnforceOverrides):
         if hasattr(self, "skip_special_tokens"):
             extra_body["skip_special_tokens"] = self.skip_special_tokens
 
+        start_time = time.time()
         if len(extra_body) > 0:
             api_response = self.client.completions.create(
                 model=self.model_name_huggingface,
@@ -300,8 +301,9 @@ class OSSHandler(BaseHandler, EnforceOverrides):
                 prompt=formatted_prompt,
                 max_tokens=leftover_tokens_count,
             )
+        end_time = time.time()
 
-        return api_response
+        return api_response, end_time - start_time
 
     @override
     def _pre_query_processing_prompting(self, test_entry: dict) -> dict:

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/cohere.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/cohere.py
@@ -131,6 +131,8 @@ class CohereHandler(BaseHandler):
             "chat_history": inference_data.get("chat_history", None),
             "preamble": self.preamble,
         }
+
+        start_time = time.time()
         api_response = self.client.chat(
             message=inference_data["message"],
             model=self.model_name.replace("-FC", ""),
@@ -140,8 +142,9 @@ class CohereHandler(BaseHandler):
             preamble=self.preamble,
             chat_history=inference_data.get("chat_history", None),
         )
+        end_time = time.time()
 
-        return api_response
+        return api_response, end_time - start_time
 
     def _pre_query_processing_FC(self, inference_data: dict, test_entry: dict) -> dict:
         for round_idx in range(len(test_entry["question"])):
@@ -242,6 +245,7 @@ class CohereHandler(BaseHandler):
             "chat_history": inference_data.get("chat_history", None),
         }
 
+        start_time = time.time()
         api_response = self.client.chat(
             message=inference_data["message"],
             model=self.model_name,
@@ -249,8 +253,9 @@ class CohereHandler(BaseHandler):
             preamble=inference_data["system_prompt"],
             chat_history=inference_data.get("chat_history", None),
         )
+        end_time = time.time()
 
-        return api_response
+        return api_response, end_time - start_time
 
     def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
         functions: list = test_entry["function"]

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/databricks.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/databricks.py
@@ -65,13 +65,16 @@ class DatabricksHandler(OpenAIHandler):
     def _query_prompting(self, inference_data: dict):
         message = inference_data["message"]
         inference_data["inference_input_log"] = {"message": repr(inference_data["message"])}
-        
+
+        start_time = time.time()
         api_response = self.client.chat.completions.create(
             messages=message,
             model=self.model_name,
             temperature=self.temperature,
         )
-        return api_response
+        end_time = time.time()
+
+        return api_response, end_time - start_time
 
     def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
         functions: list = test_entry["function"]
@@ -82,7 +85,7 @@ class DatabricksHandler(OpenAIHandler):
         test_entry["question"][0] = system_prompt_pre_processing_chat_model(
             test_entry["question"][0], functions, test_category
         )
-        
+
         # Databricks doesn't allow consecutive user prompts, so we need to combine them
         for round_idx in range(len(test_entry["question"])):
             test_entry["question"][round_idx] = combine_consecutive_user_prompts(

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/fireworks.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/fireworks.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from bfcl.model_handler.model_style import ModelStyle
 from bfcl.model_handler.proprietary_model.openai import OpenAIHandler
@@ -22,6 +23,7 @@ class FireworksHandler(OpenAIHandler):
         tools = inference_data["tools"]
         inference_data["inference_input_log"] = {"message": message, "tools": tools}
 
+        start_time = time.time()
         if len(tools) > 0:
             api_response = self.client.chat.completions.create(
                 messages=message,
@@ -35,12 +37,13 @@ class FireworksHandler(OpenAIHandler):
                 model=f"accounts/fireworks/models/{self.model_name.replace('-FC', '')}",
                 temperature=self.temperature,
             )
+        end_time = time.time()
 
-        return api_response
+        return api_response, end_time - start_time
 
     def _pre_query_processing_FC(self, inference_data: dict, test_entry: dict) -> dict:
         return super()._pre_query_processing_FC(inference_data, test_entry)
-    
+
     def _compile_tools(self, inference_data: dict, test_entry: dict) -> dict:
         return super()._compile_tools(inference_data, test_entry)
 

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gemini.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import vertexai
 from bfcl.model_handler.base_handler import BaseHandler
@@ -73,7 +74,11 @@ class GeminiHandler(BaseHandler):
 
     @retry_with_backoff(ResourceExhausted)
     def generate_with_backoff(self, client, **kwargs):
-        return client.generate_content(**kwargs)
+        start_time = time.time()
+        api_response = client.generate_content(**kwargs)
+        end_time = time.time()
+
+        return api_response, end_time - start_time
 
     #### FC methods ####
 
@@ -112,7 +117,7 @@ class GeminiHandler(BaseHandler):
         else:
             client = self.client
 
-        api_response = self.generate_with_backoff(
+        return self.generate_with_backoff(
             client=client,
             contents=inference_data["message"],
             generation_config=GenerationConfig(
@@ -120,7 +125,6 @@ class GeminiHandler(BaseHandler):
             ),
             tools=tools
         )
-        return api_response
 
     def _pre_query_processing_FC(self, inference_data: dict, test_entry: dict) -> dict:
 

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gorilla.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/gorilla.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 import requests
 from bfcl.model_handler.base_handler import BaseHandler
@@ -42,6 +43,8 @@ class GorillaHandler(BaseHandler):
             "temperature": self.temperature,
         }
         url = "https://luigi.millennium.berkeley.edu:443/v1/chat/completions"
+
+        start_time = time.time()
         api_response = requests.post(
             url,
             headers={
@@ -50,8 +53,9 @@ class GorillaHandler(BaseHandler):
             },
             data=json.dumps(requestData),
         )
+        end_time = time.time()
 
-        return api_response.json()
+        return api_response.json(), end_time - start_time
 
     def _pre_query_processing_FC(self, inference_data: dict, test_entry: dict) -> dict:
         inference_data["message"] = []

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/mistral.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/mistral.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 
 from bfcl.model_handler.base_handler import BaseHandler
 from bfcl.model_handler.constant import GORILLA_TO_OPENAPI
@@ -66,13 +67,16 @@ class MistralHandler(BaseHandler):
             "tools": tool,
         }
 
+        start_time = time.time()
         api_response = self.client.chat.complete(
             model=self.model_name.replace("-FC", ""),
             messages=message,
             tools=tool,
             temperature=self.temperature,
         )
-        return api_response
+        end_time = time.time()
+
+        return api_response, end_time - start_time
 
     def _pre_query_processing_FC(self, inference_data: dict, test_entry: dict) -> dict:
         inference_data["message"] = []
@@ -159,12 +163,15 @@ class MistralHandler(BaseHandler):
         message = inference_data["message"]
         inference_data["inference_input_log"] = {"message": message}
 
+        start_time = time.time()
         api_response = self.client.chat.complete(
             model=self.model_name,
             messages=message,
             temperature=self.temperature,
         )
-        return api_response
+        end_time = time.time()
+
+        return api_response, end_time - start_time
 
     def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
         functions: list = test_entry["function"]

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/writer.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/writer.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from bfcl.model_handler.model_style import ModelStyle
 from bfcl.model_handler.proprietary_model.openai import OpenAIHandler
@@ -19,6 +20,7 @@ class WriterHandler(OpenAIHandler):
         tools = inference_data["tools"]
         inference_data["inference_input_log"] = {"message": repr(message), "tools": tools}
 
+        start_time = time.time()
         if len(tools) > 0:
             api_response = self.client.chat.chat(
                 messages=message,
@@ -33,4 +35,6 @@ class WriterHandler(OpenAIHandler):
                 model=self.model_name,
                 temperature=self.temperature,
             )
-        return api_response
+        end_time = time.time()
+
+        return api_response, end_time - start_time

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/yi.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/proprietary_model/yi.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 
 from bfcl.model_handler.base_handler import BaseHandler
 from bfcl.model_handler.constant import GORILLA_TO_OPENAPI
@@ -39,6 +40,7 @@ class YiHandler(BaseHandler):
         tools = inference_data["tools"]
         inference_data["inference_input_log"] = {"message": repr(message), "tools": tools}
 
+        start_time = time.time()
         if len(tools) > 0:
             api_response = self.client.chat.completions.create(
                 messages=message,
@@ -52,8 +54,9 @@ class YiHandler(BaseHandler):
                 model=self.model_name.replace("-FC", ""),
                 temperature=self.temperature,
             )
+        end_time = time.time()
 
-        return api_response
+        return api_response, end_time - start_time
 
     def _pre_query_processing_FC(self, inference_data: dict, test_entry: dict) -> dict:
         inference_data["message"] = []


### PR DESCRIPTION
This pull request improves the accuracy of latency measurement by addressing the following issues:

1. **Retry Latency Handling:** Previously, when a retry occurred, the reported latency included the duration from the first attempt to the final successful attempt, resulting in inflated latency values. This change ensures that only the latency of the final successful attempt is measured. This adjustment primarily impacts the Gemini and Claude models.

2. **Preprocessing Time Exclusion:** For models requiring preprocessing before hitting their endpoints, this preprocessing time is now excluded from the reported latency, ensuring a more accurate reflection of the actual request duration.

Additionally, the `state_log` is now included as part of the `inference_log` by default. Users can disable it if needed by using the `--exclude-state-log` flag.