### PR TITLE
[BFCL] Add `--partial-eval` flag for subset evaluation and fix length-mismatch AssertionError (#1159)

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
+- [Sep 27, 2025] [#1185](https://github.com/ShishirPatil/gorilla/pull/1185): Introduce the `--partial-eval` flag to the `bfcl evaluate` command, allowing partial evaluation on a subset of available test entries in the model result files.
 - [Sep 17, 2025] [#1175](https://github.com/ShishirPatil/gorilla/pull/1175): Fix wrong date in ground truth for `live_simple_205-116-13`.
 - [Jul 17, 2025] [#1019](https://github.com/ShishirPatil/gorilla/pull/1019): BFCL V4 release:
 

--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -175,8 +175,8 @@ IDs to run:
 
 ```json
 {
-  "simple": ["simple_101", "simple_202"],
-  "multi_turn_base": ["multi_turn_base_14"]
+    "simple_python": ["simple_python_102", "simple_python_103"],
+    "multi_turn_base": ["multi_turn_base_15"]
 }
 ```
 

--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -265,6 +265,14 @@ Once you have the results, run:
 bfcl evaluate --model MODEL_NAME --test-category TEST_CATEGORY
 ```
 
+If you **only** generated a subset of benchmark entries (e.g. by using `--run-ids` during the generation step or by manually editing the result files) and you wish to evaluate *just* those entries, add the `--partial-eval` flag:
+
+```bash
+bfcl evaluate --model MODEL_NAME --test-category TEST_CATEGORY --partial-eval
+```
+
+When `--partial-eval` is set, the evaluator silently skips IDs that are not present in the model result file and computes accuracy on the remaining subset. Please note that the score may differ from a full-set evaluation and therefore might not match the official leaderboard numbers.
+
 The `MODEL_NAME` and `TEST_CATEGORY` options are the same as those used in the [Generating LLM Responses](#generating-llm-responses) section. For details, refer to [SUPPORTED_MODELS.md](./SUPPORTED_MODELS.md) and [TEST_CATEGORIES.md](./TEST_CATEGORIES.md).
 
 If in the previous step you stored the model responses in a custom directory, specify it using the `--result-dir` flag or set `BFCL_PROJECT_ROOT` so the evaluator can locate the files.

--- a/berkeley-function-call-leaderboard/bfcl_eval/__main__.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/__main__.py
@@ -251,6 +251,11 @@ def evaluate(
         "--score-dir",
         help="Relative path to the evaluation score folder, if different from the default; Path should be relative to the `berkeley-function-call-leaderboard` root folder",
     ),
+    partial_eval: bool = typer.Option(
+        False,
+        "--partial-eval",
+        help="Run evaluation on a partial set of benchmark entries (eg. entries present in the model result files) without raising for missing IDs.",
+    ),
 ):
     """
     Evaluate results from run of one or more models on a test-category (same as eval_runner.py).

--- a/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py
@@ -31,28 +31,40 @@ def get_handler(model_name: str) -> BaseHandler:
     return handler
 
 
-def _align_entries_to_model_results(
-    model_result: list[dict],
-    entries: list[dict],
-    entry_label: str,
-    test_category: str,
-) -> list[dict]:
-    """Match dataset metadata (prompt/ground truth) to the subset of IDs we actually generated."""
-    if not entries:
-        return entries
-    entry_by_id = {entry["id"]: entry for entry in entries}
-    missing_ids = [
-        result_entry["id"]
-        for result_entry in model_result
-        if result_entry["id"] not in entry_by_id
-    ]
-    if missing_ids:
-        missing_ids_str = ", ".join(sorted(missing_ids))
+def _subset_entries_by_model_ids(
+    model_result_entries: list[dict],
+    prompt_entries: list[dict],
+    ground_truth_entries: list[dict],
+    allow_missing: bool = False,
+):
+    """
+    Filter the prompt and ground truth entries so that its order/length matches the IDs present in `model_result`. When `allow_missing` is False, all IDs must be present; otherwise, any missing IDs are silently ignored.
+    """
+    if not model_result_entries:
+        return [], []
+
+    if not allow_missing and (
+        len(model_result_entries) != len(prompt_entries)
+        or len(model_result_entries) != len(ground_truth_entries)
+    ):
         raise ValueError(
-            f"Missing {entry_label} entries for IDs {missing_ids_str} in '{test_category}'."
-            " Confirm your `--run-ids` list matches the benchmark dataset."
+            f"Length of model result ({len(model_result_entries)}) does not match length of test entries ({len(prompt_entries)}) or ground truth entries ({len(ground_truth_entries)}). If you intended to run only on a subset (eg. entries present in the model result), please pass the `--partial-eval` flag."
         )
-    return [entry_by_id[result_entry["id"]] for result_entry in model_result]
+
+    all_present_ids = {entry["id"]: entry for entry in model_result_entries}
+
+    filtered_prompt_entries = [
+        prompt_entry
+        for prompt_entry in prompt_entries
+        if prompt_entry["id"] in all_present_ids
+    ]
+    filtered_ground_truth_entries = [
+        ground_truth_entry
+        for ground_truth_entry in ground_truth_entries
+        if ground_truth_entry["id"] in all_present_ids
+    ]
+
+    return filtered_prompt_entries, filtered_ground_truth_entries
 
 
 def _evaluate_single_agentic_entry(
@@ -98,7 +110,9 @@ def _evaluate_single_agentic_entry(
     for model_result_item in model_result_list[0]:
         # model_result_item is per step
         try:
-            decoded_result: list[str] = handler.decode_execute(model_result_item, has_tool_call_tag=False)
+            decoded_result: list[str] = handler.decode_execute(
+                model_result_item, has_tool_call_tag=False
+            )
             if is_empty_execute_response(decoded_result):
                 last_unsuccessful_decoding_message = model_result_item
                 continue
@@ -206,7 +220,9 @@ def _evaluate_single_multi_turn_entry(
         for model_result_item in single_turn_model_result_list:
             # model_result_item is per step
             try:
-                decoded_result: list[str] = handler.decode_execute(model_result_item, has_tool_call_tag=False)
+                decoded_result: list[str] = handler.decode_execute(
+                    model_result_item, has_tool_call_tag=False
+                )
                 if is_empty_execute_response(decoded_result):
                     # Empty output is not considered as a valid function call
                     continue
@@ -654,6 +670,7 @@ def evaluate_task(
     model_name,
     handler,
     leaderboard_table,
+    allow_missing: bool = False,
 ):
     print(f"🔍 Running test: {test_category}")
 
@@ -663,11 +680,12 @@ def evaluate_task(
     prompt = load_dataset_entry(
         test_category, include_prereq=False, include_language_specific_hint=False
     )
-    prompt = _align_entries_to_model_results(
-        model_result, prompt, "prompt", test_category
-    )
 
     if is_relevance_or_irrelevance(test_category):
+        prompt, _ = _subset_entries_by_model_ids(
+            model_result, prompt, [], allow_missing=allow_missing
+        )
+
         accuracy, total_count = relevance_file_runner(
             handler, model_result, prompt, model_name, test_category, score_dir
         )
@@ -675,8 +693,13 @@ def evaluate_task(
     else:
         # Find the corresponding possible answer entries
         possible_answer = load_ground_truth_entry(test_category)
-        possible_answer = _align_entries_to_model_results(
-            model_result, possible_answer, "ground truth", test_category
+        # Sanity: prompt and ground truth should be 1:1
+        assert len(prompt) == len(
+            possible_answer
+        ), "Length of ground truth should match prompt entries."
+
+        prompt, possible_answer = _subset_entries_by_model_ids(
+            model_result, prompt, possible_answer, allow_missing=allow_missing
         )
 
         if is_format_sensitivity(test_category):
@@ -730,7 +753,9 @@ def evaluate_task(
     return leaderboard_table
 
 
-def runner(model_names, test_categories, result_dir, score_dir):
+def runner(
+    model_names, test_categories, result_dir, score_dir, allow_missing: bool = False
+):
 
     # A dictionary to store the evaluation scores.
     # Key is model name, value is a dictionary with keys as test category
@@ -782,6 +807,7 @@ def runner(model_names, test_categories, result_dir, score_dir):
                 model_name,
                 handler,
                 leaderboard_table,
+                allow_missing=allow_missing,
             )
 
     # This function reads all the score files from local folder and updates the
@@ -792,7 +818,7 @@ def runner(model_names, test_categories, result_dir, score_dir):
     generate_leaderboard_csv(leaderboard_table, score_dir)
 
 
-def main(model, test_categories, result_dir, score_dir):
+def main(model, test_categories, result_dir, score_dir, partial_eval: bool = False):
     if result_dir is None:
         result_dir = RESULT_PATH
     else:
@@ -820,11 +846,21 @@ def main(model, test_categories, result_dir, score_dir):
             model_names.append(model_name.replace("/", "_"))
 
     # Driver function to run the evaluation for all categories involved.
-    runner(model_names, all_test_categories, result_dir, score_dir)
+    runner(
+        model_names,
+        all_test_categories,
+        result_dir,
+        score_dir,
+        allow_missing=partial_eval,
+    )
 
     print(
         f"🏁 Evaluation completed. See {score_dir / 'data_overall.csv'} for overall evaluation results on BFCL V4."
     )
+    if partial_eval:
+        print(
+            "⚠️  Partial evaluation for a single category is enabled (--partial-run flag is set). Accuracy scores are computed only on the subset of entries present in the model result files, which may differ from a full evaluation and from the official leaderboard score."
+        )
     print(
         f"See {score_dir / 'data_live.csv'}, {score_dir / 'data_non_live.csv'}, {score_dir / 'data_multi_turn.csv'}, {score_dir / 'data_agentic.csv'} and {score_dir / 'data_format_sensitivity.csv'} for detailed evaluation results on each sub-section categories respectively."
     )
@@ -857,6 +893,15 @@ if __name__ == "__main__":
         help="Path to the folder where the evaluation score files will be stored; relative to the `berkeley-function-call-leaderboard` root folder",
     )
 
+    # When this flag is set, the evaluator will run on whichever entries are present in the model result files.
+    # It will **not** assume full coverage of the benchmark and will emit a warning at the end because the
+    # accuracy may differ from a full-set evaluation.
+    parser.add_argument(
+        "--partial-eval",
+        action="store_true",
+        help="Run evaluation on a partial set of benchmark entries without raising for missing IDs.",
+    )
+
     args = parser.parse_args()
 
     load_dotenv(dotenv_path=DOTENV_PATH, verbose=True, override=True)  # Load the .env file
@@ -865,4 +910,5 @@ if __name__ == "__main__":
         args.test_category,
         args.result_dir,
         args.score_dir,
+        partial_eval=args.partial_eval,
     )

--- a/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py
@@ -892,14 +892,11 @@ if __name__ == "__main__":
         type=str,
         help="Path to the folder where the evaluation score files will be stored; relative to the `berkeley-function-call-leaderboard` root folder",
     )
-
-    # When this flag is set, the evaluator will run on whichever entries are present in the model result files.
-    # It will **not** assume full coverage of the benchmark and will emit a warning at the end because the
-    # accuracy may differ from a full-set evaluation.
     parser.add_argument(
         "--partial-eval",
+        default=False,
         action="store_true",
-        help="Run evaluation on a partial set of benchmark entries without raising for missing IDs.",
+        help="Run evaluation on a partial set of benchmark entries (eg. entries present in the model result files) without raising for missing IDs.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
### Summary
This PR fixes issue #1159 where running evaluation with a subset of IDs caused:
**AssertionError: The length of the model result (1) does not match the length of the prompt (400) or possible answer (400).**
### Changes

1. Introduces `--partial-eval` to the CLI so users can deliberately score an incomplete result file.
2. Realigns prompts / ground-truth rows to the IDs present in the model result via the new helper `_subset_entries_by_model_ids`.
3. Improves error handling – when `--partial-eval` is not supplied, a clear `ValueError` explains the remedy instead of a generic assertion.

### Testing
- Verified that evaluation now succeeds when generating only a subset of IDs.

### Related Issues
Fixes #1159