### PR TITLE
Fix qwen3 inference data and qwenfc handler chat template

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen.py
@@ -186,3 +186,12 @@ class QwenHandler(OSSHandler):
             "input_token": api_response.usage.prompt_tokens,
             "output_token": api_response.usage.completion_tokens,
         }
+
+    @override
+    def _add_assistant_message_prompting(
+        self, inference_data: dict, model_response_data: dict
+    ) -> dict:
+        inference_data["message"].append(
+            {"role": "assistant", "content": model_response_data["model_responses"], "reasoning_content": model_response_data.get("reasoning_content", "")}
+        )
+        return inference_data

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen_fc.py
@@ -196,6 +196,25 @@ class QwenFCHandler(OSSHandler):
                         formatted_prompt += f"<|im_start|>{role}\n{content}"
                 else:
                     formatted_prompt += f"<|im_start|>{role}\n{content}"
+                    
+                if "tool_calls" in message:
+                    for tool_call in message["tool_calls"]:
+                        if (tool_call == message["tool_calls"][0] and content) or tool_call != message["tool_calls"][0]:
+                            formatted_prompt += "\n"
+                        
+                        if "function" in tool_call:
+                            tool_call = tool_call["function"]
+                        
+                        formatted_prompt += '<tool_call>\n{"name": "'
+                        formatted_prompt += tool_call["name"]
+                        formatted_prompt += '", "arguments": '
+                        
+                        if isinstance(tool_call["arguments"], str):
+                            formatted_prompt += tool_call["arguments"]
+                        else:
+                            formatted_prompt += str(tool_call["arguments"])
+                        
+                        formatted_prompt += "}\n</tool_call>"
 
                 formatted_prompt += "<|im_end|>\n"
 
@@ -248,6 +267,8 @@ class QwenFCHandler(OSSHandler):
                 "role": "assistant",
                 "content": cleaned_response,
             }
+            
+        model_responses_message_for_chat_history["reasoning_content"] = reasoning_content
 
         return {
             "model_responses": cleaned_response,


### PR DESCRIPTION
1. Reasoning content was not being added in the inference data for both QwenHandler and QwenFCHandler.
2. The _format_prompt function in QwenFCHandler was not checking for tool_calls in assistant messages. All those messages where the assistant requested a tool call were converted to empty messages.

This PR fixes both the above points.

This also means that all those scores for qwen3-prompt and qwen3-FC that were calculated using local_inference, would need to be calculated again.