### PR TITLE
Extending gemma Model to be used by API inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ berkeley-function-call-leaderboard/bfcl_eval/scripts/ground_truth_conversation/
 
 # Ignore the wandb cache:
 **/wandb/
+berkeley-function-call-leaderboard/gemma_results/
+berkeley-function-call-leaderboard/gemma_score/

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -9,6 +9,7 @@ from bfcl_eval.model_handler.api_inference.dm_cito import DMCitoHandler
 from bfcl_eval.model_handler.api_inference.fireworks import FireworksHandler
 from bfcl_eval.model_handler.api_inference.functionary import FunctionaryHandler
 from bfcl_eval.model_handler.api_inference.gemini import GeminiHandler
+from bfcl_eval.model_handler.api_inference.gemma import GemmaHandler as GemmaAPIHandler
 from bfcl_eval.model_handler.api_inference.gogoagent import GoGoAgentHandler
 from bfcl_eval.model_handler.api_inference.gorilla import GorillaHandler
 from bfcl_eval.model_handler.api_inference.grok import GrokHandler
@@ -659,6 +660,68 @@ api_inference_model_map = {
         is_fc_model=False,
         underscore_to_dot=False,
     ),
+
+    # Added Gemma-3 models Api Inference
+    "gemma-3-1b-it": ModelConfig(
+        model_name="google/gemma-3-1b-it",
+        display_name="Gemma-3-1b-it (Prompt)",
+        url="https://blog.google/technology/developers/gemma-3/",
+        org="Google",
+        license="gemma-terms-of-use",
+        model_handler=GemmaAPIHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=False,
+        underscore_to_dot=False,
+    ),
+    "gemma-3-4b-it": ModelConfig(
+        model_name="gemma-3-4b-it",
+        display_name="Gemma-3-4b-it (Prompt)",
+        url="https://blog.google/technology/developers/gemma-3/",
+        org="Google",
+        license="gemma-terms-of-use",
+        model_handler=GemmaAPIHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=False,
+        underscore_to_dot=False,
+    ),
+    "gemma-3-12b-it": ModelConfig(
+        model_name="gemma-3-12b-it",
+        display_name="Gemma-3-12b-it (Prompt)",
+        url="https://blog.google/technology/developers/gemma-3/",
+        org="Google",
+        license="gemma-terms-of-use",
+        model_handler=GemmaAPIHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=False,
+        underscore_to_dot=False,
+    ),
+    "gemma-3-27b-it": ModelConfig(
+        model_name="gemma-3-27b-it",
+        display_name="Gemma-3-27b-it (Prompt)",
+        url="https://blog.google/terms-of-use/",
+        org="Google",
+        license="gemma-terms-of-use",
+        model_handler=GemmaAPIHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=False,
+        underscore_to_dot=False,
+    ),   
+    "gemma-3n-e4b-it": ModelConfig(
+        model_name="gemma-3n-e4b-it",
+        display_name="Gemma-3n-E4B(prompt)",
+        url="https://deepmind.google/technologies/gemmma/pro/",
+        org="Google",
+        license="Proprietary",
+        model_handler=GemmaAPIHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=False,
+        underscore_to_dot=False,
+    ),
     "meetkai/functionary-small-v3.1-FC": ModelConfig(
         model_name="meetkai/functionary-small-v3.1-FC",
         display_name="Functionary-Small-v3.1 (FC)",
@@ -1182,7 +1245,7 @@ local_inference_model_map = {
     "google/gemma-3-27b-it": ModelConfig(
         model_name="google/gemma-3-27b-it",
         display_name="Gemma-3-27b-it (Prompt)",
-        url="https://blog.google/technology/developers/gemma-3/",
+        url="https://blog.google/terms-of-use/",
         org="Google",
         license="gemma-terms-of-use",
         model_handler=GemmaHandler,

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gemma.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gemma.py
@@ -1,0 +1,352 @@
+import os
+import time
+
+from bfcl_eval.constants.type_mappings import GORILLA_TO_OPENAPI
+from bfcl_eval.model_handler.base_handler import BaseHandler
+from bfcl_eval.model_handler.model_style import ModelStyle
+from bfcl_eval.model_handler.utils import (
+    convert_to_tool,
+    default_decode_ast_prompting,
+    default_decode_execute_prompting,
+    extract_system_prompt,
+    format_execution_results_prompting,
+    func_doc_language_specific_pre_processing,
+    retry_with_backoff,
+    system_prompt_pre_processing_chat_model,
+)
+from google import genai
+from google.genai import errors as genai_errors
+from google.genai.types import (
+    AutomaticFunctionCallingConfig,
+    Content,
+    GenerateContentConfig,
+    Part,
+    Tool,
+)
+
+
+class GemmaHandler(BaseHandler):
+    """
+    Handler for Gemma models accessed through the Gemini API.
+    
+    Gemma models have specific constraints:
+    - No system instructions support
+    - No thinking config support
+    - Uses standard Gemini API but with limited features
+    """
+    
+    def __init__(self, model_name, temperature) -> None:
+        print(f"GemmaHandler __init__ model_name: {model_name}")
+        super().__init__(model_name, temperature)
+        self.model_style = ModelStyle.GOOGLE
+        api_key = os.getenv("GOOGLE_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "GOOGLE_API_KEY environment variable must be set for Gemma models"
+            )
+        self.client = genai.Client(api_key=api_key)
+
+    @staticmethod
+    def _substitute_prompt_role(prompts: list[dict]) -> list[dict]:
+        # Allowed roles: user, model
+        for prompt in prompts:
+            if prompt["role"] == "user":
+                prompt["role"] = "user"
+            elif prompt["role"] == "assistant":
+                prompt["role"] = "model"
+
+        return prompts
+
+    def decode_ast(self, result, language="Python"):
+        if "FC" not in self.model_name:
+            result = result.replace("```tool_code\n", "").replace("\n```", "")
+            return default_decode_ast_prompting(result, language)
+        else:
+            if type(result) is not list:
+                result = [result]
+            return result
+
+    def decode_execute(self, result):
+        if "FC" not in self.model_name:
+            result = result.replace("```tool_code\n", "").replace("\n```", "")
+            return default_decode_execute_prompting(result)
+        else:
+            func_call_list = []
+            for function_call in result:
+                for func_name, func_args in function_call.items():
+                    func_call_list.append(
+                        f"{func_name}({','.join([f'{k}={repr(v)}' for k, v in func_args.items()])})"
+                    )
+            return func_call_list
+
+    @retry_with_backoff(error_message_pattern=r".*RESOURCE_EXHAUSTED.*")
+    def generate_with_backoff(self, **kwargs):
+        start_time = time.time()
+        api_response = self.client.models.generate_content(**kwargs)
+        end_time = time.time()
+
+        return api_response, end_time - start_time
+
+    #### FC methods ####
+
+    def _query_FC(self, inference_data: dict):
+        inference_data["inference_input_log"] = {
+            "message": repr(inference_data["message"]),
+            "tools": inference_data["tools"],
+            "system_prompt": inference_data.get("system_prompt", None),
+        }
+
+        # Gemma models don't support system instructions or thinking config
+        config = GenerateContentConfig(
+            temperature=self.temperature,
+            automatic_function_calling=AutomaticFunctionCallingConfig(disable=True),
+        )
+
+        if len(inference_data["tools"]) > 0:
+            config.tools = [Tool(function_declarations=inference_data["tools"])]
+
+        return self.generate_with_backoff(
+            model=self.model_name.replace("-FC", ""),
+            contents=inference_data["message"],
+            config=config,
+        )
+
+    def _pre_query_processing_FC(self, inference_data: dict, test_entry: dict) -> dict:
+        for round_idx in range(len(test_entry["question"])):
+            test_entry["question"][round_idx] = self._substitute_prompt_role(
+                test_entry["question"][round_idx]
+            )
+
+        inference_data["message"] = []
+
+        # Extract system prompt but don't use it (Gemma doesn't support it)
+        system_prompt = extract_system_prompt(test_entry["question"][0])
+        if system_prompt:
+            # Store it for logging purposes only
+            inference_data["system_prompt"] = system_prompt
+            
+        return inference_data
+
+    def _compile_tools(self, inference_data: dict, test_entry: dict) -> dict:
+        functions: list = test_entry["function"]
+        test_category: str = test_entry["id"].rsplit("_", 1)[0]
+
+        functions = func_doc_language_specific_pre_processing(functions, test_category)
+        tools = convert_to_tool(functions, GORILLA_TO_OPENAPI, self.model_style)
+
+        inference_data["tools"] = tools
+
+        return inference_data
+
+    def _parse_query_response_FC(self, api_response: any) -> dict:
+        tool_call_func_names = []
+        fc_parts = []
+        text_parts = []
+
+        if (
+            len(api_response.candidates) > 0
+            and api_response.candidates[0].content
+            and api_response.candidates[0].content.parts
+            and len(api_response.candidates[0].content.parts) > 0
+        ):
+            response_function_call_content = api_response.candidates[0].content
+
+            for part in api_response.candidates[0].content.parts:
+                if part.function_call and part.function_call.name:
+                    part_func_name = part.function_call.name
+                    part_func_args = part.function_call.args
+                    part_func_args_dict = {k: v for k, v in part_func_args.items()}
+
+                    fc_parts.append({part_func_name: part_func_args_dict})
+                    tool_call_func_names.append(part_func_name)
+                else:
+                    text_parts.append(part.text)
+
+        else:
+            response_function_call_content = Content(
+                role="model",
+                parts=[
+                    Part(text="The model did not return any response."),
+                ],
+            )
+
+        model_responses = fc_parts if fc_parts else text_parts
+
+        return {
+            "model_responses": model_responses,
+            "model_responses_message_for_chat_history": response_function_call_content,
+            "tool_call_func_names": tool_call_func_names,
+            "reasoning_content": "",  # Gemma doesn't have thinking/reasoning
+            "input_token": api_response.usage_metadata.prompt_token_count,
+            "output_token": api_response.usage_metadata.candidates_token_count,
+        }
+
+    def add_first_turn_message_FC(
+        self, inference_data: dict, first_turn_message: list[dict]
+    ) -> dict:
+        for message in first_turn_message:
+            inference_data["message"].append(
+                Content(
+                    role=message["role"],
+                    parts=[
+                        Part(text=message["content"]),
+                    ],
+                )
+            )
+        return inference_data
+
+    def _add_next_turn_user_message_FC(
+        self, inference_data: dict, user_message: list[dict]
+    ) -> dict:
+        return self.add_first_turn_message_FC(inference_data, user_message)
+
+    def _add_assistant_message_FC(
+        self, inference_data: dict, model_response_data: dict
+    ) -> dict:
+        inference_data["message"].append(
+            model_response_data["model_responses_message_for_chat_history"]
+        )
+        return inference_data
+
+    def _add_execution_results_FC(
+        self,
+        inference_data: dict,
+        execution_results: list[str],
+        model_response_data: dict,
+    ) -> dict:
+        # Tool response needs to be converted to Content object as well.
+        tool_response_parts = []
+        for execution_result, tool_call_func_name in zip(
+            execution_results, model_response_data["tool_call_func_names"]
+        ):
+            tool_response_parts.append(
+                Part.from_function_response(
+                    name=tool_call_func_name,
+                    response={
+                        "result": execution_result,
+                    },
+                )
+            )
+
+        tool_response_content = Content(role="user", parts=tool_response_parts)
+        inference_data["message"].append(tool_response_content)
+
+        return inference_data
+
+    #### Prompting methods ####
+
+    def _query_prompting(self, inference_data: dict):
+        inference_data["inference_input_log"] = {
+            "message": repr(inference_data["message"]),
+            "system_prompt": inference_data.get("system_prompt", None),
+        }
+
+        # Gemma models don't support system instructions or thinking config
+        config = GenerateContentConfig(
+            temperature=self.temperature,
+        )
+
+        # For Gemma, we need to embed system prompt into the first user message if present
+        if "system_prompt" in inference_data and inference_data["message"]:
+            # Prepend system prompt to the first user message
+            first_message = inference_data["message"][0]
+            if first_message.role == "user" and first_message.parts:
+                original_text = first_message.parts[0].text
+                first_message.parts[0] = Part(
+                    text=f"{inference_data['system_prompt']}\n\n{original_text}"
+                )
+
+        api_response = self.generate_with_backoff(
+            model=self.model_name.replace("-FC", ""),
+            contents=inference_data["message"],
+            config=config,
+        )
+        return api_response
+
+    def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
+        functions: list = test_entry["function"]
+        test_category: str = test_entry["id"].rsplit("_", 1)[0]
+
+        functions = func_doc_language_specific_pre_processing(functions, test_category)
+
+        for round_idx in range(len(test_entry["question"])):
+            test_entry["question"][round_idx] = self._substitute_prompt_role(
+                test_entry["question"][round_idx]
+            )
+
+        test_entry["question"][0] = system_prompt_pre_processing_chat_model(
+            test_entry["question"][0], functions, test_category
+        )
+        
+        # Extract system prompt to be embedded in the first message
+        system_prompt = extract_system_prompt(test_entry["question"][0])
+
+        if system_prompt:
+            return {"message": [], "system_prompt": system_prompt}
+        else:
+            return {"message": []}
+
+    def _parse_query_response_prompting(self, api_response: any) -> dict:
+        if (
+            len(api_response.candidates) > 0
+            and api_response.candidates[0].content
+            and api_response.candidates[0].content.parts
+            and len(api_response.candidates[0].content.parts) > 0
+        ):
+            model_responses = api_response.candidates[0].content.parts[0].text
+        else:
+            model_responses = "The model did not return any response."
+
+        return {
+            "model_responses": model_responses,
+            "reasoning_content": "",  # Gemma doesn't have thinking/reasoning
+            "input_token": api_response.usage_metadata.prompt_token_count,
+            "output_token": api_response.usage_metadata.candidates_token_count,
+        }
+
+    def add_first_turn_message_prompting(
+        self, inference_data: dict, first_turn_message: list[dict]
+    ) -> dict:
+        for message in first_turn_message:
+            inference_data["message"].append(
+                Content(
+                    role=message["role"],
+                    parts=[
+                        Part(text=message["content"]),
+                    ],
+                )
+            )
+        return inference_data
+
+    def _add_next_turn_user_message_prompting(
+        self, inference_data: dict, user_message: list[dict]
+    ) -> dict:
+        return self.add_first_turn_message_prompting(inference_data, user_message)
+
+    def _add_assistant_message_prompting(
+        self, inference_data: dict, model_response_data: dict
+    ) -> dict:
+        inference_data["message"].append(
+            Content(
+                role="model",
+                parts=[
+                    Part(text=model_response_data["model_responses"]),
+                ],
+            )
+        )
+        return inference_data
+
+    def _add_execution_results_prompting(
+        self, inference_data: dict, execution_results: list[str], model_response_data: dict
+    ) -> dict:
+        formatted_results_message = format_execution_results_prompting(
+            inference_data, execution_results, model_response_data
+        )
+        tool_message = Content(
+            role="user",
+            parts=[
+                Part(text=formatted_results_message),
+            ],
+        )
+        inference_data["message"].append(tool_message)
+        return inference_data 

--- a/berkeley-function-call-leaderboard/run_commands.txt
+++ b/berkeley-function-call-leaderboard/run_commands.txt
@@ -1,0 +1,7 @@
+bfcl generate --model gemini-2.5-pro-FC --test-category simple,parallel,multiple,multi_turn
+bfcl generate --model  googleopen/gemma-3-1b-it --test-category simple
+
+gemma-3n-e4b-it
+
+
+bfcl generate --model  gemma-3-27b-it --result-dir '/Users/yashdeepprasad/Desktop/GSOC_2025/gorilla/berkeley-function-call-leaderboard/gemma_results'


### PR DESCRIPTION
Migrated Gemma-3 models (1b, 4b, 12b, 27b) from local to Google AI Studio API inference
(Thanks to  PR #1099, we are now able to use Google AI Studio API key)
As a result, we no longer need to self-host these models.

Fixes issues #1118 
Added support for Gemma-3n models (E2B, E4B) via Google AI Studio

Created a dedicated GemmaAPIHandler for API inference that converts system prompts to user prompts and disables thinking features (not supported by Gemma models)


Have tested the working and performance of all the migrated models, and they are in tandem with the BFCL scores on the online leaderboard. 

Requesting @canyon289 to have a look at this PR 