### PR TITLE
Add CohereLabs/c4ai-command-a-03-2025-FC as one of the supported models.

### DIFF
--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -129,6 +129,8 @@ For model names containing `{...}`, multiple versions are available. For example
 | xLAM-2-70b-fc-r                        | Function Calling | Self-hosted 💻 | Salesforce/Llama-xLAM-2-70b-fc-r                            |
 | xLAM-2-8b-fc-r                         | Function Calling | Self-hosted 💻 | Salesforce/Llama-xLAM-2-8b-fc-r                             |
 | yi-large                               | Function Calling | 01.AI          | yi-large-fc                                                 |
+| c4ai-command-a-03-2025-FC      | Function Calling | Self-hosted 💻 | CohereLabs/c4ai-command-a-03-2025-FC                                                 |
+
 
 ---
 

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -33,6 +33,7 @@ from bfcl_eval.model_handler.api_inference.writer import WriterHandler
 from bfcl_eval.model_handler.api_inference.yi import YiHandler
 from bfcl_eval.model_handler.local_inference.arch import ArchHandler
 from bfcl_eval.model_handler.local_inference.bielik import BielikHandler
+from bfcl_eval.model_handler.local_inference.command_a_fc import CommandAFCHandler
 from bfcl_eval.model_handler.local_inference.deepseek import DeepseekHandler
 from bfcl_eval.model_handler.local_inference.deepseek_coder import DeepseekCoderHandler
 from bfcl_eval.model_handler.local_inference.deepseek_reasoning import (
@@ -1116,6 +1117,18 @@ api_inference_model_map = {
 
 # Inference through local hosting
 local_inference_model_map = {
+    "CohereLabs/c4ai-command-a-03-2025-FC": ModelConfig(
+        model_name="CohereLabs/c4ai-command-a-03-2025",
+        display_name="C4AI-Command-A-03-2025 (FC)",
+        url="https://huggingface.co/CohereLabs/c4ai-command-a-03-2025",
+        org="Cohere",
+        license="cc-by-nc-4.0",
+        model_handler=CommandAFCHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=True,
+        underscore_to_dot=False,
+    ),
     "deepseek-ai/DeepSeek-R1": ModelConfig(
         model_name="deepseek-ai/DeepSeek-R1",
         display_name="DeepSeek-R1 (Prompt) (Local)",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
@@ -166,5 +166,6 @@ SUPPORTED_MODELS = [
     "katanemo/Arch-Agent-1.5B",
     "katanemo/Arch-Agent-3B",
     "katanemo/Arch-Agent-7B",
-    "katanemo/Arch-Agent-32B"
+    "katanemo/Arch-Agent-32B",
+    "CohereLabs/c4ai-command-a-03-2025-FC",
 ]

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/command_a_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/command_a_fc.py
@@ -1,0 +1,200 @@
+import json
+import re
+import ast
+from bfcl_eval.model_handler.local_inference.base_oss_handler import OSSHandler
+from bfcl_eval.model_handler.utils import func_doc_language_specific_pre_processing, convert_to_tool
+from bfcl_eval.constants.type_mappings import GORILLA_TO_OPENAPI
+from bfcl_eval.model_handler.model_style import ModelStyle
+from overrides import override
+
+class CommandAFCHandler(OSSHandler):
+    """
+    Handler for CohereLabs/c4ai-command-a-03-2025 model in function calling mode.
+    
+    This model uses a specific chat template for tool use that includes:
+    - Tool definitions in the conversation
+    - Tool calls in JSON format
+    - Tool results in the conversation flow
+    
+    For more details, see the model card:
+    https://huggingface.co/CohereLabs/c4ai-command-a-03-2025
+    """
+    
+    def __init__(self, model_name, temperature) -> None:
+        super().__init__(model_name, temperature)
+        self.model_name_huggingface = model_name.replace("-FC", "") if "-FC" in model_name else model_name 
+
+    @override
+    def _format_prompt(self, messages, function):
+        """
+        Format the prompt to match the CohereLabs/c4ai-command-a-03-2025 tool_use chat template exactly.
+        """
+        tools = convert_to_tool(function, GORILLA_TO_OPENAPI, ModelStyle.COHERE)
+        tokenizer = self.tokenizer
+        formatted_prompt = tokenizer.apply_chat_template(
+            messages,
+            tools=tools,
+            tokenize=False,
+            add_generation_prompt=True
+        )
+        return formatted_prompt
+    
+    def _convert_to_tool_calls(self, tool_calls: list[dict]) -> list[dict]:
+        tools = []
+        for tool_call in tool_calls:
+            tools.append(
+                {
+                    "id": tool_call["tool_call_id"],
+                    "type": "function",
+                    "function": {"name": tool_call["tool_name"], "arguments": tool_call["parameters"]}
+                }
+            )
+        return tools
+    
+    
+    @override
+    def _parse_query_response_prompting(self, api_response: any) -> dict:
+        model_response = api_response.choices[0].text 
+        
+        # Set regex patterns and extract tool_calls and tool_plan
+        tool_calls_pattern = r"<\|START_ACTION\|>(.*?)<\|END_ACTION\|>"
+        tool_plan_pattern = r"<\|START_THINKING\|>(.*?)<\|END_THINKING\|>"
+        
+        tool_calls = []
+        tool_calls_match = re.search(tool_calls_pattern, model_response, re.DOTALL)
+        if tool_calls_match:
+            tool_calls = tool_calls_match.group(1).strip()
+            tool_calls = json.loads(tool_calls)
+        
+        tool_plan = ""
+        cleaned_response = model_response   
+        tool_plan_match = re.search(tool_plan_pattern, model_response, re.DOTALL)
+        if tool_plan_match:
+            tool_plan = tool_plan_match.group(1).strip()
+            cleaned_response = re.sub(tool_plan_pattern, "", model_response, flags=re.DOTALL)
+        
+        if len(tool_calls):
+            chat_history = {
+                "role": "assistant",
+                "tool_calls": self._convert_to_tool_calls(tool_calls),
+                "tool_plan": tool_plan
+            }
+        else:
+            chat_history = {
+                "role": "assistant",
+                "content": cleaned_response,
+            }
+        
+        return {
+            "model_responses": cleaned_response,
+            "tool_calls": tool_calls,
+            "tool_plan": tool_plan,
+            "chat_history": chat_history,
+            "input_token": api_response.usage.prompt_tokens,
+            "output_token": api_response.usage.completion_tokens,
+        }
+    
+    @override
+    def _add_assistant_message_prompting(
+        self, inference_data: dict, model_response_data: dict
+    ) -> dict:
+        inference_data["message"].append(
+            model_response_data["chat_history"]
+        )
+        return inference_data
+    
+    @override
+    def _add_execution_results_prompting(
+        self, inference_data: dict, execution_results: list[str], model_response_data: dict
+    ) -> dict:
+        tool_call_messages = []
+        for tool_call, execution_result in zip(
+            inference_data["message"][-1]["tool_calls"], execution_results
+        ):
+            tool_call_messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call["id"],
+                    "content": execution_result,
+                }
+            )
+        inference_data["message"].extend(tool_call_messages)
+        return inference_data
+        
+
+    @override
+    def decode_ast(self, result, language="Python"):
+        """
+        Decode the model's response into AST format.
+        
+        The response format is:
+        '<|START_THINKING|>...<|END_THINKING|><|START_ACTION|>[{"tool_call_id": "0", "tool_name": "func_name", "parameters": {...}}]<|END_ACTION|>'
+        """
+        try:
+            # Extract the JSON array from between START_ACTION and END_ACTION tags
+            action_match = re.search(r"<\|START_ACTION\|>(.*?)<\|END_ACTION\|>", result, re.DOTALL)
+            if not action_match:
+                return []
+            
+            tool_calls_str = action_match.group(1).strip()
+            tool_calls = json.loads(tool_calls_str)
+            
+            # Ensure tool_calls is a list
+            if not isinstance(tool_calls, list):
+                tool_calls = [tool_calls]
+            
+            # Convert to required format: [{func_name: parameters}]
+            decoded_output = []
+            for tool_call in tool_calls:
+                name = tool_call["tool_name"]
+                params = tool_call["parameters"]
+                decoded_output.append({name: params})
+            
+            return decoded_output
+        except (json.JSONDecodeError, KeyError, IndexError):
+            return []
+
+    @override
+    def decode_execute(self, result):
+        """
+        Convert the model's response into executable function calls.
+        
+        The response format is:
+        '<|START_THINKING|>...<|END_THINKING|><|START_ACTION|>[{"tool_call_id": "0", "tool_name": "func_name", "parameters": {...}}]<|END_ACTION|>'
+        """
+        try:
+            # Extract the JSON array from between START_ACTION and END_ACTION tags
+            action_match = re.search(r"<\|START_ACTION\|>(.*?)<\|END_ACTION\|>", result, re.DOTALL)
+            if not action_match:
+                return []
+            
+            tool_calls_str = action_match.group(1).strip()
+            tool_calls = json.loads(tool_calls_str)
+            
+            # Ensure tool_calls is a list
+            if not isinstance(tool_calls, list):
+                tool_calls = [tool_calls]
+            
+            # Convert to executable function calls
+            execution_list = []
+            for tool_call in tool_calls:
+                name = tool_call["tool_name"]
+                params = tool_call["parameters"]
+                param_str = ",".join([f"{k}={repr(v)}" for k, v in params.items()])
+                execution_list.append(f"{name}({param_str})")
+            
+            return execution_list
+        except (json.JSONDecodeError, KeyError, IndexError):
+            return []
+
+    @override
+    def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
+        """
+        Pre-process the test entry for Cohere Command A.
+        """
+        functions: list = test_entry["function"]
+        test_category: str = test_entry["id"].rsplit("_", 1)[0]
+
+        functions = func_doc_language_specific_pre_processing(functions, test_category)
+
+        return {"message": [], "function": functions} 


### PR DESCRIPTION
Currently, command-a-03-2025-FC is defined in model_config.py, but there is no entry for CohereLabs/c4ai-command-a-03-2025.
The former, command-a-03-2025-FC, refers to an API-based inference model, whereas the latter, CohereLabs/c4ai-command-a-03-2025, is an open-source (OSS) model.

You can find the Hugging Face model card for CohereLabs/c4ai-command-a-03-2025 here:
[CohereLabs/c4ai-command-a-03-2025](https://huggingface.co/CohereLabs/c4ai-command-a-03-2025)


Evaluation results:

```
+------------------------+--------------+---------------+--------------------+------------+------------------+-----------------------+-------------------------+
| Model                  | License      | Overall Acc   | Non-Live AST Acc   | Live Acc   | Multi Turn Acc   | Relevance Detection   | Irrelevance Detection   |
+========================+==============+===============+====================+============+==================+=======================+=========================+
| C4AI-Command-A-03-2025 (FC) | cc-by-nc-4.0 | 49.12%        | 38.10%             | 72.37%     | 27.00%           | 77.78%                | 83.66%                  |
+------------------------+--------------+---------------+--------------------+------------+------------------+-----------------------+-------------------------+
```