### PR TITLE
[BFCL] Replace Exception with SyntaxError for Java and JavaScript Parsers

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/java_parser.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/java_parser.py
@@ -13,7 +13,7 @@ def parse_java_function_call(source_code):
     sexp_result = root_node.sexp()
 
     if "ERROR" in sexp_result:
-        raise Exception("Error parsing java the source code.")
+        raise SyntaxError("Error parsing java the source code.")
 
     def get_text(node):
         """Returns the text represented by the node."""

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/js_parser.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/js_parser.py
@@ -13,7 +13,7 @@ def parse_javascript_function_call(source_code):
     root_node = tree.root_node
     sexp_result = root_node.sexp()
     if "ERROR" in sexp_result:
-        raise Exception("Error js parsing the source code.")
+        raise SyntaxError("Error js parsing the source code.")
 
     # Function to recursively extract argument details
     def extract_arguments(node):


### PR DESCRIPTION
for the Java and JavaScript parsers, I updated the error handling such that it returns a `SyntaxError` rather than an `Exception`.

### Motivations
- this is done in parallel with using `bfcl` to evaluate models, raising a specific type of error works better to handle erroneous model responses (as opposed to runtime errors that are unrelated to the model itself)

### Limitations
- `SyntaxError` may be too narrow of a scope

if there is another error type that is more relevant, I'm glad to make the changes needed on my side

thanks in advance!