### PR TITLE
Add support for QwQ and Sky-T1-32B-Preview

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Jan 18, 2025] [#888](https://github.com/ShishirPatil/gorilla/pull/888): Add the following new models to the leaderboard:
+  - `NovaSky-AI/Sky-T1-32B-Preview`
+  - `Qwen/QwQ-32B-Preview`
 - [Jan 12, 2025] [#881](https://github.com/ShishirPatil/gorilla/pull/881): Fix Nova handler for consecutive user prompt issue.
 - [Jan 11, 2025] : Add new model `ZJared/Haha-7B` to the leaderboard.
 - [Jan 4, 2025] [#865](https://github.com/ShishirPatil/gorilla/pull/865): Fix a copy-paste issue in `live_parallel_multiple_9-8-0` that caused a misalignment between the question and the possible answer.

--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -97,6 +97,8 @@ Below is a comprehensive table of models supported for running leaderboard evalu
 |Team-ACE/ToolACE-8B 💻| Function Calling|
 |watt-ai/watt-tool-{8B,70B} 💻| Function Calling|
 |ZJared/Haha-7B 💻| Prompt|
+|Qwen/QwQ-32B-Preview 💻| Prompt|
+|NovaSky-AI/Sky-T1-32B-Preview 💻| Prompt|
 
 ---
 

--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
@@ -817,6 +817,18 @@ MODEL_METADATA_MAPPING = {
         "TeleAI",
         "Apache 2.0",
     ],
+    "NovaSky-AI/Sky-T1-32B-Preview": [
+        "Sky-T1-32B-Preview (Prompt)",
+        "https://huggingface.co/NovaSky-AI/Sky-T1-32B-Preview",
+        "NovaSky-AI",
+        "apache-2.0",
+    ],
+    "Qwen/QwQ-32B-Preview": [
+        "QwQ-32B-Preview (Prompt)",
+        "https://huggingface.co/Qwen/QwQ-32B-Preview",
+        "Qwen",
+        "apache-2.0",
+    ],
 }
 
 INPUT_PRICE_PER_MILLION_TOKEN = {

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
@@ -158,6 +158,8 @@ local_inference_handler_map = {
     "deepseek-ai/DeepSeek-V2-Chat-0628": DeepseekHandler,
     "deepseek-ai/DeepSeek-V2-Lite-Chat": DeepseekHandler,
     "ZJared/Haha-7B": QwenHandler,
+    "NovaSky-AI/Sky-T1-32B-Preview": QwenHandler,
+    "Qwen/QwQ-32B-Preview": QwenHandler,
 }
 
 # Deprecated/outdated models, no longer on the leaderboard


### PR DESCRIPTION
# What does this PR do?

Adds support for [Qwen/QwQ-32B-Preview](https://huggingface.co/Qwen/QwQ-32B-Preview) and [NovaSky-AI/Sky-T1-32B-Preview](https://huggingface.co/NovaSky-AI/Sky-T1-32B-Preview) 

Since both the reasoning models are finetunes of Qwen/Qwen2.5-32B-Instruct, I've used the `QwenHandler` for both. (Neither model has any special finetuning for tool use AFAIK)