### PR TITLE
Restrict GitHub Actions Workflow to Run Only on Source Repository

### DIFF
--- a/.github/workflows/bfcl-pipy-release.yml
+++ b/.github/workflows/bfcl-pipy-release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build_and_publish:
+    if: github.repository == 'ShishirPatil/gorilla'
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing

--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Jun 30, 2025] [#956](https://github.com/ShishirPatil/gorilla/pull/956): Fix typo in ground truth for multi_turn_base.
 - [Jun 29, 2025] [#1034](https://github.com/ShishirPatil/gorilla/pull/1034): Add support for `claude-opus-4-20250514` and `claude-sonnet-4-20250514`
 - [Jun 29, 2025] [#1086](https://github.com/ShishirPatil/gorilla/pull/1086): Fix duplicate test entry ID `live-relevance_3-3-0`.
 - [Jun 29, 2025] [#1087](https://github.com/ShishirPatil/gorilla/pull/1087): Add missing base-cost definitions for three airport routes in `travel_booking` backend.


### PR DESCRIPTION
This PR modifies the GitHub Actions workflow to ensure it only runs on the main (source) repository and not on forks. Forks of this repository do not have the necessary permissions or secrets for publishing to PiPy, and attempting to run the workflow on those forks results in guaranteed failures. This helps keep the CI clean.