### PR TITLE
[BFCL] CI: Add “Publish to PyPI” workflow with CalVer-serial auto-versioning

### DIFF
--- a/.github/workflows/bfcl-pipy-release.yml
+++ b/.github/workflows/bfcl-pipy-release.yml
@@ -56,5 +56,4 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
           packages-dir: berkeley-function-call-leaderboard/dist/

--- a/.github/workflows/bfcl-pipy-release.yml
+++ b/.github/workflows/bfcl-pipy-release.yml
@@ -1,0 +1,60 @@
+name: Publish BFCL to PyPI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0      # we need full history to count commits
+
+      - name: Compute CalVer-serial version
+        id: ver
+        run: |
+          # 1) today's date in UTC -> 2025.06.08
+          DATE=$(date -u '+%Y.%m.%d')
+
+          # 2) how many commits since 00:00 UTC?
+          COMMITS_TODAY=$(git rev-list --count \
+                             --since="$(date -u '+%Y-%m-%d 00:00')" HEAD)
+
+          # 3) serial = commits - 1  (first push → 0)
+          SERIAL=$((COMMITS_TODAY - 1))
+
+          if [ "$SERIAL" -eq 0 ]; then
+            VERSION="$DATE"
+          else
+            VERSION="$DATE.$SERIAL"
+          fi
+
+          echo "Computed version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build wheel & sdist
+        env:
+          # 4) Tell setuptools-scm to *pretend* this is the version
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.ver.outputs.version }}
+        working-directory: berkeley-function-call-leaderboard
+        run: |
+          python -m pip install --upgrade build "setuptools-scm[toml]>=8"
+          python -m build
+          ls -l dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: berkeley-function-call-leaderboard/dist/

--- a/berkeley-function-call-leaderboard/pyproject.toml
+++ b/berkeley-function-call-leaderboard/pyproject.toml
@@ -69,5 +69,4 @@ wandb = ["wandb==0.18.5"]
 
 [tool.setuptools_scm]
 tag_regex = '^v(?P<version>[0-9]{4}\.[0-9]{2}\.[0-9]{2}(?:\.[0-9]+)?)$'
-local_scheme = "no-local-version"
-version_scheme = "no-guess-dev"
+fallback_version = "0.0.0.dev0"

--- a/berkeley-function-call-leaderboard/pyproject.toml
+++ b/berkeley-function-call-leaderboard/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "build"]
+requires = ["setuptools>=61.0", "wheel", "build", "setuptools-scm[toml]>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "bfcl_eval"
-version = "2025.06.08"
+dynamic = ["version"]
 description = "Berkeley Function Calling Leaderboard (BFCL)"
 authors = [
     { name = "Huanzhi Mao", email = "huanzhimao@cs.berkeley.edu" },
@@ -66,3 +66,8 @@ Repository = "https://github.com/ShishirPatil/gorilla/tree/main/berkeley-functio
 oss_eval_vllm = ["vllm==0.8.5"]
 oss_eval_sglang = ["sglang[all]"]
 wandb = ["wandb==0.18.5"]
+
+[tool.setuptools_scm]
+tag_regex = '^v(?P<version>[0-9]{4}\.[0-9]{2}\.[0-9]{2}(?:\.[0-9]+)?)$'
+local_scheme = "no-local-version"
+version_scheme = "no-guess-dev"


### PR DESCRIPTION
- Introduces `Publish BFCL to PyPI` GitHub Action.
- Runs on pushes to the main branch and merged PRs.
- Auto-generates CalVer-serial version, builds sdist + wheel, and uploads via pypa/gh-action-pypi-publish 