### PR TITLE
[BFCL] Replaced system role with developer role

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai.py
@@ -10,10 +10,10 @@ from bfcl_eval.model_handler.utils import (
     convert_to_tool,
     default_decode_ast_prompting,
     default_decode_execute_prompting,
+    developer_prompt_pre_processing_chat_model,
     format_execution_results_prompting,
     func_doc_language_specific_pre_processing,
     retry_with_backoff,
-    system_prompt_pre_processing_chat_model,
 )
 from openai import OpenAI, RateLimitError
 
@@ -232,7 +232,7 @@ class OpenAIHandler(BaseHandler):
 
         functions = func_doc_language_specific_pre_processing(functions, test_category)
 
-        test_entry["question"][0] = system_prompt_pre_processing_chat_model(
+        test_entry["question"][0] = developer_prompt_pre_processing_chat_model(
             test_entry["question"][0], functions, test_category
         )
 

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/utils.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/utils.py
@@ -330,6 +330,32 @@ def system_prompt_pre_processing_chat_model(prompts, function_docs, test_categor
     return prompts
 
 
+def developer_prompt_pre_processing_chat_model(prompts, function_docs, _):
+    """
+    This is a mirror of the `system_prompt_pre_processing_chat_model` function. However, newer APIs prefer
+    using the `developer` role instead of `system` role. 
+    """
+    assert type(prompts) is list
+
+    system_prompt_template = DEFAULT_SYSTEM_PROMPT
+
+    system_prompt = system_prompt_template.format(functions=function_docs)
+
+    # Developer prompt must be in the first position
+    # If the question comes with a developer prompt, append its content at the end of the chat template.
+    if prompts[0]["role"] == "system":
+        prompts[0]["role"] = "developer"
+        prompts[0]["content"] = system_prompt + "\n\n" + prompts[0]["content"]
+    # Otherwise, use the system prompt template to create a new developer prompt.
+    else:
+        prompts.insert(
+            0,
+            {"role": "developer", "content": system_prompt},
+        )
+
+    return prompts
+
+
 def convert_system_prompt_into_user_prompt(prompts: list[dict]) -> list[dict]:
     """
     Some FC models doesn't support system prompt in the message field, so we turn it into user prompt


### PR DESCRIPTION
OpenAI's [latest model spec](https://model-spec.openai.com/2025-04-11.html#definitions) introduces the `developer` role which is preferred over using the `system` role.

However, it is probably not safe to make direct changes to the datasets prompts due to other models potentially not supporting this new role. As such, a new function was introduced to convert the roles from `system` into `developer` only for OpenAI models