### PR TITLE
Migrate to correct testing API

### DIFF
--- a/gorilla/eval/eval-scripts/codebleu/parser/tree-sitter-python/examples/python2-grammar-crlf.py
+++ b/gorilla/eval/eval-scripts/codebleu/parser/tree-sitter-python/examples/python2-grammar-crlf.py
@@ -20,21 +20,21 @@ class TokenTests(unittest.TestCase):
         # Backslash means line continuation:
         x = 1 \
         + 1
-        self.assertEquals(x, 2, 'backslash for line continuation')
+        self.assertEqual(x, 2, 'backslash for line continuation')
 
         # Backslash does not means continuation in comments :\
         x = 0
-        self.assertEquals(x, 0, 'backslash ending comment')
+        self.assertEqual(x, 0, 'backslash ending comment')
 
     def testPlainIntegers(self):
-        self.assertEquals(0xff, 255)
-        self.assertEquals(0377, 255)
-        self.assertEquals(2147483647, 017777777777)
+        self.assertEqual(0xff, 255)
+        self.assertEqual(0377, 255)
+        self.assertEqual(2147483647, 017777777777)
         # "0x" is not a valid literal
         self.assertRaises(SyntaxError, eval, "0x")
         from sys import maxint
         if maxint == 2147483647:
-            self.assertEquals(-2147483647-1, -020000000000)
+            self.assertEqual(-2147483647-1, -020000000000)
             # XXX -2147483648
             self.assert_(037777777777 > 0)
             self.assert_(0xffffffff > 0)
@@ -44,7 +44,7 @@ class TokenTests(unittest.TestCase):
                 except OverflowError:
                     self.fail("OverflowError on huge integer literal %r" % s)
         elif maxint == 9223372036854775807:
-            self.assertEquals(-9223372036854775807-1, -01000000000000000000000)
+            self.assertEqual(-9223372036854775807-1, -01000000000000000000000)
             self.assert_(01777777777777777777777 > 0)
             self.assert_(0xffffffffffffffff > 0)
             for s in '9223372036854775808', '02000000000000000000000','0x10000000000000000':
@@ -112,18 +112,18 @@ class GrammarTests(unittest.TestCase):
         def f3(two, arguments): pass
         def f4(two, (compound, (argument, list))): pass
         def f5((compound, first), two): pass
-        self.assertEquals(f2.func_code.co_varnames, ('one_argument',))
-        self.assertEquals(f3.func_code.co_varnames, ('two', 'arguments'))
+        self.assertEqual(f2.func_code.co_varnames, ('one_argument',))
+        self.assertEqual(f3.func_code.co_varnames, ('two', 'arguments'))
         if sys.platform.startswith('java'):
