### PR TITLE
[BFCL] Add Mistral Local Serving Handler and Add New Model `mistralai/Ministral-8B-Instruct-2410`

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Dec 29, 2024] [#855](https://github.com/ShishirPatil/gorilla/pull/855): Add new model `mistralai/Ministral-8B-Instruct-2410` to the leaderboard.
 - [Dec 22, 2024] [#838](https://github.com/ShishirPatil/gorilla/pull/838): Fix parameter type mismatch error in possible answers.
   - Simple: 2 affected
   - Multiple: 1 affected

--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -64,6 +64,7 @@ Below is a comprehensive table of models supported for running leaderboard evalu
 |palmyra-x-004 | Function Calling|
 |BitAgent/GoGoAgent | Prompt|
 |google/gemma-2-{2b,9b,27b}-it 💻| Prompt|
+|mistralai/Ministral-8B-Instruct-2410 💻| Function Calling|
 |meta-llama/Meta-Llama-3-{8B,70B}-Instruct 💻| Prompt|
 |meta-llama/Llama-3.1-{8B,70B}-Instruct-FC 💻| Function Calling|
 |meta-llama/Llama-3.1-{8B,70B}-Instruct 💻| Prompt|

--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
@@ -157,6 +157,12 @@ MODEL_METADATA_MAPPING = {
         "Mistral AI",
         "Proprietary",
     ],
+    "mistralai/Ministral-8B-Instruct-2410": [
+        "Ministral-8B-Instruct-2410 (FC)",
+        "https://huggingface.co/mistralai/Ministral-8B-Instruct-2410",
+        "Mistral AI",
+        "Mistral AI Research License",
+    ],
     "claude-3-sonnet-20240229-FC": [
         "Claude-3-Sonnet-20240229 (FC)",
         "https://www.anthropic.com/news/claude-3-family",

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
@@ -10,6 +10,7 @@ from bfcl.model_handler.oss_model.llama import LlamaHandler
 from bfcl.model_handler.oss_model.llama_fc import LlamaFCHandler
 from bfcl.model_handler.oss_model.minicpm import MiniCPMHandler
 from bfcl.model_handler.oss_model.minicpm_fc import MiniCPMFCHandler
+from bfcl.model_handler.oss_model.mistral_fc import MistralFCHandler
 from bfcl.model_handler.oss_model.phi import PhiHandler
 from bfcl.model_handler.oss_model.qwen import QwenHandler
 from bfcl.model_handler.oss_model.salesforce import SalesforceHandler
@@ -116,6 +117,7 @@ local_inference_handler_map = {
     "Salesforce/xLAM-7b-r": SalesforceHandler,
     "Salesforce/xLAM-8x22b-r": SalesforceHandler,
     "Salesforce/xLAM-8x7b-r": SalesforceHandler,
+    "mistralai/Ministral-8B-Instruct-2410": MistralFCHandler,
     "microsoft/Phi-3-mini-4k-instruct": PhiHandler,
     "microsoft/Phi-3-mini-128k-instruct": PhiHandler,
     "microsoft/Phi-3-small-8k-instruct": PhiHandler,

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/mistral_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/mistral_fc.py
@@ -1,7 +1,8 @@
+import json
+
 from bfcl.model_handler.oss_model.base_oss_handler import OSSHandler
 from bfcl.model_handler.utils import func_doc_language_specific_pre_processing
-
-import json
+from overrides import override
 
 
 class MistralFCHandler(OSSHandler):
@@ -52,6 +53,7 @@ class MistralFCHandler(OSSHandler):
         result_str = "[AVAILABLE_TOOLS][" + ", ".join(func_docs) + "][/AVAILABLE_TOOLS]"
         return result_str
 
+    @override
     def _format_prompt(self, messages, function):
         """
         "bos_token": "<s>"
@@ -193,6 +195,7 @@ class MistralFCHandler(OSSHandler):
         formatted_prompt += eos_token
         return formatted_prompt
 
+    @override
     def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
         functions: list = test_entry["function"]
         test_category: str = test_entry["id"].rsplit("_", 1)[0]
@@ -202,6 +205,7 @@ class MistralFCHandler(OSSHandler):
 
         return {"message": [], "function": functions}
 
+    @override
     def _add_execution_results_prompting(
         self, inference_data: dict, execution_results: list[str], model_response_data: dict
     ) -> dict:

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/mistral_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/mistral_fc.py
@@ -173,30 +173,22 @@ class MistralFCHandler(OSSHandler):
                 # If it's the last message and there's a system message, include it
                 if idx == len(loop_messages) - 1 and system_message:
                     formatted_prompt += (
-                        f"[INST]{system_message}\n\n{message["content"]}[/INST]"
+                        f"[INST]{system_message}\n\n{message['content']}[/INST]"
                     )
                 else:
-                    formatted_prompt += f"[INST]{message["content"]}[/INST]"
+                    formatted_prompt += f"[INST]{message['content']}[/INST]"
 
             elif role == "assistant":
-                formatted_prompt += f"{message["content"]}{eos_token}"
+                formatted_prompt += f"{message['content']}{eos_token}"
 
             elif role == "tool":
-                content = message.get("content", "")
-                call_id = message.get("tool_call_id")
-                if not call_id or not isinstance(call_id, str) or len(call_id) != 9:
-                    raise Exception(
-                        "Tool call IDs should be alphanumeric strings with length 9!"
-                    )
-                tool_results = {"content": content, "call_id": call_id}
-                tool_results_str = (
+                tool_results = {
+                    "content": message["content"],
+                    "call_id": message["tool_call_id"],
+                }
+                formatted_prompt += (
                     f"[TOOL_RESULTS]{json.dumps(tool_results)}[/TOOL_RESULTS]"
                 )
-                formatted_prompt += tool_results_str
-
-            elif role == "tool":
-                tool_results = {"content": message["content"], "call_id": message["tool_call_id"]}
-                formatted_prompt += f"[TOOL_RESULTS]{json.dumps(tool_results)}[/TOOL_RESULTS]"
 
         formatted_prompt += eos_token
         return formatted_prompt

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/mistral_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/oss_model/mistral_fc.py
@@ -1,0 +1,227 @@
+from bfcl.model_handler.oss_model.base_oss_handler import OSSHandler
+from bfcl.model_handler.utils import func_doc_language_specific_pre_processing
+
+import json
+
+
+class MistralFCHandler(OSSHandler):
+    def __init__(self, model_name, temperature) -> None:
+        super().__init__(model_name, temperature)
+
+    @staticmethod
+    def _construct_func_doc(functions):
+        """
+        {{- "[AVAILABLE_TOOLS][" }}
+        {%- for tool in tools %}
+            {%- set tool = tool.function %}
+            {{- '{"type": "function", "function": {' }}
+            {%- for key, val in tool.items() if key != "return" %}
+                {%- if val is string %}
+                    {{- '"' + key + '": "' + val + '"' }}
+                {%- else %}
+                    {{- '"' + key + '": ' + val|tojson }}
+                {%- endif %}
+                {%- if not loop.last %}
+                    {{- ", " }}
+                {%- endif %}
+            {%- endfor %}
+            {{- "}}" }}
+            {%- if not loop.last %}
+                {{- ", " }}
+            {%- else %}
+                {{- "]" }}
+            {%- endif %}
+        {%- endfor %}
+        {{- "[/AVAILABLE_TOOLS]" }}
+        """
+        func_docs = []
+        for tool in functions:
+            func_doc = '{"type": "function", "function": {'
+            func_doc += ", ".join(
+                (
+                    f'"{key}": "{val}"'
+                    if isinstance(val, str)
+                    else f'"{key}": {json.dumps(val)}'
+                )
+                for key, val in tool.items()
+                if key != "return"
+            )
+            func_doc += "}}"
+            func_docs.append(func_doc)
+
+        result_str = "[AVAILABLE_TOOLS][" + ", ".join(func_docs) + "][/AVAILABLE_TOOLS]"
+        return result_str
+
+    def _format_prompt(self, messages, function):
+        """
+        "bos_token": "<s>"
+        "eos_token": "</s>"
+        "chat_template":
+        {%- if messages[0]["role"] == "system" %}
+            {%- set system_message = messages[0]["content"] %}
+            {%- set loop_messages = messages[1:] %}
+        {%- else %}
+            {%- set loop_messages = messages %}
+        {%- endif %}
+        {%- if not tools is defined %}
+            {%- set tools = none %}
+        {%- endif %}
+        {%- set user_messages = loop_messages | selectattr("role", "equalto", "user") | list %}
+
+        {#- This block checks for alternating user/assistant messages, skipping tool calling messages #}
+        {%- set ns = namespace() %}
+        {%- set ns.index = 0 %}
+        {%- for message in loop_messages %}
+            {%- if not (message.role == "tool" or message.role == "tool_results" or (message.tool_calls is defined and message.tool_calls is not none)) %}
+                {%- if (message["role"] == "user") != (ns.index % 2 == 0) %}
+                    {{- raise_exception("After the optional system message, conversation roles must alternate user/assistant/user/assistant/...") }}
+                {%- endif %}
+                {%- set ns.index = ns.index + 1 %}
+            {%- endif %}
+        {%- endfor %}
+
+        {{- bos_token }}
+        {%- for message in loop_messages %}
+            {%- if message["role"] == "user" %}
+                {%- if tools is not none and (message == user_messages[-1]) %}
+                    {{- "[AVAILABLE_TOOLS][" }}
+                    {%- for tool in tools %}
+                        {%- set tool = tool.function %}
+                        {{- '{"type": "function", "function": {' }}
+                        {%- for key, val in tool.items() if key != "return" %}
+                            {%- if val is string %}
+                                {{- '"' + key + '": "' + val + '"' }}
+                            {%- else %}
+                                {{- '"' + key + '": ' + val|tojson }}
+                            {%- endif %}
+                            {%- if not loop.last %}
+                                {{- ", " }}
+                            {%- endif %}
+                        {%- endfor %}
+                        {{- "}}" }}
+                        {%- if not loop.last %}
+                            {{- ", " }}
+                        {%- else %}
+                            {{- "]" }}
+                        {%- endif %}
+                    {%- endfor %}
+                    {{- "[/AVAILABLE_TOOLS]" }}
+                    {%- endif %}
+                {%- if loop.last and system_message is defined %}
+                    {{- "[INST]" + system_message + "\n\n" + message["content"] + "[/INST]" }}
+                {%- else %}
+                    {{- "[INST]" + message["content"] + "[/INST]" }}
+                {%- endif %}
+            {%- elif (message.tool_calls is defined and message.tool_calls is not none) %}
+                {{- "[TOOL_CALLS][" }}
+                {%- for tool_call in message.tool_calls %}
+                    {%- set out = tool_call.function|tojson %}
+                    {{- out[:-1] }}
+                    {%- if not tool_call.id is defined or tool_call.id|length != 9 %}
+                        {{- raise_exception("Tool call IDs should be alphanumeric strings with length 9!") }}
+                    {%- endif %}
+                    {{- ', "id": "' + tool_call.id + '"}' }}
+                    {%- if not loop.last %}
+                        {{- ", " }}
+                    {%- else %}
+                        {{- "]" + eos_token }}
+                    {%- endif %}
+                {%- endfor %}
+            {%- elif message["role"] == "assistant" %}
+                {{- message["content"] + eos_token}}
+            {%- elif message["role"] == "tool_results" or message["role"] == "tool" %}
+                {%- if message.content is defined and message.content.content is defined %}
+                    {%- set content = message.content.content %}
+                {%- else %}
+                    {%- set content = message.content %}
+                {%- endif %}
+                {{- '[TOOL_RESULTS]{"content": ' + content|string + ", " }}
+                {%- if not message.tool_call_id is defined or message.tool_call_id|length != 9 %}
+                    {{- raise_exception("Tool call IDs should be alphanumeric strings with length 9!") }}
+                {%- endif %}
+                {{- '"call_id": "' + message.tool_call_id + '"}[/TOOL_RESULTS]' }}
+            {%- else %}
+                {{- raise_exception("Only user and assistant roles are supported, with the exception of an initial optional system message!") }}
+            {%- endif %}
+        {%- endfor %}
+        """
+        bos_token = "<s>"
+        eos_token = "</s>"
+
+        formatted_prompt = bos_token
+
+        # Handle optional system message
+        first_message = messages[0]
+        if first_message["role"] == "system":
+            system_message = first_message["content"]
+            loop_messages = messages[1:]
+        else:
+            system_message = None
+            loop_messages = messages
+
+        # Extract user messages for later reference
+        user_messages = [msg for msg in loop_messages if msg["role"] == "user"]
+
+        for idx, message in enumerate(loop_messages):
+            role = message["role"]
+
+            if role == "user":
+                # If this is the last user message and tools are provided, append AVAILABLE_TOOLS
+                if len(function) > 0 and message == user_messages[-1]:
+                    formatted_prompt += self._construct_func_doc(function)
+
+                # If it's the last message and there's a system message, include it
+                if idx == len(loop_messages) - 1 and system_message:
+                    formatted_prompt += (
+                        f"[INST]{system_message}\n\n{message["content"]}[/INST]"
+                    )
+                else:
+                    formatted_prompt += f"[INST]{message["content"]}[/INST]"
+
+            elif role == "assistant":
+                formatted_prompt += f"{message["content"]}{eos_token}"
+
+            elif role == "tool":
+                content = message.get("content", "")
+                call_id = message.get("tool_call_id")
+                if not call_id or not isinstance(call_id, str) or len(call_id) != 9:
+                    raise Exception(
+                        "Tool call IDs should be alphanumeric strings with length 9!"
+                    )
+                tool_results = {"content": content, "call_id": call_id}
+                tool_results_str = (
+                    f"[TOOL_RESULTS]{json.dumps(tool_results)}[/TOOL_RESULTS]"
+                )
+                formatted_prompt += tool_results_str
+
+            elif role == "tool":
+                tool_results = {"content": message["content"], "call_id": message["tool_call_id"]}
+                formatted_prompt += f"[TOOL_RESULTS]{json.dumps(tool_results)}[/TOOL_RESULTS]"
+
+        formatted_prompt += eos_token
+        return formatted_prompt
+
+    def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
+        functions: list = test_entry["function"]
+        test_category: str = test_entry["id"].rsplit("_", 1)[0]
+
+        functions = func_doc_language_specific_pre_processing(functions, test_category)
+        # We don't add system prompt
+
+        return {"message": [], "function": functions}
+
+    def _add_execution_results_prompting(
+        self, inference_data: dict, execution_results: list[str], model_response_data: dict
+    ) -> dict:
+        for execution_result, tool_call_id in zip(
+            execution_results, model_response_data["tool_call_ids"]
+        ):
+            inference_data["message"].append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call_id,
+                    "content": execution_result,
+                }
+            )
+
+        return inference_data


### PR DESCRIPTION
This PR adds new model `mistralai/Ministral-8B-Instruct-2410` to the leaderboard. Since this model is open-sourced on huggingface, a local-serving mistral handler is also added; this is different from the `mistral.py` in `proprietary_model` folder, which does inference through their API endpoint.