### PR TITLE
[BFCL] Add New Model `Llama-3.3-70B-Instruct`, `Llama-3.3-70B-Instruct-FC`

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Dec 16, 2024] [#837](https://github.com/ShishirPatil/gorilla/pull/837): Add the following new models to the leaderboard:
+  - `meta-llama/Llama-3.3-70B-Instruct-FC`
+  - `meta-llama/Llama-3.3-70B-Instruct`
 - [Dec 13, 2024] [#832](https://github.com/ShishirPatil/gorilla/pull/832): Add the following new models to the leaderboard:
   - `MadeAgents/Hammer2.1-7b`
   - `MadeAgents/Hammer2.1-3b`

--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -61,6 +61,8 @@ Below is a comprehensive table of models supported for running leaderboard evalu
 |meta-llama/Llama-3.1-{8B,70B}-Instruct-FC 💻| Function Calling|
 |meta-llama/Llama-3.1-{8B,70B}-Instruct 💻| Prompt|
 |meta-llama/Llama-3.2-{1B,3B}-Instruct 💻| Prompt|
+|meta-llama/Llama-3.3-70B-Instruct 💻| Prompt|
+|meta-llama/Llama-3.3-70B-Instruct-FC 💻| Function Calling|
 |deepseek-ai/DeepSeek-V2.5 💻| Function Calling|
 |deepseek-ai/DeepSeek-V2-{Chat-0628,Lite-Chat} 💻| Prompt|
 |deepseek-ai/DeepSeek-Coder-V2-{Instruct-0724,Lite-Instruct} 💻| Function Calling|

--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
@@ -517,6 +517,18 @@ MODEL_METADATA_MAPPING = {
         "Meta",
         "Meta Llama 3 Community",
     ],
+    "meta-llama/Llama-3.3-70B-Instruct": [
+        "Llama-3.3-70B-Instruct (Prompt)",
+        "https://llama.meta.com/llama3",
+        "Meta",
+        "Meta Llama 3 Community",
+    ],
+    "meta-llama/Llama-3.3-70B-Instruct-FC": [
+        "Llama-3.3-70B-Instruct (FC)",
+        "https://llama.meta.com/llama3",
+        "Meta",
+        "Meta Llama 3 Community",
+    ],
     "command-r-plus-FC": [
         "Command-R-Plus (FC) (Original)",
         "https://txt.cohere.com/command-r-plus-microsoft-azure",

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
@@ -105,6 +105,8 @@ local_inference_handler_map = {
     "meta-llama/Llama-3.1-70B-Instruct": LlamaHandler,
     "meta-llama/Llama-3.2-1B-Instruct": LlamaHandler,
     "meta-llama/Llama-3.2-3B-Instruct": LlamaHandler,
+    "meta-llama/Llama-3.3-70B-Instruct-FC": LlamaFCHandler,
+    "meta-llama/Llama-3.3-70B-Instruct": LlamaHandler,
     "Salesforce/xLAM-1b-fc-r": SalesforceHandler,
     "Salesforce/xLAM-7b-fc-r": SalesforceHandler,
     "Salesforce/xLAM-7b-r": SalesforceHandler,

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/llama.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/llama.py
@@ -4,7 +4,7 @@ from overrides import override
 
 # Note: This is the handler for the Llama models in prompring mode.
 # For function call mode, use LlamaFCHandler instead.
-# Llama 3 series are benchmarked in prompting mode while the Llama 3.1 series are benchmarked in function call mode.
+# Llama 3 series are benchmarked in prompting mode while the Llama 3.1 and 3.3 series are benchmarked in function call mode.
 class LlamaHandler(OSSHandler):
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)


### PR DESCRIPTION
Add the following new models to the leaderboard:

  - `meta-llama/Llama-3.3-70B-Instruct-FC`
  - `meta-llama/Llama-3.3-70B-Instruct`

From the [model card](https://www.llama.com/docs/model-cards-and-prompt-formats/llama3_3#-prompt-template-):

> Llama 3.3 uses the same prompt format as Llama 3.1. Prompts written for Llama 3.1 work unchanged with Llama 3.3.
> Llama 3.3 also supports the same code-interpreter and tool-calling capabilities as Llama 3.1.

So we have llama 3.3 use the same handler as llama 3.1 series. 