### PR TITLE
[BFCL] fix bug in how score_dir is handled for bfcl evaluate

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/eval_runner.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/eval_runner.py
@@ -627,7 +627,7 @@ def main(model, test_categories, api_sanity_check, result_dir, score_dir):
     if score_dir is None:
         score_dir = SCORE_PATH
     else:
-        result_dir = (PROJECT_ROOT / score_dir).resolve()
+        score_dir = (PROJECT_ROOT / score_dir).resolve()
 
     if type(test_categories) is not list:
         test_categories = [test_categories]


### PR DESCRIPTION
Small fix for when `--score-dir` is passed as an argument to `bfcl evaluate`.