### PR TITLE
Add DM-Cito-8B-v3

### DIFF
--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -37,6 +37,7 @@ For model names containing `{...}`, multiple versions are available. For example
 | DeepSeek-R1-0528                           | Function Calling | DeepSeek       | DeepSeek-R1-0528-FC                                         |
 | DeepSeek-V3-0324                           | Function Calling | DeepSeek       | DeepSeek-V3-0324-FC                                         |
 | DM-Cito-8B-v2                              | Prompt           | Mininglamp     | DM-Cito-8B-v2                                               |
+| DM-Cito-8B-v3                              | Prompt           | Mininglamp     | DM-Cito-8B-v3                                               |
 | Falcon3-{1B,3B,7B,10B}-Instruct            | Function Calling | Self-hosted 💻 | tiiuae/Falcon3-{1B,3B,7B,10B}-Instruct                      |
 | FireFunction-v2                            | Function Calling | Fireworks AI   | firefunction-v2-FC                                          |
 | Functionary-{Small,Medium}-v3.1            | Function Calling | MeetKai        | meetkai/functionary-{small,medium}-v3.1-FC                  |

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -1048,6 +1048,18 @@ api_inference_model_map = {
         is_fc_model=False,
         underscore_to_dot=False,
     ),
+    "DM-Cito-8B-v3": ModelConfig(
+        model_name="DM-Cito-8B-v3",
+        display_name="DM-Cito-8B-v3 (Prompt)",
+        url="https://www.mininglamp.com/",
+        org="Mininglamp",
+        license="Proprietary",
+        model_handler=DMCitoHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=False,
+        underscore_to_dot=False,
+    ),
     "Ling/ling-lite-v1.5": ModelConfig(
         model_name="Ling/ling-lite-v1.5",
         display_name="ling-lite-v1.5 (Prompt)",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
@@ -91,6 +91,7 @@ SUPPORTED_MODELS = [
     "qwq-32b",
     "xiaoming-14B",
     "DM-Cito-8B-v2",
+    "DM-Cito-8B-v3",
     "Ling/ling-lite-v1.5",
     "glm-4.5-FC",
     "glm-4.5-air-FC",

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mining.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mining.py
@@ -69,39 +69,65 @@ class MiningHandler(OpenAICompletionsHandler):
         }
 
     def mining_system_prompt_pre_processing_chat_model(self,prompts, function_docs, test_category):
-        system_pre="""You are a function calling AI model. 
-You are provided with function signatures within <tools></tools> XML tags.
-You may call one or more functions to assist with the user query. 
+        system_pre="""You are a function calling AI model.  
+You are provided with function signatures within <tools></tools> XML tags.  
+You may call one or more functions to assist with the user query.  
 Don't make assumptions about what values to plug into functions.
 
-Here are the available tools:
-<tools> 
-{}
+Here are the available tools:  
+<tools>  
+{}  
 </tools>
 """
         system_suffix = """
-
-Use the following pydantic model json schema for each tool call you will make: 
+Use the following pydantic model json schema for each tool call you will make:  
 {"title": "FunctionCalls", "type": "array", "properties": {"arguments": {"title": "Arguments", "type": "object"}, "name": {"title": "Name", "type": "string"}}, "required": ["arguments", "name"]}
 
-At each turn, you should try your best to complete the tasks requested by the user within the current turn. Continue to output functions to call until you have fulfilled the user's request to the best of your ability. Once you have no more functions to call, the system will consider the current turn complete and proceed to the next turn or task.
+# Output Format & Constraints
 
-# Output Format
-If you find suitable function, for each function call return a json object with function name and arguments within <tool_calls></tool_calls> XML tags as follows:
+At each turn, you should try your best to complete the user's request in the current turn.
+
+**Reasoning:**  
+You FIRST think about the reasoning process as an internal monologue, and then provide the final response. The reasoning MUST be enclosed within <think></think> tags.
+
+**Function Calls:**  
+- If you need to call any functions, output function calls within <tool_calls></tool_calls> tags.  
+- The entire content inside <tool_calls></tool_calls> MUST be a valid JSON array, where each item is a JSON object with "name" and "arguments" as specified by the schema.  
+- NEVER output <tool_calls> and <answer> tags at the same time; only one should appear per turn.  
+- Do NOT call tools if the question can be answered directly.
+
+**Final Answer:**  
+- If the question can be fully answered based on current information (without tools), use <answer></answer> tags.  
+- Inside <answer></answer>, provide only a short, precise answer to the question (not lengthy explanations).  
+- Even if you do not know the answer, output your answer inside <answer></answer> as a JSON:  
+  - {'answer': 'I do not know', 'context': 'I do not know'}  
+  - If you cannot answer the question at all, output: {'answer': 'I cannot answer this question', 'context': 'A short reason explaining why this question cannot be answered'}  
+
+**General Constraints:**  
+- At each turn, output ONLY ONE of: <tool_calls></tool_calls> OR <answer></answer> (never both).  
+- If you selected <answer></answer>, you MUST NOT propose another tool call even if the question is not answerable.  
+- All outputs must strictly follow the above format.  
+- Do not insert any additional explanation or commentary outside the specified tags.  
+- When using <tool_calls></tool_calls>, the JSON array must not be empty and must strictly conform to the schema above.
+
+**Example:**
+
 <think>
 {reasoning process here}
 </think>
 <tool_calls>
-{[tool_call]}
+[{...}, {...}]
 </tool_calls>
 
-If no suitable function is found, just respond with XML tags as follows:
+OR
+
 <think>
 {reasoning process here}
 </think>
-<tool_calls>
-[]
-</tool_calls>"""
+<answer>
+{'answer': '...', 'context': '...'}
+</answer>
+"""
         assert type(prompts) == list
 
         system_prompt = system_pre.format(function_docs)+system_suffix


### PR DESCRIPTION
This PR adds model handler for DM-Cito-8B-v3. The url of the model api is：https://rapidapi.com/kechengkevin/api/dm-cito-8b-v3

Note:
Because our server has limited performance, please don't set the number of threads too high. Using --num-threads 30 worked without any issues during our tests.