### PR TITLE
Bump `writer-sdk` Dependency Version

### DIFF
--- a/berkeley-function-call-leaderboard/pyproject.toml
+++ b/berkeley-function-call-leaderboard/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "google-cloud-aiplatform==1.84.0",
     "mpmath==1.3.0",
     "tenacity==9.0.0",
-    "writer-sdk>=1.2.0",
+    "writer-sdk>=2.1.0",
     "overrides",
     "boto3"
 ]


### PR DESCRIPTION
This PR bumps the `writer-sdk` version to `2.1.0` to solve the following error, which has recently appeared. 
```
Traceback (most recent call last):
  ....
  File ".../gorilla/berkeley-function-call-leaderboard/bfcl/model_handler/api_inference/writer.py", line 13, in __init__
    self.client = Writer(api_key=os.getenv("WRITER_API_KEY"))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/lib/python3.11/site-packages/writerai/_client.py", line 102, in __init__
    super().__init__(
  File "/opt/anaconda3/lib/python3.11/site-packages/writerai/_base_client.py", line 858, in __init__
    self._client = http_client or SyncHttpxClientWrapper(
                                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/lib/python3.11/site-packages/writerai/_base_client.py", line 756, in __init__
    super().__init__(**kwargs)
TypeError: Client.__init__() got an unexpected keyword argument 'proxies'
```