### PR TITLE
"CUSTOM" flag added to --test-categories arg and --custom-path arg added to complement it

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/__main__.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/__main__.py
@@ -105,6 +105,11 @@ def generate(
         help="A list of test categories to run the evaluation on. Use commas to separate multiple test categories.",
         callback=handle_multiple_input
     ),
+    custom_path: List[str] = typer.Option(
+        None,
+        "--custom-path",
+        help="Optional path(s) to custom JSON test files. Used only if test_category includes 'custom'.",
+    ),
     temperature: float = typer.Option(
         0.001, help="The temperature parameter for the model."
     ),
@@ -156,6 +161,7 @@ def generate(
     args = SimpleNamespace(
         model=model,
         test_category=test_category,
+        custom_path=custom_path,
         temperature=temperature,
         include_input_log=include_input_log,
         exclude_state_log=exclude_state_log,

--- a/berkeley-function-call-leaderboard/bfcl_eval/_llm_response_generation.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/_llm_response_generation.py
@@ -3,6 +3,7 @@ import json
 import time
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
+from pathlib import Path
 
 from bfcl_eval.constants.category_mapping import (
     MULTI_TURN_FUNC_DOC_FILE_MAPPING,
@@ -33,6 +34,8 @@ def get_args():
     # Refer to test_categories for supported categories.
     parser.add_argument("--test-category", type=str, default="all", nargs="+")
 
+    #Argument for the file path of a custom file when the --test-category flag is 'custom'
+    parser.add_argument("--custom-path", type=str, default=None, nargs="+", help="Set the path of your custom file. Only used when --test-category is custom")
     # Parameters for the model that you want to test.
     parser.add_argument("--temperature", type=float, default=0.001)
     parser.add_argument("--include-input-log", action="store_true", default=False)
@@ -68,7 +71,7 @@ def build_handler(model_name, temperature):
     return handler
 
 
-def get_involved_test_entries(test_category_args, run_ids):
+def get_involved_test_entries(test_category_args, run_ids, custom_path=None):
     all_test_file_paths, all_test_categories, all_test_entries_involved = [], [], []
     if run_ids:
         with open(TEST_IDS_TO_GENERATE_PATH) as f:
@@ -76,24 +79,37 @@ def get_involved_test_entries(test_category_args, run_ids):
         for category, test_ids in test_ids_to_generate.items():
             if len(test_ids) == 0:
                 continue
-            test_file_path = TEST_FILE_MAPPING[category]
-            all_test_entries_involved.extend(
-                [
-                    entry
-                    for entry in load_file(PROMPT_PATH / test_file_path)
-                    if entry["id"] in test_ids
-                ]
-            )
+            elif category == 'custom':
+                test_file_path = custom_path
+            else:
+                test_file_path = TEST_FILE_MAPPING[category]
+                all_test_entries_involved.extend(
+                    [
+                        entry
+                        for entry in load_file(PROMPT_PATH / test_file_path)
+                        if entry["id"] in test_ids
+                    ]
+                )
             all_test_categories.append(category)
             all_test_file_paths.append(test_file_path)
-
     else:
-        all_test_file_paths, all_test_categories = parse_test_category_argument(test_category_args)
-        # Make a copy here since we are removing list elemenets inside the for loop
-        for test_category, file_to_open in zip(
-            all_test_categories[:], all_test_file_paths[:]
-        ):
-            all_test_entries_involved.extend(load_file(PROMPT_PATH / file_to_open))
+        if custom_path is not None:
+            all_test_file_paths = custom_path
+            _, all_test_categories = parse_test_category_argument(test_category_args)
+            for test_category, file_to_open in zip(
+                all_test_categories[:], all_test_file_paths[:]
+            ):
+                all_test_entries_involved.extend(load_file(PROMPT_PATH / file_to_open))
+
+        else:
+            all_test_file_paths, all_test_categories = parse_test_category_argument(test_category_args)
+            print("BOOOOOM", all_test_file_paths)
+            print("DICKKKKKK", all_test_categories)
+            # Make a copy here since we are removing list elemenets inside the for loop
+            for test_category, file_to_open in zip(
+                all_test_categories[:], all_test_file_paths[:]
+            ):
+                all_test_entries_involved.extend(load_file(PROMPT_PATH / file_to_open))
 
     return (
         all_test_file_paths,
@@ -269,12 +285,14 @@ def main(args):
         args.model = [args.model]
     if type(args.test_category) is not list:
         args.test_category = [args.test_category]
+    if type(args.custom_path) is not list:
+        args.custom_path = [args.custom_path]
 
     (
         all_test_file_paths,
         all_test_categories,
         all_test_entries_involved,
-    ) = get_involved_test_entries(args.test_category, args.run_ids)
+    ) = get_involved_test_entries(args.test_category, args.run_ids, args.custom_path)
 
     for model_name in args.model:
         if model_name not in MODEL_CONFIG_MAPPING:

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/category_mapping.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/category_mapping.py
@@ -9,6 +9,7 @@ TEST_FILE_MAPPING = {
     # "exec_multiple": f"{VERSION_PREFIX}_exec_multiple.json",
     # "exec_parallel_multiple": f"{VERSION_PREFIX}_exec_parallel_multiple.json",
     "simple": f"{VERSION_PREFIX}_simple.json",
+    "custom": f"{VERSION_PREFIX}_custom.json",
     "irrelevance": f"{VERSION_PREFIX}_irrelevance.json",
     "parallel": f"{VERSION_PREFIX}_parallel.json",
     "multiple": f"{VERSION_PREFIX}_multiple.json",
@@ -38,6 +39,7 @@ TEST_FILE_MAPPING = {
 TEST_COLLECTION_MAPPING = {
     "all": [
         "simple",
+        "custom",
         "irrelevance",
         "parallel",
         "multiple",
@@ -63,6 +65,7 @@ TEST_COLLECTION_MAPPING = {
     ],
     "single_turn": [
         "simple",
+        "custom",
         "irrelevance",
         "parallel",
         "multiple",
@@ -86,6 +89,7 @@ TEST_COLLECTION_MAPPING = {
     ],
     "non_live": [
         "simple",
+        "custom",
         "irrelevance",
         "parallel",
         "multiple",
@@ -95,6 +99,7 @@ TEST_COLLECTION_MAPPING = {
     ],
     "ast": [
         "simple",
+        "custom"
         "irrelevance",
         "parallel",
         "multiple",
@@ -114,6 +119,7 @@ TEST_COLLECTION_MAPPING = {
     ],
     "python": [
         "simple",
+        "custom",
         "irrelevance",
         "parallel",
         "multiple",

--- a/berkeley-function-call-leaderboard/bfcl_eval/utils.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/utils.py
@@ -190,10 +190,16 @@ def parse_test_category_argument(test_category_args):
 
     for test_category in test_category_args:
         if test_category in TEST_COLLECTION_MAPPING:
+            print("IM HEREEEEE")
             for test_name in TEST_COLLECTION_MAPPING[test_category]:
                 test_name_total.add(test_name)
                 test_filename_total.add(TEST_FILE_MAPPING[test_name])
+        elif test_category == 'custom':
+            print("FUCKKKKK")
+            test_name_total.add(test_category)
+            test_filename_total.add(TEST_FILE_MAPPING[test_category])        
         elif test_category in TEST_FILE_MAPPING:
+            print("NOOOOOO")
             test_name_total.add(test_category)
             test_filename_total.add(TEST_FILE_MAPPING[test_category])
         else:


### PR DESCRIPTION
Issue?
- Currently a .json in bfcl_eval/data needs to have a specific name in order to run. Albeit the quick disorganization that arises from renaming your specific .json benchmark to one of the accepted --test-category tags, it is still doable. But once you want to run multiple files, you can run out of tags which restrains testing.
Proposed Solution:
- Adding a "custom" flag to the --test-category args allows for any .json file to be added to bfcl_eval/data/ with the structure "BFCL_v3_custom_*.json" and still properly run. Users are required to also use the new --custom-path arg to specify which custom .json file they want to run.