### PR TITLE
[BFCL Blog] Update BFCL V2 Blog with Latest Data Composition Number

### DIFF
--- a/blogs/12_bfcl_v2_live.html
+++ b/blogs/12_bfcl_v2_live.html
@@ -279,8 +279,8 @@
                     </p>
 
                     <p>
-                        <i>BFCL V2 • Live</i> comprises of 258 simple, 1037 multiple, 16 parallel, 24 parallel
-                        multiple, 875 irrelevance detection, and 41 relevance detection entries. Each test category is
+                        <i>BFCL V2 • Live</i> comprises of 258 simple, 1053 multiple, 16 parallel, 24 parallel
+                        multiple, 882 irrelevance detection, and 18 relevance detection entries. Each test category is
                         detailed in the
                         <a
                             href="https://gorilla.cs.berkeley.edu/blogs/8_berkeley_function_calling_leaderboard.html#categories">Evaluation


### PR DESCRIPTION
There were some number of entries changes that were introduced in the previous dataset fix PRs (such as #789). This PR updates the blog to have the up-to-date data composition number. 