### PR TITLE
Add Cohere Command A

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Mar 20, 2025] [#951](https://github.com/ShishirPatil/gorilla/pull/951): Add new model `command-a-03-2025-FC` to the leaderboard.
 - [Mar 15, 2025] [#942](https://github.com/ShishirPatil/gorilla/pull/942): Add the following new models to the leaderboard:
   - `gemini-2.0-flash-lite-001-FC`
   - `gemini-2.0-flash-lite-001`

--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -56,6 +56,7 @@ Below is a comprehensive table of models supported for running leaderboard evalu
 |nova-macro-v1.0| Function Calling|
 |command-r-plus-FC | Function Calling|
 |command-r7b-12-2024-FC | Function Calling|
+|command-a-03-2025-FC | Function Calling|
 |databrick-dbrx-instruct | Prompt|
 |firefunction-{v1,v2}-FC | Function Calling|
 |yi-large-fc | Function Calling|

--- a/berkeley-function-call-leaderboard/bfcl/constants/eval_config.py
+++ b/berkeley-function-call-leaderboard/bfcl/constants/eval_config.py
@@ -69,6 +69,7 @@ UNDERSCORE_TO_DOT = [
     "NousResearch/Hermes-2-Theta-Llama-3-70B",
     "command-r-plus-FC",
     "command-r7b-12-2024-FC",
+    "command-a-03-2025-FC",
     "THUDM/glm-4-9b-chat",
     "ibm-granite/granite-20b-functioncalling",
     "yi-large-fc",

--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/model_metadata.py
@@ -590,6 +590,12 @@ MODEL_METADATA_MAPPING = {
         "Cohere",
         "cc-by-nc-4.0",
     ],
+    "command-a-03-2025-FC": [
+        "Command A (FC)",
+        "https://cohere.com/blog/command-a",
+        "Cohere",
+        "CC-BY-NC 4.0 License (w/ Acceptable Use Addendum)",
+    ],
     "snowflake/arctic": [
         "Snowflake/snowflake-arctic-instruct (Prompt)",
         "https://huggingface.co/Snowflake/snowflake-arctic-instruct",
@@ -1003,6 +1009,7 @@ INPUT_PRICE_PER_MILLION_TOKEN = {
     "databricks-dbrx-instruct": 2.25,
     "command-r-plus-FC": 3,
     "command-r7b-12-2024-FC": 0.0375,
+    "command-a-03-2025-FC": 2.5,
     "yi-large-fc": 3,
     "palmyra-x-004": 5,
     "grok-beta": 5,
@@ -1071,6 +1078,7 @@ OUTPUT_PRICE_PER_MILLION_TOKEN = {
     "databricks-dbrx-instruct": 6.75,
     "command-r-plus-FC": 15,
     "command-r7b-12-2024-FC": 0.15,
+    "command-a-03-2025-FC": 10,
     "yi-large-fc": 3,
     "palmyra-x-004": 12,
     "grok-beta": 15,

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
@@ -94,6 +94,7 @@ api_inference_handler_map = {
     "databricks-dbrx-instruct": DatabricksHandler,
     "command-r-plus-FC": CohereHandler,
     "command-r7b-12-2024-FC": CohereHandler,
+    "command-a-03-2025-FC": CohereHandler,
     "snowflake/arctic": NvidiaHandler,
     "nvidia/nemotron-4-340b-instruct": NvidiaHandler,
     "BitAgent/GoGoAgent": GoGoAgentHandler,


### PR DESCRIPTION
Hello from Cohere 👋 

This PR submits our latest model - [Command A](https://cohere.com/blog/command-a). When I ran this against [f81063](https://github.com/ShishirPatil/gorilla/commit/f8106312357d2e687a905610fe972b64482ab8e2) I got the following score, and hopefully you'll be able to reproduce them:

```
| Overall Acc | Model          | Model Link                        | Cost ($ Per 1k Function Calls) | Latency Mean (s) | Latency Standard Deviation (s) | Latency 95th Percentile (s) | Non-Live AST Acc | Non-Live Simple AST | Non-Live Multiple AST | Non-Live Parallel AST | Non-Live Parallel Multiple AST | Non-Live Exec Acc | Non-Live Simple Exec | Non-Live Multiple Exec | Non-Live Parallel Exec | Non-Live Parallel Multiple Exec | Live Acc | Live Simple AST | Live Multiple AST | Live Parallel AST | Live Parallel Multiple AST | Multi Turn Acc | Multi Turn Base | Multi Turn Miss Func | Multi Turn Miss Param | Multi Turn Long Context | Relevance Detection | Irrelevance Detection | Organization |
|-------------|----------------|-----------------------------------|--------------------------------|------------------|--------------------------------|-----------------------------|------------------|---------------------|-----------------------|-----------------------|--------------------------------|-------------------|----------------------|------------------------|------------------------|---------------------------------|----------|-----------------|-------------------|-------------------|----------------------------|----------------|-----------------|----------------------|-----------------------|-------------------------|---------------------|-----------------------|--------------|
| 63.14%      | Command A (FC) | https://cohere.com/blog/command-a | 6.74                           | 6.22             | 11.38                          | 17.1                        | 86.73%           | 73.92%              | 93.50%                | 93.50%                | 86.00%                         | 82.12%            | 97.00%               | 88.00%                 | 76.00%                 | 67.50%                          | 80.14%   | 83.72%          | 76.92%            | 81.25%            | 62.50%                     | 24.38%         | 32.00%          | 23.00%               | 22.00%                | 20.50%                  | 72.22%              | 86.16%                | Cohere       |

```

Thanks in advance for taking the time to review, and I look forward to seeing us on the leaderboard 🎉 