### PR TITLE
[BFCL] nit: Print traceback on generation error

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/_llm_response_generation.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/_llm_response_generation.py
@@ -205,6 +205,7 @@ def multi_threaded_inference(handler, test_case, include_input_log, exclude_stat
                     "❗️❗️ Error occurred during inference. Maximum reties reached for rate limit or other error. Continuing to next test case."
                 )
                 print(f"❗️❗️ Test case ID: {test_case['id']}, Error: {str(e)}")
+                traceback.print_exc()
                 print("-" * 100)
 
                 return {

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/base_oss_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/base_oss_handler.py
@@ -285,6 +285,7 @@ class OSSHandler(BaseHandler, EnforceOverrides):
                 "❗️❗️ Error occurred during inference. Maximum reties reached for rate limit or other error. Continuing to next test case."
             )
             print(f"❗️❗️ Test case ID: {test_case['id']}, Error: {str(e)}")
+            traceback.print_exc()
             print("-" * 100)
 
             model_responses = f"Error during inference: {str(e)}"


### PR DESCRIPTION
When the generation pipeline encounters an exception, this PR ensures that the traceback is printed directly to the terminal, in addition to being logged to the local result file. This allows developers to immediately view and debug errors in real-time.