### PR TITLE
[BFCL] Use HTTPS instead of HTTP for OMDB

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/executable_eval/data/executable_python_function.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/executable_eval/data/executable_python_function.py
@@ -862,7 +862,7 @@ def get_movie_rating(movie_name):
     Args:
         movie_name (str): The name of the movie.
     """
-    url = "http://www.omdbapi.com/"
+    url = "https://www.omdbapi.com/"
     params = {"t": movie_name, "apikey": api_key["OMDB-API-KEY"]}
     response = requests.get(url, params=params)
     return response.json()["Rated"]
@@ -874,7 +874,7 @@ def get_movie_director(movie_name):
     Args:
         movie_name (str): The name of the movie.
     """
-    url = "http://www.omdbapi.com/"
+    url = "https://www.omdbapi.com/"
     params = {"t": movie_name, "apikey": api_key["OMDB-API-KEY"]}
     response = requests.get(url, params=params)
     return response.json()["Director"]


### PR DESCRIPTION
Executable evals fail sometimes with the following returned as the response: `{"Response":"False","Error":"Invalid API key!"}`
See this for context: https://github.com/omdbapi/OMDb-API/issues/311#issuecomment-2138657319.
