### PR TITLE
[BFCL] Fix API Keys Handling

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/_llm_response_generation.py
+++ b/berkeley-function-call-leaderboard/bfcl/_llm_response_generation.py
@@ -323,11 +323,6 @@ def main(args):
         )
         print("----------")
 
-    # Apply function credential config if any of the test categories are executable
-    # We can know for sure that any executable categories will not be included if the API Keys are not supplied.
-    if any([is_executable(category) for category in all_test_categories]):
-        apply_function_credential_config(input_path=PROMPT_PATH)
-
     if args.result_dir is not None:
         args.result_dir = PROJECT_ROOT / args.result_dir
     else:

--- a/berkeley-function-call-leaderboard/bfcl/utils.py
+++ b/berkeley-function-call-leaderboard/bfcl/utils.py
@@ -198,7 +198,7 @@ def check_api_key_supplied() -> bool:
     """
     ENV_VARS = ("GEOCODE_API_KEY", "RAPID_API_KEY", "OMDB_API_KEY", "EXCHANGERATE_API_KEY")
     for var in ENV_VARS:
-        if os.getenv(var) == "":
+        if os.getenv(var) is None:
             return False
     return True
 


### PR DESCRIPTION
The following bugs can all be reproduced from a clean, unmodified version of the repository. All of them have been addressed by this PR.
#### Setup 1:  
- **Input:** `test_case_ids_to_generate.json` → `rest: ["rest_0"]`  
- **.env:** No API key provided  
- **Command:** `bfcl generate --model gpt-4o-mini-2024-07-18 --run-ids`

1. fix `check_api_key_supplied` implementation in `utils.py`. `os.getenv(var)` returns `None` instead of a string

2. After the previous issue is fixed, a `NameError` occurs when no result file existed and `existing_ids` was only conditionally defined inside a loop
   ```
   Exception has occurred: NameError  
   free variable 'existing_ids' referenced before assignment in enclosing scope
   ```
3. Under this setup, no test should be called, but test case `rest_0` was still collected unexpectedly. 
![Screenshot 2025-03-25 at 2 17 05 AM](https://github.com/user-attachments/assets/f880909b-f44f-4afc-9cd8-8f329f1eb019)

#### Setup 2:  
- **.env:** All API keys provided  
- **Command:** `bfcl generate --model gpt-4o-mini-2024-07-18 --test-category rest`

4. API keys were replaced in the rest tests JSON file, but the credential information in the question passed to the `generate_result` function was not correct.