### PR TITLE
Adding New Model Haha-7B

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Dec 30, 2024] : Add new model `Haha-7B` to the leaderboard.
 - [Dec 29, 2024] [#857](https://github.com/ShishirPatil/gorilla/pull/857): Add new model `DeepSeek-V3` to the leaderboard.
 - [Dec 29, 2024] [#855](https://github.com/ShishirPatil/gorilla/pull/855): Add new model `mistralai/Ministral-8B-Instruct-2410` to the leaderboard.
 - [Dec 22, 2024] [#838](https://github.com/ShishirPatil/gorilla/pull/838): Fix parameter type mismatch error in possible answers.

--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -96,7 +96,7 @@ Below is a comprehensive table of models supported for running leaderboard evalu
 |THUDM/glm-4-9b-chat 💻| Function Calling|
 |Team-ACE/ToolACE-8B 💻| Function Calling|
 |watt-ai/watt-tool-{8B,70B} 💻| Function Calling|
-
+|TeleAI/Haha-7B 💻| Prompt|
 ---
 
 ## Understanding Versioned Models

--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
@@ -811,6 +811,12 @@ MODEL_METADATA_MAPPING = {
         "xAI",
         "Proprietary",
     ],
+    "Haha-7B": [
+        "Haha-7B",
+        "https://www.modelscope.cn/models/z17828079650/Haha-7B",
+        "TeleAI",
+        "Apache 2.0",
+    ],
 }
 
 INPUT_PRICE_PER_MILLION_TOKEN = {

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
@@ -157,6 +157,7 @@ local_inference_handler_map = {
     "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct": DeepseekCoderHandler,
     "deepseek-ai/DeepSeek-V2-Chat-0628": DeepseekHandler,
     "deepseek-ai/DeepSeek-V2-Lite-Chat": DeepseekHandler,
+    "TeleAI/Haha-8b": QwenHandler,
 }
 
 # Deprecated/outdated models, no longer on the leaderboard


### PR DESCRIPTION
This PR adds new model `Haha-7B` to the leaderboard. 
`Haha-7B`  is a new open-sourced model developed by.