### PR TITLE
Fix type hint for TravelAPI.book_flight return type

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/multi_turn_eval/func_source_code/travel_booking.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/multi_turn_eval/func_source_code/travel_booking.py
@@ -471,7 +471,7 @@ class TravelAPI:
         travel_from: str,
         travel_to: str,
         travel_class: str,
-    ) -> Dict[str, Union[str, bool]]:
+    ) -> Dict[str, Union[str, bool, Dict]]:
         """
         Book a flight given the travel information. From and To should be the airport codes in the IATA format.
 


### PR DESCRIPTION
## Summary
This PR fixes a type annotation bug in the `TravelAPI.book_flight` method in the Berkeley Function Call Leaderboard evaluation code.

## The Issue
The `book_flight` method's return type annotation was incorrectly specified as:
```python
Dict[str, Union[str, bool]]
```

However, the actual implementation returns `booking_history` as a Dict (either `self.booking_record` when `long_context` is enabled, or an empty dict `{}` otherwise).

## The Fix
Updated the type hint to:
```python
Dict[str, Union[str, bool, Dict]]
```

This accurately reflects that the return dictionary can contain values of type `str`, `bool`, or `Dict`.

## File Changed
- `berkeley-function-call-leaderboard/bfcl_eval/eval_checker/multi_turn_eval/func_source_code/travel_booking.py`