-            self.assertEquals(f4.func_code.co_varnames,
+            self.assertEqual(f4.func_code.co_varnames,
                    ('two', '(compound, (argument, list))', 'compound', 'argument',
                                 'list',))
-            self.assertEquals(f5.func_code.co_varnames,
+            self.assertEqual(f5.func_code.co_varnames,
                    ('(compound, first)', 'two', 'compound', 'first'))
         else:
-            self.assertEquals(f4.func_code.co_varnames,
+            self.assertEqual(f4.func_code.co_varnames,
                   ('two', '.1', 'compound', 'argument',  'list'))
-            self.assertEquals(f5.func_code.co_varnames,
+            self.assertEqual(f5.func_code.co_varnames,
                   ('.0', 'two', 'compound', 'first'))
         def a1(one_arg,): pass
         def a2(two, args,): pass
@@ -159,10 +159,10 @@ class GrammarTests(unittest.TestCase):
         # ceval unpacks the formal arguments into the first argcount names;
         # thus, the names nested inside tuples must appear after these names.
         if sys.platform.startswith('java'):
-            self.assertEquals(v3.func_code.co_varnames, ('a', '(b, c)', 'rest', 'b', 'c'))
+            self.assertEqual(v3.func_code.co_varnames, ('a', '(b, c)', 'rest', 'b', 'c'))
         else:
-            self.assertEquals(v3.func_code.co_varnames, ('a', '.1', 'rest', 'b', 'c'))
-        self.assertEquals(v3(1, (2, 3), 4), (1, 2, 3, (4,)))
+            self.assertEqual(v3.func_code.co_varnames, ('a', '.1', 'rest', 'b', 'c'))
+        self.assertEqual(v3(1, (2, 3), 4), (1, 2, 3, (4,)))
         def d01(a=1): pass
         d01()
         d01(1)
@@ -243,7 +243,7 @@ class GrammarTests(unittest.TestCase):
         # keyword arguments after *arglist
         def f(*args, **kwargs):
             return args, kwargs
-        self.assertEquals(f(1, x=2, *[3, 4], y=5), ((1, 3, 4),
+        self.assertEqual(f(1, x=2, *[3, 4], y=5), ((1, 3, 4),
                                                     {'x':2, 'y':5}))
         self.assertRaises(SyntaxError, eval, "f(1, *(2,3), 4)")
         self.assertRaises(SyntaxError, eval, "f(1, x=2, *(3,4), x=5)")
@@ -255,15 +255,15 @@ class GrammarTests(unittest.TestCase):
     def testLambdef(self):
         ### lambdef: 'lambda' [varargslist] ':' test
         l1 = lambda : 0
-        self.assertEquals(l1(), 0)
+        self.assertEqual(l1(), 0)
         l2 = lambda : a[d] # XXX just testing the expression
         l3 = lambda : [2 < x for x in [-1, 3, 0L]]
-        self.assertEquals(l3(), [0, 1, 0])
+        self.assertEqual(l3(), [0, 1, 0])
         l4 = lambda x = lambda y = lambda z=1 : z : y() : x()
-        self.assertEquals(l4(), 1)
+        self.assertEqual(l4(), 1)
         l5 = lambda x, y, z=2: x + y + z
-        self.assertEquals(l5(1, 2), 5)
-        self.assertEquals(l5(1, 2, 3), 6)
+        self.assertEqual(l5(1, 2), 5)
+        self.assertEqual(l5(1, 2, 3), 6)
         check_syntax_error(self, "lambda x: x = 2")
         check_syntax_error(self, "lambda (None,): None")
 
@@ -516,7 +516,7 @@ hello world
         try:
             assert 0, "msg"
         except AssertionError, e:
-            self.assertEquals(e.args[0], "msg")
+            self.assertEqual(e.args[0], "msg")
         else:
             if __debug__:
                 self.fail("AssertionError not raised by assert 0")
@@ -550,7 +550,7 @@ hello world
             x = 1
         else:
             x = 2
-        self.assertEquals(x, 2)
+        self.assertEqual(x, 2)
 
     def testFor(self):
         # 'for' exprlist 'in' exprlist ':' suite ['else' ':' suite]
@@ -703,7 +703,7 @@ hello world
         d[1,2,3] = 4
         L = list(d)
         L.sort()
-        self.assertEquals(str(L), '[1, (1,), (1, 2), (1, 2, 3)]')
+        self.assertEqual(str(L), '[1, (1,), (1, 2), (1, 2, 3)]')
 
     def testAtoms(self):
         ### atom: '(' [testlist] ')' | '[' [testlist] ']' | '{' [dictmaker] '}' | '`' testlist '`' | NAME | NUMBER | STRING
@@ -941,28 +941,28 @@ jumps over
 the 'lazy' dog.
 """
         y = '\nThe "quick"\nbrown fox\njumps over\nthe \'lazy\' dog.\n'
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = '''
 The "quick"
 brown fox
 jumps over
 the 'lazy' dog.
 '''
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = "\n\
 The \"quick\"\n\
 brown fox\n\
 jumps over\n\
 the 'lazy' dog.\n\
 "
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = '\n\
 The \"quick\"\n\
 brown fox\n\
 jumps over\n\
 the \'lazy\' dog.\n\
 '
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
 
 
 

--- a/gorilla/eval/eval-scripts/codebleu/parser/tree-sitter-python/examples/python2-grammar.py
+++ b/gorilla/eval/eval-scripts/codebleu/parser/tree-sitter-python/examples/python2-grammar.py
@@ -20,21 +20,21 @@ class TokenTests(unittest.TestCase):
         # Backslash means line continuation:
         x = 1 \
         + 1
-        self.assertEquals(x, 2, 'backslash for line continuation')
+        self.assertEqual(x, 2, 'backslash for line continuation')
 
         # Backslash does not means continuation in comments :\
         x = 0
-        self.assertEquals(x, 0, 'backslash ending comment')
+        self.assertEqual(x, 0, 'backslash ending comment')
 
     def testPlainIntegers(self):
-        self.assertEquals(0xff, 255)
-        self.assertEquals(0377, 255)
-        self.assertEquals(2147483647, 017777777777)
+        self.assertEqual(0xff, 255)
+        self.assertEqual(0377, 255)
+        self.assertEqual(2147483647, 017777777777)
         # "0x" is not a valid literal
         self.assertRaises(SyntaxError, eval, "0x")
         from sys import maxint
         if maxint == 2147483647:
-            self.assertEquals(-2147483647-1, -020000000000)
+            self.assertEqual(-2147483647-1, -020000000000)
             # XXX -2147483648
             self.assert_(037777777777 > 0)
             self.assert_(0xffffffff > 0)
@@ -44,7 +44,7 @@ class TokenTests(unittest.TestCase):
                 except OverflowError:
                     self.fail("OverflowError on huge integer literal %r" % s)
         elif maxint == 9223372036854775807:
-            self.assertEquals(-9223372036854775807-1, -01000000000000000000000)
+            self.assertEqual(-9223372036854775807-1, -01000000000000000000000)
             self.assert_(01777777777777777777777 > 0)
             self.assert_(0xffffffffffffffff > 0)
             for s in '9223372036854775808', '02000000000000000000000', \
@@ -113,18 +113,18 @@ class GrammarTests(unittest.TestCase):
         def f3(two, arguments): pass
         def f4(two, (compound, (argument, list))): pass
         def f5((compound, first), two): pass
-        self.assertEquals(f2.func_code.co_varnames, ('one_argument',))
-        self.assertEquals(f3.func_code.co_varnames, ('two', 'arguments'))
+        self.assertEqual(f2.func_code.co_varnames, ('one_argument',))
+        self.assertEqual(f3.func_code.co_varnames, ('two', 'arguments'))
         if sys.platform.startswith('java'):
-            self.assertEquals(f4.func_code.co_varnames,
+            self.assertEqual(f4.func_code.co_varnames,
                    ('two', '(compound, (argument, list))', 'compound', 'argument',
                                 'list',))
-            self.assertEquals(f5.func_code.co_varnames,
+            self.assertEqual(f5.func_code.co_varnames,
                    ('(compound, first)', 'two', 'compound', 'first'))
         else:
-            self.assertEquals(f4.func_code.co_varnames,
+            self.assertEqual(f4.func_code.co_varnames,
                   ('two', '.1', 'compound', 'argument',  'list'))
-            self.assertEquals(f5.func_code.co_varnames,
+            self.assertEqual(f5.func_code.co_varnames,
                   ('.0', 'two', 'compound', 'first'))
         def a1(one_arg,): pass
         def a2(two, args,): pass
@@ -160,10 +160,10 @@ class GrammarTests(unittest.TestCase):
         # ceval unpacks the formal arguments into the first argcount names;
         # thus, the names nested inside tuples must appear after these names.
         if sys.platform.startswith('java'):
-            self.assertEquals(v3.func_code.co_varnames, ('a', '(b, c)', 'rest', 'b', 'c'))
+            self.assertEqual(v3.func_code.co_varnames, ('a', '(b, c)', 'rest', 'b', 'c'))
         else:
-            self.assertEquals(v3.func_code.co_varnames, ('a', '.1', 'rest', 'b', 'c'))
-        self.assertEquals(v3(1, (2, 3), 4), (1, 2, 3, (4,)))
+            self.assertEqual(v3.func_code.co_varnames, ('a', '.1', 'rest', 'b', 'c'))
+        self.assertEqual(v3(1, (2, 3), 4), (1, 2, 3, (4,)))
         def d01(a=1): pass
         d01()
         d01(1)
@@ -244,7 +244,7 @@ class GrammarTests(unittest.TestCase):
         # keyword arguments after *arglist
         def f(*args, **kwargs):
             return args, kwargs
-        self.assertEquals(f(1, x=2, *[3, 4], y=5), ((1, 3, 4),
+        self.assertEqual(f(1, x=2, *[3, 4], y=5), ((1, 3, 4),
                                                     {'x':2, 'y':5}))
         self.assertRaises(SyntaxError, eval, "f(1, *(2,3), 4)")
         self.assertRaises(SyntaxError, eval, "f(1, x=2, *(3,4), x=5)")
@@ -256,15 +256,15 @@ class GrammarTests(unittest.TestCase):
     def testLambdef(self):
         ### lambdef: 'lambda' [varargslist] ':' test
         l1 = lambda : 0
-        self.assertEquals(l1(), 0)
+        self.assertEqual(l1(), 0)
         l2 = lambda : a[d] # XXX just testing the expression
         l3 = lambda : [2 < x for x in [-1, 3, 0L]]
-        self.assertEquals(l3(), [0, 1, 0])
+        self.assertEqual(l3(), [0, 1, 0])
         l4 = lambda x = lambda y = lambda z=1 : z : y() : x()
-        self.assertEquals(l4(), 1)
+        self.assertEqual(l4(), 1)
         l5 = lambda x, y, z=2: x + y + z
-        self.assertEquals(l5(1, 2), 5)
-        self.assertEquals(l5(1, 2, 3), 6)
+        self.assertEqual(l5(1, 2), 5)
+        self.assertEqual(l5(1, 2, 3), 6)
         check_syntax_error(self, "lambda x: x = 2")
         check_syntax_error(self, "lambda (None,): None")
 
@@ -517,7 +517,7 @@ hello world
         try:
             assert 0, "msg"
         except AssertionError, e:
-            self.assertEquals(e.args[0], "msg")
+            self.assertEqual(e.args[0], "msg")
         else:
             if __debug__:
                 self.fail("AssertionError not raised by assert 0")
@@ -551,7 +551,7 @@ hello world
             x = 1
         else:
             x = 2
-        self.assertEquals(x, 2)
+        self.assertEqual(x, 2)
 
     def testFor(self):
         # 'for' exprlist 'in' exprlist ':' suite ['else' ':' suite]
@@ -704,7 +704,7 @@ hello world
         d[1,2,3] = 4
         L = list(d)
         L.sort()
-        self.assertEquals(str(L), '[1, (1,), (1, 2), (1, 2, 3)]')
+        self.assertEqual(str(L), '[1, (1,), (1, 2), (1, 2, 3)]')
 
     def testAtoms(self):
         ### atom: '(' [testlist] ')' | '[' [testlist] ']' | '{' [dictmaker] '}' | '`' testlist '`' | NAME | NUMBER | STRING
@@ -942,28 +942,28 @@ jumps over
 the 'lazy' dog.
 """
         y = '\nThe "quick"\nbrown fox\njumps over\nthe \'lazy\' dog.\n'
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = '''
 The "quick"
 brown fox
 jumps over
 the 'lazy' dog.
 '''
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = "\n\
 The \"quick\"\n\
 brown fox\n\
 jumps over\n\
 the 'lazy' dog.\n\
 "
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = '\n\
 The \"quick\"\n\
 brown fox\n\
 jumps over\n\
 the \'lazy\' dog.\n\
 '
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
 
 
 

--- a/gorilla/eval/eval-scripts/codebleu/parser/tree-sitter-python/examples/python3-grammar-crlf.py
+++ b/gorilla/eval/eval-scripts/codebleu/parser/tree-sitter-python/examples/python3-grammar-crlf.py
@@ -20,23 +20,23 @@ class TokenTests(unittest.TestCase):
         # Backslash means line continuation:
         x = 1 \
         + 1
-        self.assertEquals(x, 2, 'backslash for line continuation')
+        self.assertEqual(x, 2, 'backslash for line continuation')
 
         # Backslash does not means continuation in comments :\
         x = 0
-        self.assertEquals(x, 0, 'backslash ending comment')
+        self.assertEqual(x, 0, 'backslash ending comment')
 
     def testPlainIntegers(self):
-        self.assertEquals(type(000), type(0))
-        self.assertEquals(0xff, 255)
-        self.assertEquals(0o377, 255)
-        self.assertEquals(2147483647, 0o17777777777)
-        self.assertEquals(0b1001, 9)
+        self.assertEqual(type(000), type(0))
+        self.assertEqual(0xff, 255)
+        self.assertEqual(0o377, 255)
+        self.assertEqual(2147483647, 0o17777777777)
+        self.assertEqual(0b1001, 9)
         # "0x" is not a valid literal
         self.assertRaises(SyntaxError, eval, "0x")
         from sys import maxsize
         if maxsize == 2147483647:
-            self.assertEquals(-2147483647-1, -0o20000000000)
+            self.assertEqual(-2147483647-1, -0o20000000000)
             # XXX -2147483648
             self.assert_(0o37777777777 > 0)
             self.assert_(0xffffffff > 0)
@@ -48,7 +48,7 @@ class TokenTests(unittest.TestCase):
                 except OverflowError:
                     self.fail("OverflowError on huge integer literal %r" % s)
         elif maxsize == 9223372036854775807:
-            self.assertEquals(-9223372036854775807-1, -0o1000000000000000000000)
+            self.assertEqual(-9223372036854775807-1, -0o1000000000000000000000)
             self.assert_(0o1777777777777777777777 > 0)
             self.assert_(0xffffffffffffffff > 0)
             self.assert_(0b11111111111111111111111111111111111111111111111111111111111111 > 0)
@@ -147,8 +147,8 @@ class GrammarTests(unittest.TestCase):
         f1(*(), **{})
         def f2(one_argument): pass
         def f3(two, arguments): pass
-        self.assertEquals(f2.__code__.co_varnames, ('one_argument',))
-        self.assertEquals(f3.__code__.co_varnames, ('two', 'arguments'))
+        self.assertEqual(f2.__code__.co_varnames, ('one_argument',))
+        self.assertEqual(f3.__code__.co_varnames, ('two', 'arguments'))
         def a1(one_arg,): pass
         def a2(two, args,): pass
         def v0(*rest): pass
@@ -269,37 +269,37 @@ class GrammarTests(unittest.TestCase):
         # keyword arguments after *arglist
         def f(*args, **kwargs):
             return args, kwargs
-        self.assertEquals(f(1, x=2, *[3, 4], y=5), ((1, 3, 4),
+        self.assertEqual(f(1, x=2, *[3, 4], y=5), ((1, 3, 4),
                                                     {'x':2, 'y':5}))
         self.assertRaises(SyntaxError, eval, "f(1, *(2,3), 4)")
         self.assertRaises(SyntaxError, eval, "f(1, x=2, *(3,4), x=5)")
 
         # argument annotation tests
         def f(x) -> list: pass
-        self.assertEquals(f.__annotations__, {'return': list})
+        self.assertEqual(f.__annotations__, {'return': list})
         def f(x:int): pass
-        self.assertEquals(f.__annotations__, {'x': int})
+        self.assertEqual(f.__annotations__, {'x': int})
         def f(*x:str): pass
-        self.assertEquals(f.__annotations__, {'x': str})
+        self.assertEqual(f.__annotations__, {'x': str})
         def f(**x:float): pass
-        self.assertEquals(f.__annotations__, {'x': float})
+        self.assertEqual(f.__annotations__, {'x': float})
         def f(x, y:1+2): pass
-        self.assertEquals(f.__annotations__, {'y': 3})
+        self.assertEqual(f.__annotations__, {'y': 3})
         def f(a, b:1, c:2, d): pass
-        self.assertEquals(f.__annotations__, {'b': 1, 'c': 2})
+        self.assertEqual(f.__annotations__, {'b': 1, 'c': 2})
         def f(a, b:1, c:2, d, e:3=4, f=5, *g:6): pass
-        self.assertEquals(f.__annotations__,
+        self.assertEqual(f.__annotations__,
                           {'b': 1, 'c': 2, 'e': 3, 'g': 6})
         def f(a, b:1, c:2, d, e:3=4, f=5, *g:6, h:7, i=8, j:9=10,
               **k:11) -> 12: pass
-        self.assertEquals(f.__annotations__,
+        self.assertEqual(f.__annotations__,
                           {'b': 1, 'c': 2, 'e': 3, 'g': 6, 'h': 7, 'j': 9,
                            'k': 11, 'return': 12})
         # Check for SF Bug #1697248 - mixing decorators and a return annotation
         def null(x): return x
         @null
         def f(x) -> list: pass
-        self.assertEquals(f.__annotations__, {'return': list})
+        self.assertEqual(f.__annotations__, {'return': list})
 
         # test closures with a variety of oparg's
         closure = 1
@@ -315,20 +315,20 @@ class GrammarTests(unittest.TestCase):
     def testLambdef(self):
         ### lambdef: 'lambda' [varargslist] ':' test
         l1 = lambda : 0
-        self.assertEquals(l1(), 0)
+        self.assertEqual(l1(), 0)
         l2 = lambda : a[d] # XXX just testing the expression
         l3 = lambda : [2 < x for x in [-1, 3, 0]]
-        self.assertEquals(l3(), [0, 1, 0])
+        self.assertEqual(l3(), [0, 1, 0])
         l4 = lambda x = lambda y = lambda z=1 : z : y() : x()
-        self.assertEquals(l4(), 1)
+        self.assertEqual(l4(), 1)
         l5 = lambda x, y, z=2: x + y + z
-        self.assertEquals(l5(1, 2), 5)
-        self.assertEquals(l5(1, 2, 3), 6)
+        self.assertEqual(l5(1, 2), 5)
+        self.assertEqual(l5(1, 2, 3), 6)
         check_syntax_error(self, "lambda x: x = 2")
         check_syntax_error(self, "lambda (None,): None")
         l6 = lambda x, y, *, k=20: x+y+k
-        self.assertEquals(l6(1,2), 1+2+20)
-        self.assertEquals(l6(1,2,k=10), 1+2+10)
+        self.assertEqual(l6(1,2), 1+2+20)
+        self.assertEqual(l6(1,2,k=10), 1+2+10)
 
 
     ### stmt: simple_stmt | compound_stmt
@@ -484,7 +484,7 @@ class GrammarTests(unittest.TestCase):
         try:
             assert 0, "msg"
         except AssertionError as e:
-            self.assertEquals(e.args[0], "msg")
+            self.assertEqual(e.args[0], "msg")
         else:
             if __debug__:
                 self.fail("AssertionError not raised by assert 0")
@@ -518,7 +518,7 @@ class GrammarTests(unittest.TestCase):
             x = 1
         else:
             x = 2
-        self.assertEquals(x, 2)
+        self.assertEqual(x, 2)
 
     def testFor(self):
         # 'for' exprlist 'in' exprlist ':' suite ['else' ':' suite]
@@ -670,7 +670,7 @@ class GrammarTests(unittest.TestCase):
         d[1,2,3] = 4
         L = list(d)
         L.sort(key=lambda x: x if isinstance(x, tuple) else ())
-        self.assertEquals(str(L), '[1, (1,), (1, 2), (1, 2, 3)]')
+        self.assertEqual(str(L), '[1, (1,), (1, 2), (1, 2, 3)]')
 
     def testAtoms(self):
         ### atom: '(' [testlist] ')' | '[' [testlist] ']' | '{' [dictsetmaker] '}' | NAME | NUMBER | STRING
@@ -914,28 +914,28 @@ jumps over
 the 'lazy' dog.
 """
         y = '\nThe "quick"\nbrown fox\njumps over\nthe \'lazy\' dog.\n'
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = '''
 The "quick"
 brown fox
 jumps over
 the 'lazy' dog.
 '''
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = "\n\
 The \"quick\"\n\
 brown fox\n\
 jumps over\n\
 the 'lazy' dog.\n\
 "
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = '\n\
 The \"quick\"\n\
 brown fox\n\
 jumps over\n\
 the \'lazy\' dog.\n\
 '
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
 
 
 def test_main():

--- a/gorilla/eval/eval-scripts/codebleu/parser/tree-sitter-python/examples/python3-grammar.py
+++ b/gorilla/eval/eval-scripts/codebleu/parser/tree-sitter-python/examples/python3-grammar.py
@@ -20,23 +20,23 @@ class TokenTests(unittest.TestCase):
         # Backslash means line continuation:
         x = 1 \
         + 1
-        self.assertEquals(x, 2, 'backslash for line continuation')
+        self.assertEqual(x, 2, 'backslash for line continuation')
 
         # Backslash does not means continuation in comments :\
         x = 0
-        self.assertEquals(x, 0, 'backslash ending comment')
+        self.assertEqual(x, 0, 'backslash ending comment')
 
     def testPlainIntegers(self):
-        self.assertEquals(type(000), type(0))
-        self.assertEquals(0xff, 255)
-        self.assertEquals(0o377, 255)
-        self.assertEquals(2147483647, 0o17777777777)
-        self.assertEquals(0b1001, 9)
+        self.assertEqual(type(000), type(0))
+        self.assertEqual(0xff, 255)
+        self.assertEqual(0o377, 255)
+        self.assertEqual(2147483647, 0o17777777777)
+        self.assertEqual(0b1001, 9)
         # "0x" is not a valid literal
         self.assertRaises(SyntaxError, eval, "0x")
         from sys import maxsize
         if maxsize == 2147483647:
-            self.assertEquals(-2147483647-1, -0o20000000000)
+            self.assertEqual(-2147483647-1, -0o20000000000)
             # XXX -2147483648
             self.assert_(0o37777777777 > 0)
             self.assert_(0xffffffff > 0)
@@ -48,7 +48,7 @@ class TokenTests(unittest.TestCase):
                 except OverflowError:
                     self.fail("OverflowError on huge integer literal %r" % s)
         elif maxsize == 9223372036854775807:
-            self.assertEquals(-9223372036854775807-1, -0o1000000000000000000000)
+            self.assertEqual(-9223372036854775807-1, -0o1000000000000000000000)
             self.assert_(0o1777777777777777777777 > 0)
             self.assert_(0xffffffffffffffff > 0)
             self.assert_(0b11111111111111111111111111111111111111111111111111111111111111 > 0)
@@ -147,8 +147,8 @@ class GrammarTests(unittest.TestCase):
         f1(*(), **{})
         def f2(one_argument): pass
         def f3(two, arguments): pass
-        self.assertEquals(f2.__code__.co_varnames, ('one_argument',))
-        self.assertEquals(f3.__code__.co_varnames, ('two', 'arguments'))
+        self.assertEqual(f2.__code__.co_varnames, ('one_argument',))
+        self.assertEqual(f3.__code__.co_varnames, ('two', 'arguments'))
         def a1(one_arg,): pass
         def a2(two, args,): pass
         def v0(*rest): pass
@@ -269,37 +269,37 @@ class GrammarTests(unittest.TestCase):
         # keyword arguments after *arglist
         def f(*args, **kwargs):
             return args, kwargs
-        self.assertEquals(f(1, x=2, *[3, 4], y=5), ((1, 3, 4),
+        self.assertEqual(f(1, x=2, *[3, 4], y=5), ((1, 3, 4),
                                                     {'x':2, 'y':5}))
         self.assertRaises(SyntaxError, eval, "f(1, *(2,3), 4)")
         self.assertRaises(SyntaxError, eval, "f(1, x=2, *(3,4), x=5)")
 
         # argument annotation tests
         def f(x) -> list: pass
-        self.assertEquals(f.__annotations__, {'return': list})
+        self.assertEqual(f.__annotations__, {'return': list})
         def f(x:int): pass
-        self.assertEquals(f.__annotations__, {'x': int})
+        self.assertEqual(f.__annotations__, {'x': int})
         def f(*x:str): pass
-        self.assertEquals(f.__annotations__, {'x': str})
+        self.assertEqual(f.__annotations__, {'x': str})
         def f(**x:float): pass
-        self.assertEquals(f.__annotations__, {'x': float})
+        self.assertEqual(f.__annotations__, {'x': float})
         def f(x, y:1+2): pass
-        self.assertEquals(f.__annotations__, {'y': 3})
+        self.assertEqual(f.__annotations__, {'y': 3})
         def f(a, b:1, c:2, d): pass
-        self.assertEquals(f.__annotations__, {'b': 1, 'c': 2})
+        self.assertEqual(f.__annotations__, {'b': 1, 'c': 2})
         def f(a, b:1, c:2, d, e:3=4, f=5, *g:6): pass
-        self.assertEquals(f.__annotations__,
+        self.assertEqual(f.__annotations__,
                           {'b': 1, 'c': 2, 'e': 3, 'g': 6})
         def f(a, b:1, c:2, d, e:3=4, f=5, *g:6, h:7, i=8, j:9=10,
               **k:11) -> 12: pass
-        self.assertEquals(f.__annotations__,
+        self.assertEqual(f.__annotations__,
                           {'b': 1, 'c': 2, 'e': 3, 'g': 6, 'h': 7, 'j': 9,
                            'k': 11, 'return': 12})
         # Check for SF Bug #1697248 - mixing decorators and a return annotation
         def null(x): return x
         @null
         def f(x) -> list: pass
-        self.assertEquals(f.__annotations__, {'return': list})
+        self.assertEqual(f.__annotations__, {'return': list})
 
         # test closures with a variety of oparg's
         closure = 1
@@ -315,20 +315,20 @@ class GrammarTests(unittest.TestCase):
     def testLambdef(self):
         ### lambdef: 'lambda' [varargslist] ':' test
         l1 = lambda : 0
-        self.assertEquals(l1(), 0)
+        self.assertEqual(l1(), 0)
         l2 = lambda : a[d] # XXX just testing the expression
         l3 = lambda : [2 < x for x in [-1, 3, 0]]
-        self.assertEquals(l3(), [0, 1, 0])
+        self.assertEqual(l3(), [0, 1, 0])
         l4 = lambda x = lambda y = lambda z=1 : z : y() : x()
-        self.assertEquals(l4(), 1)
+        self.assertEqual(l4(), 1)
         l5 = lambda x, y, z=2: x + y + z
-        self.assertEquals(l5(1, 2), 5)
-        self.assertEquals(l5(1, 2, 3), 6)
+        self.assertEqual(l5(1, 2), 5)
+        self.assertEqual(l5(1, 2, 3), 6)
         check_syntax_error(self, "lambda x: x = 2")
         check_syntax_error(self, "lambda (None,): None")
         l6 = lambda x, y, *, k=20: x+y+k
-        self.assertEquals(l6(1,2), 1+2+20)
-        self.assertEquals(l6(1,2,k=10), 1+2+10)
+        self.assertEqual(l6(1,2), 1+2+20)
+        self.assertEqual(l6(1,2,k=10), 1+2+10)
 
 
     ### stmt: simple_stmt | compound_stmt
@@ -484,7 +484,7 @@ class GrammarTests(unittest.TestCase):
         try:
             assert 0, "msg"
         except AssertionError as e:
-            self.assertEquals(e.args[0], "msg")
+            self.assertEqual(e.args[0], "msg")
         else:
             if __debug__:
                 self.fail("AssertionError not raised by assert 0")
@@ -518,7 +518,7 @@ class GrammarTests(unittest.TestCase):
             x = 1
         else:
             x = 2
-        self.assertEquals(x, 2)
+        self.assertEqual(x, 2)
 
     def testFor(self):
         # 'for' exprlist 'in' exprlist ':' suite ['else' ':' suite]
@@ -670,7 +670,7 @@ class GrammarTests(unittest.TestCase):
         d[1,2,3] = 4
         L = list(d)
         L.sort(key=lambda x: x if isinstance(x, tuple) else ())
-        self.assertEquals(str(L), '[1, (1,), (1, 2), (1, 2, 3)]')
+        self.assertEqual(str(L), '[1, (1,), (1, 2), (1, 2, 3)]')
 
     def testAtoms(self):
         ### atom: '(' [testlist] ')' | '[' [testlist] ']' | '{' [dictsetmaker] '}' | NAME | NUMBER | STRING
@@ -914,28 +914,28 @@ jumps over
 the 'lazy' dog.
 """
         y = '\nThe "quick"\nbrown fox\njumps over\nthe \'lazy\' dog.\n'
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = '''
 The "quick"
 brown fox
 jumps over
 the 'lazy' dog.
 '''
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = "\n\
 The \"quick\"\n\
 brown fox\n\
 jumps over\n\
 the 'lazy' dog.\n\
 "
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
         y = '\n\
 The \"quick\"\n\
 brown fox\n\
 jumps over\n\
 the \'lazy\' dog.\n\
 '
-        self.assertEquals(x, y)
+        self.assertEqual(x, y)
 
 
 def test_main():


### PR DESCRIPTION
# PR Summary
The `assertEquals` method is deprecated and replaced with `assertEqual`. This small PR adjusts sources to changes.