### PR TITLE
add handler for Bielik

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Jan 20, 2025] [#887](https://github.com/ShishirPatil/gorilla/pull/887): Add new model `speakleash/Bielik-11B-v2.3-Instruct` to the leaderboard.
 - [Jan 18, 2025] [#888](https://github.com/ShishirPatil/gorilla/pull/888): Add the following new models to the leaderboard:
   - `NovaSky-AI/Sky-T1-32B-Preview`
   - `Qwen/QwQ-32B-Preview`

--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -97,6 +97,7 @@ Below is a comprehensive table of models supported for running leaderboard evalu
 |Team-ACE/ToolACE-8B 💻| Function Calling|
 |watt-ai/watt-tool-{8B,70B} 💻| Function Calling|
 |ZJared/Haha-7B 💻| Prompt|
+|speakleash/Bielik-11B-v2.3-Instruct 💻| Prompt|
 
 ---
 

--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
@@ -818,7 +818,7 @@ MODEL_METADATA_MAPPING = {
         "Apache 2.0",
     ],
     "speakleash/Bielik-11B-v2.3-Instruct": [
-        "Bielik-11B-v2.3-Instruct",
+        "Bielik-11B-v2.3-Instruct (Prompt)",
         "https://huggingface.co/speakleash/Bielik-11B-v2.3-Instruct",
         "SpeakLeash & ACK Cyfronet AGH",
         "Apache 2.0",

--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
@@ -817,6 +817,12 @@ MODEL_METADATA_MAPPING = {
         "TeleAI",
         "Apache 2.0",
     ],
+    "speakleash/Bielik-11B-v2.3-Instruct": [
+        "Bielik-11B-v2.3-Instruct",
+        "https://huggingface.co/speakleash/Bielik-11B-v2.3-Instruct",
+        "SpeakLeash & ACK Cyfronet AGH",
+        "Apache 2.0",
+    ],
 }
 
 INPUT_PRICE_PER_MILLION_TOKEN = {

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
@@ -30,6 +30,7 @@ from bfcl.model_handler.local_inference.minicpm import MiniCPMHandler
 from bfcl.model_handler.local_inference.minicpm_fc import MiniCPMFCHandler
 from bfcl.model_handler.local_inference.mistral_fc import MistralFCHandler
 from bfcl.model_handler.local_inference.phi import PhiHandler
+from bfcl.model_handler.local_inference.quick_testing_oss import QuickTestingOSSHandler
 from bfcl.model_handler.local_inference.qwen import QwenHandler
 from bfcl.model_handler.local_inference.salesforce import SalesforceHandler
 

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
@@ -15,6 +15,7 @@ from bfcl.model_handler.api_inference.nvidia import NvidiaHandler
 from bfcl.model_handler.api_inference.openai import OpenAIHandler
 from bfcl.model_handler.api_inference.writer import WriterHandler
 from bfcl.model_handler.api_inference.yi import YiHandler
+from bfcl.model_handler.local_inference.bielik import BielikHandler
 from bfcl.model_handler.local_inference.deepseek import DeepseekHandler
 from bfcl.model_handler.local_inference.deepseek_coder import DeepseekCoderHandler
 from bfcl.model_handler.local_inference.gemma import GemmaHandler
@@ -158,6 +159,7 @@ local_inference_handler_map = {
     "deepseek-ai/DeepSeek-V2-Chat-0628": DeepseekHandler,
     "deepseek-ai/DeepSeek-V2-Lite-Chat": DeepseekHandler,
     "ZJared/Haha-7B": QwenHandler,
+    "speakleash/Bielik-11B-v2.3-Instruct": BielikHandler
 }
 
 # Deprecated/outdated models, no longer on the leaderboard

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/base_oss_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/base_oss_handler.py
@@ -270,6 +270,10 @@ class OSSHandler(BaseHandler, EnforceOverrides):
     #### Prompting methods ####
 
     def _format_prompt(self, messages, function):
+        """
+        Manually apply the chat template to construct the formatted prompt.
+        This way, we can have full control over the final formatted prompt and is generally recommended for advanced use cases.
+        """
         raise NotImplementedError(
             "OSS Models should implement their own prompt formatting."
         )

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/bielik.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/bielik.py
@@ -1,17 +1,25 @@
 from bfcl.model_handler.local_inference.base_oss_handler import OSSHandler
 from overrides import override
-from transformers import AutoTokenizer
 
 # Note: This is the handler for the Bielik in prompting mode. This model does not support function calls.
+
 
 class BielikHandler(OSSHandler):
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
 
     @override
     def _format_prompt(self, messages, function):
-        
-        formatted_prompt = self.tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+        """
+        "bos_token": "<s>",
+        "chat_template": "{{bos_token}}{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}",
+        """
 
+        formatted_prompt = "<s>"
+
+        for message in messages:
+            formatted_prompt += f"<|im_start|>{message['role']}\n{message['content']}<|im_end|>\n"
+
+        formatted_prompt += f"<|im_start|>assistant\n"
+        
         return formatted_prompt

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/bielik.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/bielik.py
@@ -1,0 +1,17 @@
+from bfcl.model_handler.local_inference.base_oss_handler import OSSHandler
+from overrides import override
+from transformers import AutoTokenizer
+
+# Note: This is the handler for the Bielik in prompting mode. This model does not support function calls.
+
+class BielikHandler(OSSHandler):
+    def __init__(self, model_name, temperature) -> None:
+        super().__init__(model_name, temperature)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    @override
+    def _format_prompt(self, messages, function):
+        
+        formatted_prompt = self.tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=False)
+
+        return formatted_prompt

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/quick_testing_oss.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/quick_testing_oss.py
@@ -1,0 +1,23 @@
+from bfcl.model_handler.local_inference.base_oss_handler import OSSHandler
+from overrides import override
+
+"""
+Note: 
+This handler only have the `_format_prompt` method overridden to apply the chat template automatically. Other methods are inherited from the OSSHandler.
+We DO NOT recommend using this handler directly. This handler only serve as a fallback, or for quick testing.
+Formatting the prompt manually give us better control over the final formatted prompt and is generally recommended for advanced use cases.
+"""
+
+
+class QuickTestingOSSHandler(OSSHandler):
+    def __init__(self, model_name, temperature) -> None:
+        super().__init__(model_name, temperature)
+
+    @override
+    def _format_prompt(self, messages, function):
+
+        formatted_prompt = self.tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False
+        )
+
+        return formatted_prompt


### PR DESCRIPTION
Adding Handler for Open Source LLM Bielik available on HF - https://huggingface.co/speakleash/Bielik-11B-v2.3-Instruct .
I chose to load tokenizer in the constructor of the handler, so that I automatically apply chat template. As a result, I can reuse this handler for models with various templates.