### PR TITLE
[BFCL] Add New Models `Llama-4-Scout`, `Llama-4-Maverick`

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Apr 9, 2025] [#981](https://github.com/ShishirPatil/gorilla/pull/981): Add the following new models to the leaderboard:
+  - `meta-llama/Llama-4-Scout-17B-16E-Instruct-FC`
+  - `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8-FC`
 - [Apr 9, 2025] [#943](https://github.com/ShishirPatil/gorilla/pull/943): Retire the executable categories from the leaderboard. The following categories will be excluded from the evaluation pipeline:
   - `rest`
   - `exec_simple`

--- a/berkeley-function-call-leaderboard/CONTRIBUTING.md
+++ b/berkeley-function-call-leaderboard/CONTRIBUTING.md
@@ -24,9 +24,11 @@ berkeley-function-call-leaderboard/
 │   │   ├── multi_turn_eval/      # Multi-turn evaluation
 │   ├── model_handler/            # All model-specific handlers
 │   │   ├── local_inference/            # Handlers for locally-hosted models
-│   │   │   ├── base_oss_handler.py   # Base handler for OSS models
-│   │   │   ├── llama_fc.py           # Example: LLaMA (FC mode)
-│   │   │   ├── deepseek_coder.py     # Example: DeepSeek Coder
+│   │   │   ├── base_oss_handler.py       # Base handler for OSS models
+│   │   │   ├── gemma.py                  # Example: Gemma models
+│   │   │   ├── qwen.py                   # Example: Qwen models (Prompt mode)
+│   │   │   ├── qwen_fc.py                # Example: Qwen models (FC mode)
+│   │   │   ├── deepseek_reasoning.py     # Example: DeepSeek reasoning models (with reasoning trace)
 │   │   │   ├── ...
 │   │   ├── api_inference/    # Handlers for API-based models
 │   │   │   ├── openai.py             # Example: OpenAI models
@@ -63,7 +65,7 @@ We support models in two modes:
 
 For API-based models (such as OpenAI GPT), both FC and Prompting modes can be defined in the same handler. Methods related to FC mode end with `_FC`, while Prompting mode methods end with `_prompting`.
 
-For locally-hosted models, we only implement prompting methods to maintain code readablity. If a locally-hosted model has both FC and Prompting modes, you will typically create two separate handlers (e.g., `llama_fc.py` for FC mode and `llama.py` for Prompting mode).
+For locally-hosted models, we only implement prompting methods to maintain code readablity. If a locally-hosted model has both FC and Prompting modes, you will typically create two separate handlers (e.g., `qwen_fc.py` for FC mode and `qwen.py` for Prompting mode).
 
 ## Creating Your Model Handler
 

--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -14,108 +14,109 @@ Below is a comprehensive table of models supported for running leaderboard evalu
 
 For model names containing `{...}`, multiple versions are available. For example, `meta-llama/Llama-3.1-{8B,70B}-Instruct` means we support both models: `meta-llama/Llama-3.1-8B-Instruct` and `meta-llama/Llama-3.1-70B-Instruct`.
 
-| Base Model                                     | Type             | Provider       | Model ID on BFCL                                            |
-| ---------------------------------------------- | ---------------- | -------------- | ----------------------------------------------------------- |
-| Amazon-Nova-Lite-v1:0                          | Function Calling | AWS            | nova-lite-v1.0                                              |
-| Amazon-Nova-Micro-v1:0                         | Function Calling | AWS            | nova-micro-v1.0                                             |
-| Amazon-Nova-Pro-v1:0                           | Function Calling | AWS            | nova-pro-v1.0                                               |
-| Bielik-11B-v2.3-Instruct                       | Prompt           | Self-hosted 💻 | speakleash/Bielik-11B-v2.3-Instruct                         |
-| BitAgent-8B                                    | Prompt           | Self-hosted 💻 | BitAgent/BitAgent-8B                                        |
-| Claude-3-Opus-20240229                         | Function Calling | Anthropic      | claude-3-opus-20240229-FC                                   |
-| Claude-3-Opus-20240229                         | Prompt           | Anthropic      | claude-3-opus-20240229                                      |
-| claude-3.5-haiku-20241022                      | Function Calling | Anthropic      | claude-3-5-haiku-20241022-FC                                |
-| claude-3.5-haiku-20241022                      | Prompt           | Anthropic      | claude-3-5-haiku-20241022                                   |
-| Claude-3.5-Sonnet-20241022                     | Function Calling | Anthropic      | claude-3-5-sonnet-20241022-FC                               |
-| Claude-3.5-Sonnet-20241022                     | Prompt           | Anthropic      | claude-3-5-sonnet-20241022                                  |
-| Claude-3.7-Sonnet-20250219                     | Function Calling | Anthropic      | claude-3-7-sonnet-20250219-FC                               |
-| Claude-3.7-Sonnet-20250219                     | Prompt           | Anthropic      | claude-3-7-sonnet-20250219                                  |
-| CoALM-{8B, 70B, 405B}                          | Function Calling | Self-hosted 💻 | uiuc-convai/CoALM-{8B,70B,405B}                             |
-| Command A                                      | Function Calling | Cohere         | command-a-03-2025-FC                                        |
-| Command R7B                                    | Function Calling | Cohere         | command-r7b-12-2024-FC                                      |
-| Command-R-Plus                                 | Function Calling | Cohere         | command-r-plus-FC                                           |
-| DBRX-Instruct                                  | Prompt           | Databricks     | databricks-dbrx-instruct                                    |
-| DeepSeek-Coder-V2{-Lite-Instruct}              | Function Calling | Self-hosted 💻 | deepseek-ai/DeepSeek-Coder-V2-{Instruct-0724,Lite-Instruct} |
-| DeepSeek-R1                                    | Prompt           | DeepSeek       | DeepSeek-R1                                                 |
-| DeepSeek-R1                                    | Prompt           | Self-hosted 💻 | deepseek-ai/DeepSeek-R1                                     |
-| DeepSeek-V2-{Chat-0628,Lite-Chat}              | Prompt           | Self-hosted 💻 | deepseek-ai/DeepSeek-V2-{Chat-0628,Lite-Chat}               |
-| DeepSeek-V2.5                                  | Function Calling | Self-hosted 💻 | deepseek-ai/DeepSeek-V2.5                                   |
-| DeepSeek-V3                                    | Function Calling | DeepSeek       | DeepSeek-V3-FC                                              |
-| Falcon3-{1B,3B,7B,10B}-Instruct                | Function Calling | Self-hosted 💻 | tiiuae/Falcon3-{1B,3B,7B,10B}-Instruct                      |
-| FireFunction-{v1,v2}                           | Function Calling | Fireworks AI   | firefunction-{v1,v2}-FC                                     |
-| Functionary-{Small,Medium}-v3.1                | Function Calling | MeetKai        | meetkai/functionary-{small,medium}-v3.1-FC                  |
-| Gemini-2.0-Flash-001                           | Function Calling | Google         | gemini-2.0-flash-001-FC                                     |
-| Gemini-2.0-Flash-001                           | Prompt           | Google         | gemini-2.0-flash-001                                        |
-| Gemini-2.0-Flash-Lite-001                      | Function Calling | Google         | gemini-2.0-flash-lite-001-FC                                |
-| Gemini-2.0-Flash-Lite-001                      | Prompt           | Google         | gemini-2.0-flash-lite-001                                   |
-| Gemini-2.0-Flash-Thinking-Exp-01-21            | Prompt           | Google         | gemini-2.0-flash-thinking-exp-01-21                         |
-| Gemini-2.5-Pro-Exp-03-25                       | Function Calling | Google         | gemini-2.5-pro-exp-03-25-FC                                 |
-| Gemini-2.5-Pro-Exp-03-25                       | Prompt           | Google         | gemini-2.5-pro-exp-03-25                                    |
-| Gemma-3-{1b,4b,12b,27b}-it                     | Prompt           | Self-hosted 💻 | google/gemma-3-{1b,4b,12b,27b}-it                           |
-| GLM-4-9b-Chat                                  | Function Calling | Self-hosted 💻 | THUDM/glm-4-9b-chat                                         |
-| GoGoAgent                                      | Prompt           | BitAgent       | BitAgent/GoGoAgent                                          |
-| Gorilla-OpenFunctions-v2                       | Function Calling | Gorilla LLM    | gorilla-openfunctions-v2                                    |
-| GPT-3.5-Turbo-0125                             | Function Calling | OpenAI         | gpt-3.5-turbo-0125-FC                                       |
-| GPT-3.5-Turbo-0125                             | Prompt           | OpenAI         | gpt-3.5-turbo-0125                                          |
-| GPT-4-turbo-2024-04-09                         | Function Calling | OpenAI         | gpt-4-turbo-2024-04-09-FC                                   |
-| GPT-4-turbo-2024-04-09                         | Prompt           | OpenAI         | gpt-4-turbo-2024-04-09                                      |
-| GPT-4.5-Preview-2025-02-27                     | Function Calling | OpenAI         | gpt-4.5-preview-2025-02-27-FC                               |
-| GPT-4.5-Preview-2025-02-27                     | Prompt           | OpenAI         | gpt-4.5-preview-2025-02-27                                  |
-| GPT-4o-2024-11-20                              | Function Calling | OpenAI         | gpt-4o-2024-11-20-FC                                        |
-| GPT-4o-2024-11-20                              | Prompt           | OpenAI         | gpt-4o-2024-11-20                                           |
-| GPT-4o-mini-2024-07-18                         | Function Calling | OpenAI         | gpt-4o-mini-2024-07-18-FC                                   |
-| GPT-4o-mini-2024-07-18                         | Prompt           | OpenAI         | gpt-4o-mini-2024-07-18                                      |
-| Granite-20b-FunctionCalling                    | Function Calling | Self-hosted 💻 | ibm-granite/granite-20b-functioncalling                     |
-| Grok-beta                                      | Function Calling | xAI            | grok-beta                                                   |
-| Haha-7B                                        | Prompt           | Self-hosted 💻 | ZJared/Haha-7B                                              |
-| Hammer2.1-{7b,3b,1.5b,0.5b}                    | Function Calling | Self-hosted 💻 | MadeAgents/Hammer2.1-{7b,3b,1.5b,0.5b}                      |
-| Hermes-2-Pro-Llama-3-{8B,70B}                  | Function Calling | Self-hosted 💻 | NousResearch/Hermes-2-Pro-Llama-3-{8B,70B}                  |
-| Hermes-2-Pro-Mistral-7B                        | Function Calling | Self-hosted 💻 | NousResearch/Hermes-2-Pro-Mistral-7B                        |
-| Hermes-2-Theta-Llama-3-{8B,70B}                | Function Calling | Self-hosted 💻 | NousResearch/Hermes-2-Theta-Llama-3-{8B,70B}                |
-| Llama-3-{8B,70B}-Instruct                      | Prompt           | Self-hosted 💻 | meta-llama/Meta-Llama-3-{8B,70B}-Instruct                   |
-| Llama-3.1-{8B,70B}-Instruct                    | Function Calling | Self-hosted 💻 | meta-llama/Llama-3.1-{8B,70B}-Instruct-FC                   |
-| Llama-3.1-{8B,70B}-Instruct                    | Prompt           | Self-hosted 💻 | meta-llama/Llama-3.1-{8B,70B}-Instruct                      |
-| Llama-3.2-{1B,3B}-Instruct                     | Prompt           | Self-hosted 💻 | meta-llama/Llama-3.2-{1B,3B}-Instruct                       |
-| Llama-3.3-70B-Instruct                         | Prompt           | Self-hosted 💻 | meta-llama/Llama-3.3-70B-Instruct                           |
-| Llama-3.3-70B-Instruct                         | Function Calling | Self-hosted 💻 | meta-llama/Llama-3.3-70B-Instruct-FC                        |
-| MiniCPM3-4B                                    | Prompt           | Self-hosted 💻 | openbmb/MiniCPM3-4B                                         |
-| MiniCPM3-4B-FC                                 | Function Calling | Self-hosted 💻 | openbmb/MiniCPM3-4B-FC                                      |
-| Ministral-8B-Instruct-2410                     | Function Calling | Self-hosted 💻 | mistralai/Ministral-8B-Instruct-2410                        |
-| mistral-large-2407                             | Function Calling | Mistral AI     | mistral-large-2407-FC                                       |
-| mistral-large-2407                             | Prompt           | Mistral AI     | mistral-large-2407                                          |
-| Mistral-Medium-2312                            | Prompt           | Mistral AI     | mistral-medium-2312                                         |
-| Mistral-small-2402                             | Function Calling | Mistral AI     | mistral-small-2402-FC                                       |
-| Mistral-Small-2402                             | Prompt           | Mistral AI     | mistral-small-2402                                          |
-| Mistral-tiny-2312                              | Prompt           | Mistral AI     | mistral-tiny-2312                                           |
-| Nemotron-4-340b-instruct                       | Prompt           | Nvidia         | nvidia/nemotron-4-340b-instruct                             |
-| Nexusflow-Raven-v2                             | Function Calling | Nexusflow      | Nexusflow-Raven-v2                                          |
-| o1-2024-12-17                                  | Function Calling | OpenAI         | o1-2024-12-17-FC                                            |
-| o1-2024-12-17                                  | Prompt           | OpenAI         | o1-2024-12-17                                               |
-| o3-mini-2025-01-31                             | Function Calling | OpenAI         | o3-mini-2025-01-31-FC                                       |
-| o3-mini-2025-01-31                             | Prompt           | OpenAI         | o3-mini-2025-01-31                                          |
-| Open-Mistral-Nemo-2407                         | Prompt           | Mistral AI     | open-mistral-nemo-2407                                      |
-| Open-Mistral-Nemo-2407                         | Function Calling | Mistral AI     | open-mistral-nemo-2407-FC                                   |
-| Open-Mixtral-{8x7b,8x22b}                      | Prompt           | Mistral AI     | open-mixtral-{8x7b,8x22b}                                   |
-| Open-Mixtral-8x22b                             | Function Calling | Mistral AI     | open-mixtral-8x22b-FC                                       |
-| palmyra-x-004                                  | Function Calling | Writer         | palmyra-x-004                                               |
-| Phi-3-medium-{4k,128k}-instruct                | Prompt           | Self-hosted 💻 | microsoft/Phi-3-medium-{4k,128k}-instruct                   |
-| Phi-3-mini-{4k,128k}-instruct                  | Prompt           | Self-hosted 💻 | microsoft/Phi-3-mini-{4k,128k}-instruct                     |
-| Phi-3-small-{8k,128k}-instruct                 | Prompt           | Self-hosted 💻 | microsoft/Phi-3-small-{8k,128k}-instruct                    |
-| Phi-3.5-mini-instruct                          | Prompt           | Self-hosted 💻 | microsoft/Phi-3.5-mini-instruct                             |
-| Qwen2-{1.5B,7B}-Instruct                       | Prompt           | Self-hosted 💻 | Qwen/Qwen2-{1.5B,7B}-Instruct                               |
-| Qwen2.5-{0.5B,1.5B,3B,7B,14B,32B,72B}-Instruct | Prompt           | Self-hosted 💻 | Qwen/Qwen2.5-{0.5B,1.5B,3B,7B,14B,32B,72B}-Instruct         |
-| Qwen2.5-{0.5B,1.5B,3B,7B,14B,32B,72B}-Instruct | Function Calling | Self-hosted 💻 | Qwen/Qwen2.5-{0.5B,1.5B,3B,7B,14B,32B,72B}-Instruct-FC      |
-| QwQ-32B-Preview                                | Prompt           | Self-hosted 💻 | Qwen/QwQ-32B-Preview                                        |
-| Sky-T1-32B-Preview                             | Prompt           | Self-hosted 💻 | NovaSky-AI/Sky-T1-32B-Preview                               |
-| Snowflake/snowflake-arctic-instruct            | Prompt           | Snowflake      | snowflake/arctic                                            |
-| ToolACE-2-8B                                   | Function Calling | Self-hosted 💻 | Team-ACE/ToolACE-2-8B                                       |
-| ToolACE-8B                                     | Function Calling | Self-hosted 💻 | Team-ACE/ToolACE-8B                                         |
-| watt-tool-{8B,70B}                             | Function Calling | Self-hosted 💻 | watt-ai/watt-tool-{8B,70B}                                  |
-| xLAM-2-70b-fc-r                                | Function Calling | Self-hosted 💻 | Salesforce/Llama-xLAM-2-70b-fc-r                            |
-| xLAM-2-32b-fc-r                                | Function Calling | Self-hosted 💻 | Salesforce/xLAM-2-32b-fc-r                                  |
-| xLAM-2-8b-fc-r                                 | Function Calling | Self-hosted 💻 | Salesforce/Llama-xLAM-2-8b-fc-r                             |
-| xLAM-2-3b-fc-r                                 | Function Calling | Self-hosted 💻 | Salesforce/xLAM-2-3b-fc-r                                   |
-| xLAM-2-1b-fc-r                                 | Function Calling | Self-hosted 💻 | Salesforce/xLAM-2-1b-fc-r                                   |
-| yi-large                                       | Function Calling | 01.AI          | yi-large-fc                                                 |
+| Base Model                                        | Type             | Provider       | Model ID on BFCL                                            |
+| ------------------------------------------------- | ---------------- | -------------- | ----------------------------------------------------------- |
+| Amazon-Nova-Lite-v1:0                             | Function Calling | AWS            | nova-lite-v1.0                                              |
+| Amazon-Nova-Micro-v1:0                            | Function Calling | AWS            | nova-micro-v1.0                                             |
+| Amazon-Nova-Pro-v1:0                              | Function Calling | AWS            | nova-pro-v1.0                                               |
+| Bielik-11B-v2.3-Instruct                          | Prompt           | Self-hosted 💻 | speakleash/Bielik-11B-v2.3-Instruct                         |
+| BitAgent-8B                                       | Prompt           | Self-hosted 💻 | BitAgent/BitAgent-8B                                        |
+| Claude-3-Opus-20240229                            | Function Calling | Anthropic      | claude-3-opus-20240229-FC                                   |
+| Claude-3-Opus-20240229                            | Prompt           | Anthropic      | claude-3-opus-20240229                                      |
+| claude-3.5-haiku-20241022                         | Function Calling | Anthropic      | claude-3-5-haiku-20241022-FC                                |
+| claude-3.5-haiku-20241022                         | Prompt           | Anthropic      | claude-3-5-haiku-20241022                                   |
+| Claude-3.5-Sonnet-20241022                        | Function Calling | Anthropic      | claude-3-5-sonnet-20241022-FC                               |
+| Claude-3.5-Sonnet-20241022                        | Prompt           | Anthropic      | claude-3-5-sonnet-20241022                                  |
+| Claude-3.7-Sonnet-20250219                        | Function Calling | Anthropic      | claude-3-7-sonnet-20250219-FC                               |
+| Claude-3.7-Sonnet-20250219                        | Prompt           | Anthropic      | claude-3-7-sonnet-20250219                                  |
+| CoALM-{8B, 70B, 405B}                             | Function Calling | Self-hosted 💻 | uiuc-convai/CoALM-{8B,70B,405B}                             |
+| Command A                                         | Function Calling | Cohere         | command-a-03-2025-FC                                        |
+| Command R7B                                       | Function Calling | Cohere         | command-r7b-12-2024-FC                                      |
+| Command-R-Plus                                    | Function Calling | Cohere         | command-r-plus-FC                                           |
+| DBRX-Instruct                                     | Prompt           | Databricks     | databricks-dbrx-instruct                                    |
+| DeepSeek-Coder-V2{-Lite-Instruct}                 | Function Calling | Self-hosted 💻 | deepseek-ai/DeepSeek-Coder-V2-{Instruct-0724,Lite-Instruct} |
+| DeepSeek-R1                                       | Prompt           | DeepSeek       | DeepSeek-R1                                                 |
+| DeepSeek-R1                                       | Prompt           | Self-hosted 💻 | deepseek-ai/DeepSeek-R1                                     |
+| DeepSeek-V2-{Chat-0628,Lite-Chat}                 | Prompt           | Self-hosted 💻 | deepseek-ai/DeepSeek-V2-{Chat-0628,Lite-Chat}               |
+| DeepSeek-V2.5                                     | Function Calling | Self-hosted 💻 | deepseek-ai/DeepSeek-V2.5                                   |
+| DeepSeek-V3                                       | Function Calling | DeepSeek       | DeepSeek-V3-FC                                              |
+| Falcon3-{1B,3B,7B,10B}-Instruct                   | Function Calling | Self-hosted 💻 | tiiuae/Falcon3-{1B,3B,7B,10B}-Instruct                      |
+| FireFunction-{v1,v2}                              | Function Calling | Fireworks AI   | firefunction-{v1,v2}-FC                                     |
+| Functionary-{Small,Medium}-v3.1                   | Function Calling | MeetKai        | meetkai/functionary-{small,medium}-v3.1-FC                  |
+| Gemini-2.0-Flash-001                              | Function Calling | Google         | gemini-2.0-flash-001-FC                                     |
+| Gemini-2.0-Flash-001                              | Prompt           | Google         | gemini-2.0-flash-001                                        |
+| Gemini-2.0-Flash-Lite-001                         | Function Calling | Google         | gemini-2.0-flash-lite-001-FC                                |
+| Gemini-2.0-Flash-Lite-001                         | Prompt           | Google         | gemini-2.0-flash-lite-001                                   |
+| Gemini-2.0-Flash-Thinking-Exp-01-21               | Prompt           | Google         | gemini-2.0-flash-thinking-exp-01-21                         |
+| Gemini-2.5-Pro-Exp-03-25                          | Function Calling | Google         | gemini-2.5-pro-exp-03-25-FC                                 |
+| Gemini-2.5-Pro-Exp-03-25                          | Prompt           | Google         | gemini-2.5-pro-exp-03-25                                    |
+| Gemma-3-{1b,4b,12b,27b}-it                        | Prompt           | Self-hosted 💻 | google/gemma-3-{1b,4b,12b,27b}-it                           |
+| GLM-4-9b-Chat                                     | Function Calling | Self-hosted 💻 | THUDM/glm-4-9b-chat                                         |
+| GoGoAgent                                         | Prompt           | BitAgent       | BitAgent/GoGoAgent                                          |
+| Gorilla-OpenFunctions-v2                          | Function Calling | Gorilla LLM    | gorilla-openfunctions-v2                                    |
+| GPT-3.5-Turbo-0125                                | Function Calling | OpenAI         | gpt-3.5-turbo-0125-FC                                       |
+| GPT-3.5-Turbo-0125                                | Prompt           | OpenAI         | gpt-3.5-turbo-0125                                          |
+| GPT-4-turbo-2024-04-09                            | Function Calling | OpenAI         | gpt-4-turbo-2024-04-09-FC                                   |
+| GPT-4-turbo-2024-04-09                            | Prompt           | OpenAI         | gpt-4-turbo-2024-04-09                                      |
+| GPT-4.5-Preview-2025-02-27                        | Function Calling | OpenAI         | gpt-4.5-preview-2025-02-27-FC                               |
+| GPT-4.5-Preview-2025-02-27                        | Prompt           | OpenAI         | gpt-4.5-preview-2025-02-27                                  |
+| GPT-4o-2024-11-20                                 | Function Calling | OpenAI         | gpt-4o-2024-11-20-FC                                        |
+| GPT-4o-2024-11-20                                 | Prompt           | OpenAI         | gpt-4o-2024-11-20                                           |
+| GPT-4o-mini-2024-07-18                            | Function Calling | OpenAI         | gpt-4o-mini-2024-07-18-FC                                   |
+| GPT-4o-mini-2024-07-18                            | Prompt           | OpenAI         | gpt-4o-mini-2024-07-18                                      |
+| Granite-20b-FunctionCalling                       | Function Calling | Self-hosted 💻 | ibm-granite/granite-20b-functioncalling                     |
+| Grok-beta                                         | Function Calling | xAI            | grok-beta                                                   |
+| Haha-7B                                           | Prompt           | Self-hosted 💻 | ZJared/Haha-7B                                              |
+| Hammer2.1-{7b,3b,1.5b,0.5b}                       | Function Calling | Self-hosted 💻 | MadeAgents/Hammer2.1-{7b,3b,1.5b,0.5b}                      |
+| Hermes-2-Pro-Llama-3-{8B,70B}                     | Function Calling | Self-hosted 💻 | NousResearch/Hermes-2-Pro-Llama-3-{8B,70B}                  |
+| Hermes-2-Pro-Mistral-7B                           | Function Calling | Self-hosted 💻 | NousResearch/Hermes-2-Pro-Mistral-7B                        |
+| Hermes-2-Theta-Llama-3-{8B,70B}                   | Function Calling | Self-hosted 💻 | NousResearch/Hermes-2-Theta-Llama-3-{8B,70B}                |
+| Llama-3-{8B,70B}-Instruct                         | Function Calling | Self-hosted 💻 | meta-llama/Meta-Llama-3-{8B,70B}-Instruct-FC                |
+| Llama-3.1-{8B,70B}-Instruct                       | Function Calling | Self-hosted 💻 | meta-llama/Llama-3.1-{8B,70B}-Instruct-FC                   |
+| Llama-3.1-{8B,70B}-Instruct                       | Prompt           | Self-hosted 💻 | meta-llama/Llama-3.1-{8B,70B}-Instruct                      |
+| Llama-3.2-{1B,3B}-Instruct                        | Function Calling | Self-hosted 💻 | meta-llama/Llama-3.2-{1B,3B}-Instruct-FC                    |
+| Llama-3.3-70B-Instruct                            | Function Calling | Self-hosted 💻 | meta-llama/Llama-3.3-70B-Instruct-FC                        |
+| meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 | Function Calling | Self-hosted 💻 | meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8-FC        |
+| meta-llama/Llama-4-Scout-17B-16E-Instruct         | Function Calling | Self-hosted 💻 | meta-llama/Llama-4-Scout-17B-16E-Instruct-FC                |
+| MiniCPM3-4B                                       | Prompt           | Self-hosted 💻 | openbmb/MiniCPM3-4B                                         |
+| MiniCPM3-4B-FC                                    | Function Calling | Self-hosted 💻 | openbmb/MiniCPM3-4B-FC                                      |
+| Ministral-8B-Instruct-2410                        | Function Calling | Self-hosted 💻 | mistralai/Ministral-8B-Instruct-2410                        |
+| mistral-large-2407                                | Function Calling | Mistral AI     | mistral-large-2407-FC                                       |
+| mistral-large-2407                                | Prompt           | Mistral AI     | mistral-large-2407                                          |
+| Mistral-Medium-2312                               | Prompt           | Mistral AI     | mistral-medium-2312                                         |
+| Mistral-small-2402                                | Function Calling | Mistral AI     | mistral-small-2402-FC                                       |
+| Mistral-Small-2402                                | Prompt           | Mistral AI     | mistral-small-2402                                          |
+| Mistral-tiny-2312                                 | Prompt           | Mistral AI     | mistral-tiny-2312                                           |
+| Nemotron-4-340b-instruct                          | Prompt           | Nvidia         | nvidia/nemotron-4-340b-instruct                             |
+| Nexusflow-Raven-v2                                | Function Calling | Nexusflow      | Nexusflow-Raven-v2                                          |
+| o1-2024-12-17                                     | Function Calling | OpenAI         | o1-2024-12-17-FC                                            |
+| o1-2024-12-17                                     | Prompt           | OpenAI         | o1-2024-12-17                                               |
+| o3-mini-2025-01-31                                | Function Calling | OpenAI         | o3-mini-2025-01-31-FC                                       |
+| o3-mini-2025-01-31                                | Prompt           | OpenAI         | o3-mini-2025-01-31                                          |
+| Open-Mistral-Nemo-2407                            | Prompt           | Mistral AI     | open-mistral-nemo-2407                                      |
+| Open-Mistral-Nemo-2407                            | Function Calling | Mistral AI     | open-mistral-nemo-2407-FC                                   |
+| Open-Mixtral-{8x7b,8x22b}                         | Prompt           | Mistral AI     | open-mixtral-{8x7b,8x22b}                                   |
+| Open-Mixtral-8x22b                                | Function Calling | Mistral AI     | open-mixtral-8x22b-FC                                       |
+| palmyra-x-004                                     | Function Calling | Writer         | palmyra-x-004                                               |
+| Phi-3-medium-{4k,128k}-instruct                   | Prompt           | Self-hosted 💻 | microsoft/Phi-3-medium-{4k,128k}-instruct                   |
+| Phi-3-mini-{4k,128k}-instruct                     | Prompt           | Self-hosted 💻 | microsoft/Phi-3-mini-{4k,128k}-instruct                     |
+| Phi-3-small-{8k,128k}-instruct                    | Prompt           | Self-hosted 💻 | microsoft/Phi-3-small-{8k,128k}-instruct                    |
+| Phi-3.5-mini-instruct                             | Prompt           | Self-hosted 💻 | microsoft/Phi-3.5-mini-instruct                             |
+| Qwen2-{1.5B,7B}-Instruct                          | Prompt           | Self-hosted 💻 | Qwen/Qwen2-{1.5B,7B}-Instruct                               |
+| Qwen2.5-{0.5B,1.5B,3B,7B,14B,32B,72B}-Instruct    | Prompt           | Self-hosted 💻 | Qwen/Qwen2.5-{0.5B,1.5B,3B,7B,14B,32B,72B}-Instruct         |
+| Qwen2.5-{0.5B,1.5B,3B,7B,14B,32B,72B}-Instruct    | Function Calling | Self-hosted 💻 | Qwen/Qwen2.5-{0.5B,1.5B,3B,7B,14B,32B,72B}-Instruct-FC      |
+| QwQ-32B-Preview                                   | Prompt           | Self-hosted 💻 | Qwen/QwQ-32B-Preview                                        |
+| Sky-T1-32B-Preview                                | Prompt           | Self-hosted 💻 | NovaSky-AI/Sky-T1-32B-Preview                               |
+| Snowflake/snowflake-arctic-instruct               | Prompt           | Snowflake      | snowflake/arctic                                            |
+| ToolACE-2-8B                                      | Function Calling | Self-hosted 💻 | Team-ACE/ToolACE-2-8B                                       |
+| ToolACE-8B                                        | Function Calling | Self-hosted 💻 | Team-ACE/ToolACE-8B                                         |
+| watt-tool-{8B,70B}                                | Function Calling | Self-hosted 💻 | watt-ai/watt-tool-{8B,70B}                                  |
+| xLAM-2-70b-fc-r                                   | Function Calling | Self-hosted 💻 | Salesforce/Llama-xLAM-2-70b-fc-r                            |
+| xLAM-2-32b-fc-r                                   | Function Calling | Self-hosted 💻 | Salesforce/xLAM-2-32b-fc-r                                  |
+| xLAM-2-8b-fc-r                                    | Function Calling | Self-hosted 💻 | Salesforce/Llama-xLAM-2-8b-fc-r                             |
+| xLAM-2-3b-fc-r                                    | Function Calling | Self-hosted 💻 | Salesforce/xLAM-2-3b-fc-r                                   |
+| xLAM-2-1b-fc-r                                    | Function Calling | Self-hosted 💻 | Salesforce/xLAM-2-1b-fc-r                                   |
+| yi-large                                          | Function Calling | 01.AI          | yi-large-fc                                                 |
 
 ---
 

--- a/berkeley-function-call-leaderboard/bfcl/constants/model_metadata.py
+++ b/berkeley-function-call-leaderboard/bfcl/constants/model_metadata.py
@@ -516,14 +516,14 @@ MODEL_METADATA_MAPPING = {
         "NousResearch",
         "apache-2.0",
     ],
-    "meta-llama/Meta-Llama-3-8B-Instruct": [
-        "Meta-Llama-3-8B-Instruct (Prompt)",
+    "meta-llama/Meta-Llama-3-8B-Instruct-FC": [
+        "Meta-Llama-3-8B-Instruct (FC)",
         "https://llama.meta.com/llama3",
         "Meta",
         "Meta Llama 3 Community",
     ],
-    "meta-llama/Meta-Llama-3-70B-Instruct": [
-        "Meta-Llama-3-70B-Instruct (Prompt)",
+    "meta-llama/Meta-Llama-3-70B-Instruct-FC": [
+        "Meta-Llama-3-70B-Instruct (FC)",
         "https://llama.meta.com/llama3",
         "Meta",
         "Meta Llama 3 Community",
@@ -540,14 +540,14 @@ MODEL_METADATA_MAPPING = {
         "Meta",
         "Meta Llama 3 Community",
     ],
-    "meta-llama/Llama-3.2-1B-Instruct": [
-        "Llama-3.2-1B-Instruct (Prompt)",
+    "meta-llama/Llama-3.2-1B-Instruct-FC": [
+        "Llama-3.2-1B-Instruct (FC)",
         "https://llama.meta.com/llama3",
         "Meta",
         "Meta Llama 3 Community",
     ],
-    "meta-llama/Llama-3.2-3B-Instruct": [
-        "Llama-3.2-3B-Instruct (Prompt)",
+    "meta-llama/Llama-3.2-3B-Instruct-FC": [
+        "Llama-3.2-3B-Instruct (FC)",
         "https://llama.meta.com/llama3",
         "Meta",
         "Meta Llama 3 Community",
@@ -564,17 +564,23 @@ MODEL_METADATA_MAPPING = {
         "Meta",
         "Meta Llama 3 Community",
     ],
-    "meta-llama/Llama-3.3-70B-Instruct": [
-        "Llama-3.3-70B-Instruct (Prompt)",
-        "https://llama.meta.com/llama3",
-        "Meta",
-        "Meta Llama 3 Community",
-    ],
     "meta-llama/Llama-3.3-70B-Instruct-FC": [
         "Llama-3.3-70B-Instruct (FC)",
         "https://llama.meta.com/llama3",
         "Meta",
         "Meta Llama 3 Community",
+    ],
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8-FC": [
+        "Llama-4-Maverick-17B-128E-Instruct-FP8 (FC)",
+        "https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+        "Meta",
+        "Meta Llama 4 Community",
+    ],
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct-FC": [
+        "Llama-4-Scout-17B-16E-Instruct (FC)",
+        "https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
+        "Meta",
+        "Meta Llama 4 Community",
     ],
     "command-r-plus-FC": [
         "Command-R-Plus (FC)",

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/handler_map.py
@@ -27,7 +27,7 @@ from bfcl.model_handler.local_inference.granite import GraniteHandler
 from bfcl.model_handler.local_inference.hammer import HammerHandler
 from bfcl.model_handler.local_inference.hermes import HermesHandler
 from bfcl.model_handler.local_inference.llama import LlamaHandler
-from bfcl.model_handler.local_inference.llama_fc import LlamaFCHandler
+from bfcl.model_handler.local_inference.llama_3_1 import LlamaHandler_3_1
 from bfcl.model_handler.local_inference.minicpm import MiniCPMHandler
 from bfcl.model_handler.local_inference.minicpm_fc import MiniCPMFCHandler
 from bfcl.model_handler.local_inference.mistral_fc import MistralFCHandler
@@ -111,16 +111,17 @@ local_inference_handler_map = {
     "google/gemma-3-4b-it": GemmaHandler,
     "google/gemma-3-12b-it": GemmaHandler,
     "google/gemma-3-27b-it": GemmaHandler,
-    "meta-llama/Meta-Llama-3-8B-Instruct": LlamaHandler,
-    "meta-llama/Meta-Llama-3-70B-Instruct": LlamaHandler,
-    "meta-llama/Llama-3.1-8B-Instruct-FC": LlamaFCHandler,
+    "meta-llama/Meta-Llama-3-8B-Instruct-FC": LlamaHandler,
+    "meta-llama/Meta-Llama-3-70B-Instruct-FC": LlamaHandler,
+    "meta-llama/Llama-3.1-8B-Instruct-FC": LlamaHandler_3_1,
     "meta-llama/Llama-3.1-8B-Instruct": LlamaHandler,
-    "meta-llama/Llama-3.1-70B-Instruct-FC": LlamaFCHandler,
+    "meta-llama/Llama-3.1-70B-Instruct-FC": LlamaHandler_3_1,
     "meta-llama/Llama-3.1-70B-Instruct": LlamaHandler,
-    "meta-llama/Llama-3.2-1B-Instruct": LlamaHandler,
-    "meta-llama/Llama-3.2-3B-Instruct": LlamaHandler,
-    "meta-llama/Llama-3.3-70B-Instruct-FC": LlamaFCHandler,
-    "meta-llama/Llama-3.3-70B-Instruct": LlamaHandler,
+    "meta-llama/Llama-3.2-1B-Instruct-FC": LlamaHandler,
+    "meta-llama/Llama-3.2-3B-Instruct-FC": LlamaHandler,
+    "meta-llama/Llama-3.3-70B-Instruct-FC": LlamaHandler,
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct-FC": LlamaHandler,
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8-FC": LlamaHandler,
     "Salesforce/Llama-xLAM-2-70b-fc-r": SalesforceLlamaHandler,
     "Salesforce/Llama-xLAM-2-8b-fc-r": SalesforceLlamaHandler,
     "Salesforce/xLAM-2-32b-fc-r": SalesforceQwenHandler,

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/llama.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/llama.py
@@ -2,20 +2,56 @@ from bfcl.model_handler.local_inference.base_oss_handler import OSSHandler
 from overrides import override
 
 
-# Note: This is the handler for the Llama models in prompring mode.
-# For function call mode, use LlamaFCHandler instead.
-# Llama 3 series are benchmarked in prompting mode while the Llama 3.1 and 3.3 series are benchmarked in function call mode.
 class LlamaHandler(OSSHandler):
+    """
+    This the handler for the Llama models in function calling mode.
+    According to the Llama model card, function calling should be handled differently
+    than what is suggested by the standard Hugging Face chat template. 
+    For more details, see: 
+    https://www.llama.com/docs/model-cards-and-prompt-formats/llama4_omni/#-zero-shot-function-calling---system-message-
+    This applies to all Llama 3 and Llama 4 series models, except for Llama 3.1.
+    
+    In addition, because Llama uses the same system prompt as the default BFCL system
+    prompt that's normally provided to the model in "prompt mode", the constructed 
+    formatted prompt string remains same in both modes. 
+    As a result, we will not have separate "prompt mode" for Llama models to avoid confusion.
+    """
+
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)
 
     @override
     def _format_prompt(self, messages, function):
-        formatted_prompt = "<|begin_of_text|>"
+        # For Llama 4 series, they use a different set of tokens than Llama 3
+        if "Llama-4" in self.model_name:
+            formatted_prompt = "<|begin_of_text|>"
 
-        for message in messages:
-            formatted_prompt += f"<|start_header_id|>{message['role']}<|end_header_id|>\n\n{message['content'].strip()}<|eot_id|>"
+            for message in messages:
+                formatted_prompt += f"<|header_start|>{message['role']}<|header_end|>\n\n{message['content'].strip()}<|eot|>"
 
-        formatted_prompt += f"<|start_header_id|>assistant<|end_header_id|>\n\n"
+            formatted_prompt += f"<|header_start|>assistant<|header_end|>\n\n"
+        # For Llama 3 series
+        else:
+            formatted_prompt = "<|begin_of_text|>"
+
+            for message in messages:
+                formatted_prompt += f"<|start_header_id|>{message['role']}<|end_header_id|>\n\n{message['content'].strip()}<|eot_id|>"
+
+            formatted_prompt += f"<|start_header_id|>assistant<|end_header_id|>\n\n"
 
         return formatted_prompt
+
+    @override
+    def _add_execution_results_prompting(
+        self, inference_data: dict, execution_results: list[str], model_response_data: dict
+    ) -> dict:
+        for execution_result in execution_results:
+            # Llama uses the `ipython` role for execution results
+            inference_data["message"].append(
+                {
+                    "role": "ipython",
+                    "content": execution_result,
+                }
+            )
+
+        return inference_data

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/llama.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/llama.py
@@ -19,6 +19,7 @@ class LlamaHandler(OSSHandler):
 
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)
+        self.model_name_huggingface = model_name.replace("-FC", "")
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/llama_3_1.py
+++ b/berkeley-function-call-leaderboard/bfcl/model_handler/local_inference/llama_3_1.py
@@ -5,7 +5,15 @@ from bfcl.model_handler.utils import func_doc_language_specific_pre_processing
 from overrides import override
 
 
-class LlamaFCHandler(OSSHandler):
+class LlamaHandler_3_1(OSSHandler):
+    """
+    Handler for Llama 3.1 series models in function calling mode.
+    Per their model card, function calling is handled in the same way as
+    the Hugging Face chat template suggests.
+    https://www.llama.com/docs/model-cards-and-prompt-formats/llama3_1/#json-based-tool-calling
+    
+    For all other Llama models, see the LlamaHandler class.
+    """
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)
         self.model_name_huggingface = model_name.replace("-FC", "")


### PR DESCRIPTION
Address #978 

This PR adds support for the following models, with self-hosted inference method:
  - `meta-llama/Llama-4-Scout-17B-16E-Instruct-FC`
  - `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8-FC`