### PR TITLE
[BFCL] Remove latency data for open source models

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/eval_runner_helper.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/eval_runner_helper.py
@@ -102,7 +102,7 @@ def record_cost_latency(leaderboard_table, model_name, model_output_data):
     leaderboard_table[model_name]["latency"]["data"].extend(latency)
 
 
-def get_cost_letency_info(model_name, cost_data, latency_data):
+def get_cost_latency_info(model_name, cost_data, latency_data):
     cost, mean_latency, std_latency, percentile_95_latency = "N/A", "N/A", "N/A", "N/A"
     model_config = MODEL_CONFIG_MAPPING[model_name]
 
@@ -194,7 +194,7 @@ def generate_leaderboard_csv(
 
         cost_data = value.get("cost", {"input_data": [], "output_data": []})
         latency_data = value.get("latency", {"data": []})
-        cost, latency_mean, latency_std, percentile_95_latency = get_cost_letency_info(
+        cost, latency_mean, latency_std, percentile_95_latency = get_cost_latency_info(
             model_name_escaped, cost_data, latency_data
         )
 

--- a/berkeley-function-call-leaderboard/bfcl/eval_checker/eval_runner_helper.py
+++ b/berkeley-function-call-leaderboard/bfcl/eval_checker/eval_runner_helper.py
@@ -106,6 +106,10 @@ def get_cost_letency_info(model_name, cost_data, latency_data):
     cost, mean_latency, std_latency, percentile_95_latency = "N/A", "N/A", "N/A", "N/A"
     model_config = MODEL_CONFIG_MAPPING[model_name]
 
+    if model_config.input_price is None or model_config.output_price is None:
+        # Open source models should not have a cost or latency
+        return "N/A", "N/A", "N/A", "N/A"
+
     if (
         model_config.input_price is not None
         and len(cost_data["input_data"]) > 0
@@ -127,9 +131,6 @@ def get_cost_letency_info(model_name, cost_data, latency_data):
         mean_latency = round(mean_latency, 2)
         std_latency = round(std_latency, 2)
         percentile_95_latency = round(percentile_95_latency, 2)
-
-    if model_config.input_price is None or model_config.output_price is None:
-        cost = "N/A"
 
     return cost, mean_latency, std_latency, percentile_95_latency
 


### PR DESCRIPTION
This PR removes latency statistics for models that do not have a input/output cost (typically open source models). This is because latency for these open source models usually depend on the hardware that they are run on.