### PR TITLE
[BFCL Chore] Implement `retry_with_backoff` for Amazon Nova Handler

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/claude.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/claude.py
@@ -70,7 +70,7 @@ class ClaudeHandler(BaseHandler):
             function_call = convert_to_function_call(result)
             return function_call
 
-    @retry_with_backoff(RateLimitError)
+    @retry_with_backoff(error_type=RateLimitError)
     def generate_with_backoff(self, **kwargs):
         start_time = time.time()
         api_response = self.client.beta.prompt_caching.messages.create(**kwargs)

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/cohere.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/cohere.py
@@ -101,7 +101,7 @@ class CohereHandler(BaseHandler):
         }
         return metadata, latency
 
-    @retry_with_backoff(Exception, stop=stop_after_attempt(5), reraise=True)
+    @retry_with_backoff(error_type=Exception, stop=stop_after_attempt(5), reraise=True)
     def generate_with_backoff(
         self,
         messages: list,

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/deepseek.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/deepseek.py
@@ -18,7 +18,7 @@ class DeepSeekAPIHandler(OpenAIHandler):
             base_url="https://api.deepseek.com", api_key=os.getenv("DEEPSEEK_API_KEY")
         )
 
-    @retry_with_backoff(RateLimitError)
+    @retry_with_backoff(error_type=RateLimitError)
     def generate_with_backoff(self, **kwargs):
         """
         Per the DeepSeek API documentation:

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/gemini.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/gemini.py
@@ -72,7 +72,7 @@ class GeminiHandler(BaseHandler):
                     )
             return func_call_list
 
-    @retry_with_backoff(ResourceExhausted)
+    @retry_with_backoff(error_type=ResourceExhausted)
     def generate_with_backoff(self, client, **kwargs):
         start_time = time.time()
         api_response = client.generate_content(**kwargs)

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/nova.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/nova.py
@@ -12,7 +12,6 @@ from bfcl.model_handler.utils import (
     func_doc_language_specific_pre_processing,
     retry_with_backoff,
 )
-from tenacity import RetryCallState
 
 class NovaHandler(BaseHandler):
     def __init__(self, model_name, temperature) -> None:

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/nova.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/nova.py
@@ -36,16 +36,7 @@ class NovaHandler(BaseHandler):
             return []
         return convert_to_function_call(result)
 
-    @staticmethod
-    def retry_condition(retry_state):
-        # print(type(retry_state))
-        if type(retry_state) is not RetryCallState:
-            return False
-        if "(ThrottlingException)" in str(retry_state.outcome.exception()):
-            return True
-        return False
-
-    @retry_with_backoff(retry_condition=retry_condition)
+    @retry_with_backoff(error_message_pattern=r".*\(ThrottlingException\).*")
     def generate_with_backoff(self, **kwargs):
         start_time = time.time()
         api_response = self.client.converse(**kwargs)

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/openai.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/openai.py
@@ -43,7 +43,7 @@ class OpenAIHandler(BaseHandler):
         else:
             return default_decode_execute_prompting(result)
 
-    @retry_with_backoff(RateLimitError)
+    @retry_with_backoff(error_type=RateLimitError)
     def generate_with_backoff(self, **kwargs):
         start_time = time.time()
         api_response = self.client.chat.completions.create(**kwargs)

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/utils.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/utils.py
@@ -2,14 +2,21 @@ import ast
 import builtins
 import copy
 import json
-import os
+import operator
 import re
+from functools import reduce
+from typing import Callable, Optional, Type
 
 from bfcl.model_handler.constant import DEFAULT_SYSTEM_PROMPT, GORILLA_TO_OPENAPI
 from bfcl.model_handler.model_style import ModelStyle
 from bfcl.model_handler.parser.java_parser import parse_java_function_call
 from bfcl.model_handler.parser.js_parser import parse_javascript_function_call
-from tenacity import retry, retry_if_exception_type, wait_random_exponential
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    retry_if_result,
+    wait_random_exponential,
+)
 
 
 def _cast_to_openai_type(properties, mapping):
@@ -721,27 +728,60 @@ def decoded_output_to_execution_list(decoded_output):
     return execution_list
 
 
-def retry_with_backoff(error_type, min_wait=6, max_wait=120, **kwargs):
+def retry_with_backoff(
+    error_type: Optional[Type[Exception]] = None,
+    retry_condition: Optional[Callable[[any], bool]] = None,
+    min_wait: int = 6,
+    max_wait: int = 120,
+    **kwargs,
+) -> Callable:
     """
-    General decorator to retry with backoff for a specific error type.
+    Decorator to retry a function with exponential backoff based on specified error types or result conditions.
 
-    :param error_type: The exception type to retry on.
-    :param min_wait: Minimum wait time for the backoff.
-    :param max_wait: Maximum wait time for the backoff.
+    Note:
+        At least one of `error_type` or `retry_condition` must be provided.
+        If both `error_type` and `retry_condition` are provided, the retry will occur if either condition is met.
+
+    Args:
+        error_type (Type[Exception], optional): The exception type to retry on.
+        retry_condition (Callable[[any], bool], optional):
+            A callable that takes the function's result and returns True if a retry should occur.
+            This is useful when the user wants to retry based on the exception message or result,
+            especially if the exception raised is too broad.
+        min_wait (int, optional): Minimum wait time in seconds for the backoff.
+        max_wait (int, optional): Maximum wait time in seconds for the backoff.
+        **kwargs: Additional keyword arguments for the `tenacity.retry` decorator, such as `stop`, `reraise`, etc.
+
+    Returns:
+        Callable: The decorated function with retry logic applied.
     """
 
-    def decorator(func):
+    def decorator(func: Callable) -> Callable:
+        # Collect retry conditions based on provided parameters
+        conditions = []
+        if error_type is not None:
+            conditions.append(retry_if_exception_type(error_type))
+        if retry_condition is not None:
+            conditions.append(retry_if_result(retry_condition))
+
+        if not conditions:
+            raise ValueError("Either error_type or retry_condition must be provided.")
+
+        # Combine all conditions using logical OR
+        retry_policy = reduce(operator.or_, conditions)
+
         @retry(
             wait=wait_random_exponential(min=min_wait, max=max_wait),
-            retry=retry_if_exception_type(error_type),
+            retry=retry_policy,
             before_sleep=lambda retry_state: print(
-                f"Attempt {retry_state.attempt_number} failed. Sleeping for {float(round(retry_state.next_action.sleep, 2))} seconds before retrying..."
+                f"Attempt {retry_state.attempt_number} failed. "
+                f"Sleeping for {retry_state.next_action.sleep:.2f} seconds before retrying... "
                 f"Error: {retry_state.outcome.exception()}"
             ),
             **kwargs,
         )
-        def wrapped(*args, **kwargs):
-            return func(*args, **kwargs)
+        def wrapped(*args, **inner_kwargs):
+            return func(*args, **inner_kwargs)
 
         return wrapped
 


### PR DESCRIPTION
This PR introduces the retry_with_backoff mechanism for Nova models to address throttling issues when calling the AWS Bedrock endpoint. 
Because Bedrock does not throw a dedicated throttling exception ([link](https://docs.aws.amazon.com/ja_jp/bedrock/latest/APIReference/CommonErrors.html)), the existing decorator was updated to allow custom retry conditions driven by exception messages. 
Additionally, type hints and improved docstrings have been added to enhance maintainability and readability.