### PR TITLE
[BFCL] Fix prompt concatenation bug in Qwen template

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Jun 18, 2025] [#1068](https://github.com/ShishirPatil/gorilla/pull/1068): Fix prompt concatenation issue in Qwen chat template. The self-hosted `Qwen3` models are affected.
 - [Jun 15, 2025] [#966](https://github.com/ShishirPatil/gorilla/pull/966): Removed the `travel_cost` parameter from multi-turn backend `TravelAPI.book_flight()` and now compute cost internally to eliminate ambiguity.
 - [Jun 15, 2025] [#1060](https://github.com/ShishirPatil/gorilla/pull/1060): Fixed multi-turn backend `GorillaFileSystem._get_item()` method to correctly handle `"."` in path strings.
 - [Jun 14, 2025] [#1032](https://github.com/ShishirPatil/gorilla/pull/1032): Add `Llama-3.1-Nemotron-Ultra-253B-v1` to the leaderboard.

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen.py
@@ -164,7 +164,7 @@ class QwenHandler(OSSHandler):
                 formatted_prompt += f"\n<tool_response>\n{content}\n</tool_response>"
 
                 if idx == len(messages) - 1 or next_role != "tool":
-                    formatted_prompt + "<|im_end|>\n"
+                    formatted_prompt += "<|im_end|>\n"
 
         formatted_prompt += "<|im_start|>assistant\n"
         return formatted_prompt

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen_fc.py
@@ -209,7 +209,7 @@ class QwenFCHandler(OSSHandler):
                 formatted_prompt += f"\n<tool_response>\n{content}\n</tool_response>"
 
                 if idx == len(messages) - 1 or next_role != "tool":
-                    formatted_prompt + "<|im_end|>\n"
+                    formatted_prompt += "<|im_end|>\n"
 
         formatted_prompt += "<|im_start|>assistant\n"
         return formatted_prompt


### PR DESCRIPTION
This PR fixes an issue where the special token `<|im_end|>\n` was being incorrectly added using. This operation does not modify `formatted_prompt` in-place, which can lead to the token not being appended as expected. 

**Changes**
Replaced `formatted_prompt + "<|im_end|>\n"` with `formatted_prompt += "<|im_end|>\n"` to ensure proper in-place string concatenation.

**Note**
This issue significantly affects `Qwen3` model performance in the leaderboard.