### PR TITLE
[BFCL] Using model_name attribute

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/.env.example
+++ b/berkeley-function-call-leaderboard/bfcl_eval/.env.example
@@ -3,6 +3,9 @@ SERPAPI_API_KEY=
 
 # Provide the API key for the model(s) you intend to use
 OPENAI_API_KEY=sk-XXXXXX
+OPENAI_DEFAULT_HEADERS=
+OPENAI_BASE_URL=
+
 ANTHROPIC_API_KEY=
 # We use Google AI Studio to inference Google Gemini models
 GOOGLE_API_KEY=

--- a/berkeley-function-call-leaderboard/bfcl_eval/_llm_response_generation.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/_llm_response_generation.py
@@ -64,9 +64,12 @@ def get_args():
 
 def build_handler(model_name, temperature):
     config = MODEL_CONFIG_MAPPING[model_name]
-    handler = config.model_handler(model_name, temperature)
-    # Propagate config flags to the handler instance
-    handler.is_fc_model = config.is_fc_model
+    handler = config.model_handler(
+        model_name=config.model_name,
+        temperature=temperature,
+        registry_name=model_name,
+        is_fc_model=config.is_fc_model,
+    )
     return handler
 
 
@@ -206,7 +209,11 @@ def generate_results(args, model_name, test_cases_total):
         is_oss_model = True
         # For OSS models, if the user didn't explicitly set the number of threads,
         # we default to 100 threads to speed up the inference.
-        num_threads = args.num_threads if args.num_threads is not None else LOCAL_SERVER_MAX_CONCURRENT_REQUEST
+        num_threads = (
+            args.num_threads
+            if args.num_threads is not None
+            else LOCAL_SERVER_MAX_CONCURRENT_REQUEST
+        )
     else:
         handler: BaseHandler
         is_oss_model = False

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -126,7 +126,7 @@ api_inference_model_map = {
     ),
     "DeepSeek-R1-0528": ModelConfig(
         model_name="DeepSeek-R1-0528",
-        display_name="DeepSeek-R1-0528 (Prompt) (Reasoning)",
+        display_name="DeepSeek-R1-0528 (Prompt)",
         url="https://api-docs.deepseek.com/news/news250528",
         org="DeepSeek",
         license="MIT",
@@ -138,7 +138,7 @@ api_inference_model_map = {
     ),
     "DeepSeek-R1-0528-FC": ModelConfig(
         model_name="DeepSeek-R1-0528-FC",
-        display_name="DeepSeek-R1-0528 (FC) (Reasoning)",
+        display_name="DeepSeek-R1-0528 (FC)",
         url="https://api-docs.deepseek.com/news/news250528",
         org="DeepSeek",
         license="MIT",
@@ -162,7 +162,7 @@ api_inference_model_map = {
     ),
     "gpt-5-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-2025-08-07",
-        display_name="GPT-5-2025-08-07 (FC) (Reasoning)",
+        display_name="GPT-5-2025-08-07 (FC)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -174,7 +174,7 @@ api_inference_model_map = {
     ),
     "gpt-5-2025-08-07": ModelConfig(
         model_name="gpt-5-2025-08-07",
-        display_name="GPT-5-2025-08-07 (Prompt) (Reasoning)",
+        display_name="GPT-5-2025-08-07 (Prompt)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -186,7 +186,7 @@ api_inference_model_map = {
     ),
     "gpt-5-mini-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-mini-2025-08-07",
-        display_name="GPT-5-mini-2025-08-07 (FC) (Reasoning)",
+        display_name="GPT-5-mini-2025-08-07 (FC)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -198,7 +198,7 @@ api_inference_model_map = {
     ),
     "gpt-5-mini-2025-08-07": ModelConfig(
         model_name="gpt-5-mini-2025-08-07",
-        display_name="GPT-5-mini-2025-08-07 (Prompt) (Reasoning)",
+        display_name="GPT-5-mini-2025-08-07 (Prompt)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -210,7 +210,7 @@ api_inference_model_map = {
     ),
     "gpt-5-nano-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-nano-2025-08-07",
-        display_name="GPT-5-nano-2025-08-07 (FC) (Reasoning)",
+        display_name="GPT-5-nano-2025-08-07 (FC)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -222,7 +222,7 @@ api_inference_model_map = {
     ),
     "gpt-5-nano-2025-08-07": ModelConfig(
         model_name="gpt-5-nano-2025-08-07",
-        display_name="GPT-5-nano-2025-08-07 (Prompt) (Reasoning)",
+        display_name="GPT-5-nano-2025-08-07 (Prompt)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -354,7 +354,7 @@ api_inference_model_map = {
     ),
     "o3-2025-04-16": ModelConfig(
         model_name="o3-2025-04-16",
-        display_name="o3-2025-04-16 (Prompt) (Reasoning)",
+        display_name="o3-2025-04-16 (Prompt)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
         license="Proprietary",
@@ -366,7 +366,7 @@ api_inference_model_map = {
     ),
     "o3-2025-04-16-FC": ModelConfig(
         model_name="o3-2025-04-16",
-        display_name="o3-2025-04-16 (FC) (Reasoning)",
+        display_name="o3-2025-04-16 (FC)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
         license="Proprietary",
@@ -378,7 +378,7 @@ api_inference_model_map = {
     ),
     "o4-mini-2025-04-16": ModelConfig(
         model_name="o4-mini-2025-04-16",
-        display_name="o4-mini-2025-04-16 (Prompt) (Reasoning)",
+        display_name="o4-mini-2025-04-16 (Prompt)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
         license="Proprietary",
@@ -390,7 +390,7 @@ api_inference_model_map = {
     ),
     "o4-mini-2025-04-16-FC": ModelConfig(
         model_name="o4-mini-2025-04-16",
-        display_name="o4-mini-2025-04-16 (FC) (Reasoning)",
+        display_name="o4-mini-2025-04-16 (FC)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
         license="Proprietary",
@@ -402,7 +402,7 @@ api_inference_model_map = {
     ),
     "claude-opus-4-1-20250805": ModelConfig(
         model_name="claude-opus-4-1-20250805",
-        display_name="Claude-Opus-4-1-20250805 (Prompt) (Reasoning)",
+        display_name="Claude-Opus-4-1-20250805 (Prompt)",
         url="https://www.anthropic.com/news/claude-4",
         org="Anthropic",
         license="Proprietary",
@@ -414,7 +414,7 @@ api_inference_model_map = {
     ),
     "claude-opus-4-1-20250805-FC": ModelConfig(
         model_name="claude-opus-4-1-20250805",
-        display_name="Claude-Opus-4-1-20250805 (FC) (Reasoning)",
+        display_name="Claude-Opus-4-1-20250805 (FC)",
         url="https://www.anthropic.com/news/claude-4",
         org="Anthropic",
         license="Proprietary",
@@ -426,7 +426,7 @@ api_inference_model_map = {
     ),
     "claude-sonnet-4-20250514": ModelConfig(
         model_name="claude-sonnet-4-20250514",
-        display_name="Claude-Sonnet-4-20250514 (Prompt) (Reasoning)",
+        display_name="Claude-Sonnet-4-20250514 (Prompt)",
         url="https://www.anthropic.com/news/claude-4",
         org="Anthropic",
         license="Proprietary",
@@ -438,7 +438,7 @@ api_inference_model_map = {
     ),
     "claude-sonnet-4-20250514-FC": ModelConfig(
         model_name="claude-sonnet-4-20250514",
-        display_name="Claude-Sonnet-4-20250514 (FC) (Reasoning)",
+        display_name="Claude-Sonnet-4-20250514 (FC)",
         url="https://www.anthropic.com/news/claude-4",
         org="Anthropic",
         license="Proprietary",
@@ -534,7 +534,7 @@ api_inference_model_map = {
     ),
     "mistral-large-2411": ModelConfig(
         model_name="mistral-large-2411",
-        display_name="mistral-large-2411 (Prompt) (Reasoning)",
+        display_name="mistral-large-2411 (Prompt)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -546,7 +546,7 @@ api_inference_model_map = {
     ),
     "mistral-large-2411-FC": ModelConfig(
         model_name="mistral-large-2411",
-        display_name="mistral-large-2411 (FC) (Reasoning)",
+        display_name="mistral-large-2411 (FC)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -630,7 +630,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash-lite-preview-06-17": ModelConfig(
         model_name="gemini-2.5-flash-lite-preview-06-17",
-        display_name="Gemini-2.5-Flash-Lite-Preview-06-17 (Prompt) (Reasoning)",
+        display_name="Gemini-2.5-Flash-Lite-Preview-06-17 (Prompt)",
         url="https://deepmind.google/technologies/gemini/flash-lite/",
         org="Google",
         license="Proprietary",
@@ -654,7 +654,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash": ModelConfig(
         model_name="gemini-2.5-flash",
-        display_name="Gemini-2.5-Flash (Prompt) (Reasoning)",
+        display_name="Gemini-2.5-Flash (Prompt)",
         url="https://deepmind.google/technologies/gemini/flash/",
         org="Google",
         license="Proprietary",
@@ -678,7 +678,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-pro": ModelConfig(
         model_name="gemini-2.5-pro",
-        display_name="Gemini-2.5-Pro (Prompt) (Reasoning)",
+        display_name="Gemini-2.5-Pro (Prompt)",
         url="https://deepmind.google/technologies/gemini/pro/",
         org="Google",
         license="Proprietary",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -165,7 +165,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "gpt-5-2025-08-07-FC": ModelConfig(
-        model_name="gpt-5-2025-08-07-FC",
+        model_name="gpt-5-2025-08-07",
         display_name="GPT-5-2025-08-07 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
@@ -191,7 +191,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "gpt-5-mini-2025-08-07-FC": ModelConfig(
-        model_name="gpt-5-mini-2025-08-07-FC",
+        model_name="gpt-5-mini-2025-08-07",
         display_name="GPT-5-mini-2025-08-07 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
@@ -217,7 +217,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "gpt-5-nano-2025-08-07-FC": ModelConfig(
-        model_name="gpt-5-nano-2025-08-07-FC",
+        model_name="gpt-5-nano-2025-08-07",
         display_name="GPT-5-nano-2025-08-07 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
@@ -243,7 +243,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "gpt-4.1-2025-04-14-FC": ModelConfig(
-        model_name="gpt-4.1-2025-04-14-FC",
+        model_name="gpt-4.1-2025-04-14",
         display_name="GPT-4.1-2025-04-14 (FC)",
         url="https://openai.com/index/gpt-4-1/",
         org="OpenAI",
@@ -267,7 +267,7 @@ api_inference_model_map = {
         underscore_to_dot=False,
     ),
     "gpt-4.1-mini-2025-04-14-FC": ModelConfig(
-        model_name="gpt-4.1-mini-2025-04-14-FC",
+        model_name="gpt-4.1-mini-2025-04-14",
         display_name="GPT-4.1-mini-2025-04-14 (FC)",
         url="https://openai.com/index/gpt-4-1/",
         org="OpenAI",
@@ -291,7 +291,7 @@ api_inference_model_map = {
         underscore_to_dot=False,
     ),
     "gpt-4.1-nano-2025-04-14-FC": ModelConfig(
-        model_name="gpt-4.1-nano-2025-04-14-FC",
+        model_name="gpt-4.1-nano-2025-04-14",
         display_name="GPT-4.1-nano-2025-04-14 (FC)",
         url="https://openai.com/index/gpt-4-1/",
         org="OpenAI",
@@ -327,7 +327,7 @@ api_inference_model_map = {
         underscore_to_dot=False,
     ),
     "gpt-4o-2024-11-20-FC": ModelConfig(
-        model_name="gpt-4o-2024-11-20-FC",
+        model_name="gpt-4o-2024-11-20",
         display_name="GPT-4o-2024-11-20 (FC)",
         url="https://openai.com/index/hello-gpt-4o/",
         org="OpenAI",
@@ -351,7 +351,7 @@ api_inference_model_map = {
         underscore_to_dot=False,
     ),
     "gpt-4o-mini-2024-07-18-FC": ModelConfig(
-        model_name="gpt-4o-mini-2024-07-18-FC",
+        model_name="gpt-4o-mini-2024-07-18",
         display_name="GPT-4o-mini-2024-07-18 (FC)",
         url="https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/",
         org="OpenAI",
@@ -376,7 +376,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "o3-2025-04-16-FC": ModelConfig(
-        model_name="o3-2025-04-16-FC",
+        model_name="o3-2025-04-16",
         display_name="o3-2025-04-16 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
@@ -402,7 +402,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "o4-mini-2025-04-16-FC": ModelConfig(
-        model_name="o4-mini-2025-04-16-FC",
+        model_name="o4-mini-2025-04-16",
         display_name="o4-mini-2025-04-16 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
@@ -479,7 +479,7 @@ api_inference_model_map = {
         underscore_to_dot=False,
     ),
     "claude-3-5-haiku-20241022-FC": ModelConfig(
-        model_name="claude-3-5-haiku-20241022-FC",
+        model_name="claude-3-5-haiku-20241022",
         display_name="claude-3.5-haiku-20241022 (FC)",
         url="https://www.anthropic.com/news/3-5-models-and-computer-use",
         org="Anthropic",
@@ -491,7 +491,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "nova-pro-v1.0": ModelConfig(
-        model_name="nova-pro-v1.0",
+        model_name="nova-pro-v1:0",
         display_name="Amazon-Nova-Pro-v1:0 (FC)",
         url="https://aws.amazon.com/cn/ai/generative-ai/nova/",
         org="Amazon",
@@ -503,7 +503,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "nova-lite-v1.0": ModelConfig(
-        model_name="nova-lite-v1.0",
+        model_name="nova-lite-v1:0",
         display_name="Amazon-Nova-Lite-v1:0 (FC)",
         url="https://aws.amazon.com/cn/ai/generative-ai/nova/",
         org="Amazon",
@@ -515,7 +515,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "nova-micro-v1.0": ModelConfig(
-        model_name="nova-micro-v1.0",
+        model_name="nova-micro-v1:0",
         display_name="Amazon-Nova-Micro-v1:0 (FC)",
         url="https://aws.amazon.com/cn/ai/generative-ai/nova/",
         org="Amazon",
@@ -539,7 +539,7 @@ api_inference_model_map = {
         underscore_to_dot=False,
     ),
     "open-mistral-nemo-2407-FC": ModelConfig(
-        model_name="open-mistral-nemo-2407-FC",
+        model_name="open-mistral-nemo-2407",
         display_name="Open-Mistral-Nemo-2407 (FC)",
         url="https://mistral.ai/news/mistral-nemo/",
         org="Mistral AI",
@@ -564,7 +564,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "mistral-large-2411-FC": ModelConfig(
-        model_name="mistral-large-2411-FC",
+        model_name="mistral-large-2411",
         display_name="mistral-large-2411 (FC) (Reasoning)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
@@ -590,7 +590,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "mistral-small-2506-FC": ModelConfig(
-        model_name="mistral-small-2506-FC",
+        model_name="mistral-small-2506",
         display_name="Mistral-small-2506 (FC) (Reasoning)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
@@ -616,7 +616,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "mistral-medium-2505-FC": ModelConfig(
-        model_name="mistral-medium-2505-FC",
+        model_name="mistral-medium-2505",
         display_name="Mistral-Medium-2505 (FC) (Reasoning)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
@@ -629,7 +629,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "firefunction-v2-FC": ModelConfig(
-        model_name="firefunction-v2-FC",
+        model_name="firefunction-v2",
         display_name="FireFunction-v2 (FC)",
         url="https://huggingface.co/fireworks-ai/firefunction-v2",
         org="Fireworks",
@@ -641,7 +641,7 @@ api_inference_model_map = {
         underscore_to_dot=False,
     ),
     "gemini-2.5-flash-lite-preview-06-17-FC": ModelConfig(
-        model_name="gemini-2.5-flash-lite-preview-06-17-FC",
+        model_name="gemini-2.5-flash-lite-preview-06-17",
         display_name="Gemini-2.5-Flash-Lite-Preview-06-17 (FC)",
         url="https://deepmind.google/technologies/gemini/flash-lite/",
         org="Google",
@@ -666,7 +666,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "gemini-2.5-flash-FC": ModelConfig(
-        model_name="gemini-2.5-flash-FC",
+        model_name="gemini-2.5-flash",
         display_name="Gemini-2.5-Flash (FC)",
         url="https://deepmind.google/technologies/gemini/flash/",
         org="Google",
@@ -690,7 +690,7 @@ api_inference_model_map = {
         underscore_to_dot=False,
     ),
     "gemini-2.5-pro-FC": ModelConfig(
-        model_name="gemini-2.5-pro-FC",
+        model_name="gemini-2.5-pro",
         display_name="Gemini-2.5-Pro (FC) (Reasoning)",
         url="https://deepmind.google/technologies/gemini/pro/",
         org="Google",
@@ -716,7 +716,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "meetkai/functionary-small-v3.1-FC": ModelConfig(
-        model_name="meetkai/functionary-small-v3.1-FC",
+        model_name="meetkai/functionary-small-v3.1",
         display_name="Functionary-Small-v3.1 (FC)",
         url="https://huggingface.co/meetkai/functionary-small-v3.1",
         org="MeetKai",
@@ -728,7 +728,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "meetkai/functionary-medium-v3.1-FC": ModelConfig(
-        model_name="meetkai/functionary-medium-v3.1-FC",
+        model_name="meetkai/functionary-medium-v3.1",
         display_name="Functionary-Medium-v3.1 (FC)",
         url="https://huggingface.co/meetkai/functionary-medium-v3.1",
         org="MeetKai",
@@ -740,7 +740,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "command-r7b-12-2024-FC": ModelConfig(
-        model_name="command-r7b-12-2024-FC",
+        model_name="command-r7b-12-2024",
         display_name="Command R7B (FC) (Reasoning)",
         url="https://cohere.com/blog/command-r7b",
         org="Cohere",
@@ -753,7 +753,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "command-a-03-2025-FC": ModelConfig(
-        model_name="command-a-03-2025-FC",
+        model_name="command-a-03-2025",
         display_name="Command A (FC)",
         url="https://cohere.com/blog/command-a",
         org="Cohere",
@@ -815,7 +815,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "grok-4-0709-FC": ModelConfig(
-        model_name="grok-4-0709-FC",
+        model_name="grok-4-0709",
         display_name="Grok-4-0709 (FC) (Reasoning)",
         url="https://docs.x.ai/docs/models",
         org="xAI",
@@ -841,7 +841,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "qwen3-0.6b-FC": ModelConfig(
-        model_name="qwen3-0.6b-FC",
+        model_name="qwen3-0.6b",
         display_name="Qwen3-0.6B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-0.6B",
         org="Qwen",
@@ -867,7 +867,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "qwen3-1.7b-FC": ModelConfig(
-        model_name="qwen3-1.7b-FC",
+        model_name="qwen3-1.7b",
         display_name="Qwen3-1.7B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
@@ -893,7 +893,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "qwen3-4b-FC": ModelConfig(
-        model_name="qwen3-4b-FC",
+        model_name="qwen3-4b",
         display_name="Qwen3-4B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-4B",
         org="Qwen",
@@ -919,7 +919,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "qwen3-8b-FC": ModelConfig(
-        model_name="qwen3-8b-FC",
+        model_name="qwen3-8b",
         display_name="Qwen3-8B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
@@ -945,7 +945,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "qwen3-14b-FC": ModelConfig(
-        model_name="qwen3-14b-FC",
+        model_name="qwen3-14b",
         display_name="Qwen3-14B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
@@ -971,7 +971,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "qwen3-32b-FC": ModelConfig(
-        model_name="qwen3-32b-FC",
+        model_name="qwen3-32b",
         display_name="Qwen3-32B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
@@ -1023,7 +1023,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "qwen3-235b-a22b-instruct-2507-FC": ModelConfig(
-        model_name="qwen3-235b-a22b-instruct-2507-FC",
+        model_name="qwen3-235b-a22b-instruct-2507",
         display_name="Qwen3-235B-A22B-Instruct-2507 (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507",
         org="Qwen",
@@ -1049,7 +1049,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "qwq-32b-FC": ModelConfig(
-        model_name="qwq-32b-FC",
+        model_name="qwq-32b",
         display_name="QwQ-32B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
@@ -1111,7 +1111,7 @@ api_inference_model_map = {
         underscore_to_dot=False,
     ),
     "glm-4.5-FC": ModelConfig(
-        model_name="glm-4.5-FC",
+        model_name="glm-4.5",
         display_name="GLM-4.5 (FC) (Reasoning)",
         url="https://huggingface.co/zai-org/GLM-4.5",
         org="Zhipu AI",
@@ -1124,7 +1124,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "glm-4.5-air-FC": ModelConfig(
-        model_name="glm-4.5-air-FC",
+        model_name="glm-4.5-air",
         display_name="GLM-4.5-Air (FC) (Reasoning)",
         url="https://huggingface.co/zai-org/GLM-4.5-Air",
         org="Zhipu AI",
@@ -1137,7 +1137,7 @@ api_inference_model_map = {
         reasoning_mode=True,
     ),
     "kimi-k2-0711-preview-FC": ModelConfig(
-        model_name="moonshotai/Kimi-K2-Instruct-FC",
+        model_name="moonshotai/Kimi-K2-Instruct",
         display_name="Moonshotai-Kimi-K2-Instruct (FC) (Reasoning)",
         url="https://huggingface.co/moonshotai/Kimi-K2-Instruct",
         org="MoonshotAI",
@@ -1228,7 +1228,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "meta-llama/Llama-3.1-8B-Instruct-FC": ModelConfig(
-        model_name="meta-llama/Llama-3.1-8B-Instruct-FC",
+        model_name="meta-llama/Llama-3.1-8B-Instruct",
         display_name="Llama-3.1-8B-Instruct (FC) (Reasoning)",
         url="https://llama.meta.com/llama3",
         org="Meta",
@@ -1254,7 +1254,7 @@ local_inference_model_map = {
         reasoning_mode=True,
     ),
     "meta-llama/Llama-3.1-70B-Instruct-FC": ModelConfig(
-        model_name="meta-llama/Llama-3.1-70B-Instruct-FC",
+        model_name="meta-llama/Llama-3.1-70B-Instruct",
         display_name="Llama-3.1-70B-Instruct (FC) (Reasoning)",
         url="https://llama.meta.com/llama3",
         org="Meta",
@@ -1280,7 +1280,7 @@ local_inference_model_map = {
         reasoning_mode=True,
     ),
     "meta-llama/Llama-3.2-1B-Instruct-FC": ModelConfig(
-        model_name="meta-llama/Llama-3.2-1B-Instruct-FC",
+        model_name="meta-llama/Llama-3.2-1B-Instruct",
         display_name="Llama-3.2-1B-Instruct (FC)",
         url="https://llama.meta.com/llama3",
         org="Meta",
@@ -1292,7 +1292,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "meta-llama/Llama-3.2-3B-Instruct-FC": ModelConfig(
-        model_name="meta-llama/Llama-3.2-3B-Instruct-FC",
+        model_name="meta-llama/Llama-3.2-3B-Instruct",
         display_name="Llama-3.2-3B-Instruct (FC)",
         url="https://llama.meta.com/llama3",
         org="Meta",
@@ -1304,7 +1304,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "meta-llama/Llama-3.3-70B-Instruct-FC": ModelConfig(
-        model_name="meta-llama/Llama-3.3-70B-Instruct-FC",
+        model_name="meta-llama/Llama-3.3-70B-Instruct",
         display_name="Llama-3.3-70B-Instruct (FC)",
         url="https://llama.meta.com/llama3",
         org="Meta",
@@ -1316,7 +1316,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "meta-llama/Llama-4-Scout-17B-16E-Instruct-FC": ModelConfig(
-        model_name="meta-llama/Llama-4-Scout-17B-16E-Instruct-FC",
+        model_name="meta-llama/Llama-4-Scout-17B-16E-Instruct",
         display_name="Llama-4-Scout-17B-16E-Instruct (FC)",
         url="https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
         org="Meta",
@@ -1328,7 +1328,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8-FC": ModelConfig(
-        model_name="meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8-FC",
+        model_name="meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
         display_name="Llama-4-Maverick-17B-128E-Instruct-FP8 (FC)",
         url="https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
         org="Meta",
@@ -1444,7 +1444,7 @@ local_inference_model_map = {
         reasoning_mode=True,
     ),
     "microsoft/Phi-4-mini-instruct-FC": ModelConfig(
-        model_name="microsoft/Phi-4-mini-instruct-FC",
+        model_name="microsoft/Phi-4-mini-instruct",
         display_name="Phi-4-mini-instruct (FC) (Reasoning)",
         url="https://huggingface.co/microsoft/Phi-4-mini-instruct",
         org="Microsoft",
@@ -1555,7 +1555,7 @@ local_inference_model_map = {
         underscore_to_dot=True,
     ),
     "Qwen/Qwen3-0.6B-FC": ModelConfig(
-        model_name="Qwen/Qwen3-0.6B-FC",
+        model_name="Qwen/Qwen3-0.6B",
         display_name="Qwen3-0.6B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-0.6B",
         org="Qwen",
@@ -1580,7 +1580,7 @@ local_inference_model_map = {
         reasoning_mode=True,
     ),
     "Qwen/Qwen3-1.7B-FC": ModelConfig(
-        model_name="Qwen/Qwen3-1.7B-FC",
+        model_name="Qwen/Qwen3-1.7B",
         display_name="Qwen3-1.7B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
@@ -1606,7 +1606,7 @@ local_inference_model_map = {
         reasoning_mode=True,
     ),
     "Qwen/Qwen3-4B-Instruct-2507-FC": ModelConfig(
-        model_name="Qwen/Qwen3-4B-Instruct-2507-FC",
+        model_name="Qwen/Qwen3-4B-Instruct-2507",
         display_name="Qwen3-4B-Instruct-2507 (FC)",
         url="https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507",
         org="Qwen",
@@ -1630,7 +1630,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "Qwen/Qwen3-8B-FC": ModelConfig(
-        model_name="Qwen/Qwen3-8B-FC",
+        model_name="Qwen/Qwen3-8B",
         display_name="Qwen3-8B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
@@ -1656,7 +1656,7 @@ local_inference_model_map = {
         reasoning_mode=True,
     ),
     "Qwen/Qwen3-14B-FC": ModelConfig(
-        model_name="Qwen/Qwen3-14B-FC",
+        model_name="Qwen/Qwen3-14B",
         display_name="Qwen3-14B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
@@ -1682,7 +1682,7 @@ local_inference_model_map = {
         reasoning_mode=True,
     ),
     "Qwen/Qwen3-32B-FC": ModelConfig(
-        model_name="Qwen/Qwen3-32B-FC",
+        model_name="Qwen/Qwen3-32B",
         display_name="Qwen3-32B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
@@ -1708,7 +1708,7 @@ local_inference_model_map = {
         reasoning_mode=True,
     ),
     "Qwen/Qwen3-30B-A3B-Instruct-2507-FC": ModelConfig(
-        model_name="Qwen/Qwen3-30B-A3B-Instruct-2507-FC",
+        model_name="Qwen/Qwen3-30B-A3B-Instruct-2507",
         display_name="Qwen3-30B-A3B-Instruct-2507 (FC)",
         url="https://huggingface.co/Qwen/Qwen3-30B-A3B-Instruct-2507",
         org="Qwen",
@@ -1780,7 +1780,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "openbmb/MiniCPM3-4B-FC": ModelConfig(
-        model_name="openbmb/MiniCPM3-4B-FC",
+        model_name="openbmb/MiniCPM3-4B",
         display_name="MiniCPM3-4B-FC (FC)",
         url="https://huggingface.co/openbmb/MiniCPM3-4B",
         org="openbmb",
@@ -1853,7 +1853,7 @@ local_inference_model_map = {
         reasoning_mode=True,
     ),
     "tiiuae/Falcon3-10B-Instruct-FC": ModelConfig(
-        model_name="tiiuae/Falcon3-10B-Instruct-FC",
+        model_name="tiiuae/Falcon3-10B-Instruct",
         display_name="Falcon3-10B-Instruct (FC)",
         url="https://huggingface.co/tiiuae/Falcon3-10B-Instruct",
         org="TII UAE",
@@ -1865,7 +1865,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "tiiuae/Falcon3-7B-Instruct-FC": ModelConfig(
-        model_name="tiiuae/Falcon3-7B-Instruct-FC",
+        model_name="tiiuae/Falcon3-7B-Instruct",
         display_name="Falcon3-7B-Instruct (FC)",
         url="https://huggingface.co/tiiuae/Falcon3-7B-Instruct",
         org="TII UAE",
@@ -1877,7 +1877,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "tiiuae/Falcon3-3B-Instruct-FC": ModelConfig(
-        model_name="tiiuae/Falcon3-3B-Instruct-FC",
+        model_name="tiiuae/Falcon3-3B-Instruct",
         display_name="Falcon3-3B-Instruct (FC)",
         url="https://huggingface.co/tiiuae/Falcon3-3B-Instruct",
         org="TII UAE",
@@ -1889,7 +1889,7 @@ local_inference_model_map = {
         underscore_to_dot=False,
     ),
     "tiiuae/Falcon3-1B-Instruct-FC": ModelConfig(
-        model_name="tiiuae/Falcon3-1B-Instruct-FC",
+        model_name="tiiuae/Falcon3-1B-Instruct",
         display_name="Falcon3-1B-Instruct (FC)",
         url="https://huggingface.co/tiiuae/Falcon3-1B-Instruct",
         org="TII UAE",
@@ -2040,7 +2040,7 @@ local_inference_model_map = {
 third_party_inference_model_map = {
     # Via Novita AI Endpoint
     "meta-llama/llama-4-maverick-17b-128e-instruct-fp8-novita": ModelConfig(
-        model_name="meta-llama/llama-4-maverick-17b-128e-instruct-fp8-novita",
+        model_name="meta-llama/llama-4-maverick-17b-128e-instruct-fp8",
         display_name="Llama-4-Maverick-17B-128E-Instruct-FP8 (Prompt) (Novita)",
         url="https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
         org="Meta",
@@ -2052,7 +2052,7 @@ third_party_inference_model_map = {
         underscore_to_dot=False,
     ),
     "meta-llama/llama-4-maverick-17b-128e-instruct-fp8-FC-novita": ModelConfig(
-        model_name="meta-llama/llama-4-maverick-17b-128e-instruct-fp8-FC-novita",
+        model_name="meta-llama/llama-4-maverick-17b-128e-instruct-fp8",
         display_name="Llama-4-Maverick-17B-128E-Instruct-FP8 (FC) (Novita)",
         url="https://huggingface.co/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
         org="Meta",
@@ -2064,7 +2064,7 @@ third_party_inference_model_map = {
         underscore_to_dot=True,
     ),
     "meta-llama/llama-4-scout-17b-16e-instruct-novita": ModelConfig(
-        model_name="meta-llama/llama-4-scout-17b-16e-instruct-novita",
+        model_name="meta-llama/llama-4-scout-17b-16e-instruct",
         display_name="Llama-4-Scout-17B-16E-Instruct (Prompt) (Novita)",
         url="https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
         org="Meta",
@@ -2076,7 +2076,7 @@ third_party_inference_model_map = {
         underscore_to_dot=False,
     ),
     "meta-llama/llama-4-scout-17b-16e-instruct-FC-novita": ModelConfig(
-        model_name="meta-llama/llama-4-scout-17b-16e-instruct-FC-novita",
+        model_name="meta-llama/llama-4-scout-17b-16e-instruct",
         display_name="Llama-4-Scout-17B-16E-Instruct (FC) (Novita)",
         url="https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E-Instruct",
         org="Meta",
@@ -2088,7 +2088,7 @@ third_party_inference_model_map = {
         underscore_to_dot=True,
     ),
     "qwen/qwq-32b-FC-novita": ModelConfig(
-        model_name="qwen/qwq-32b-FC-novita",
+        model_name="qwen/qwq-32b",
         display_name="Qwen/QwQ-32B (FC) (Novita) (Reasoning)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
@@ -2101,7 +2101,7 @@ third_party_inference_model_map = {
         reasoning_mode=True,
     ),
     "qwen/qwq-32b-novita": ModelConfig(
-        model_name="qwen/qwq-32b-novita",
+        model_name="qwen/qwq-32b",
         display_name="Qwen/QwQ-32B (Prompt) (Novita) (Reasoning)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -126,7 +126,7 @@ api_inference_model_map = {
     ),
     "DeepSeek-R1-0528": ModelConfig(
         model_name="DeepSeek-R1-0528",
-        display_name="DeepSeek-R1-0528 (Prompt)",
+        display_name="DeepSeek-R1-0528 (Prompt) (Reasoning)",
         url="https://api-docs.deepseek.com/news/news250528",
         org="DeepSeek",
         license="MIT",
@@ -138,7 +138,7 @@ api_inference_model_map = {
     ),
     "DeepSeek-R1-0528-FC": ModelConfig(
         model_name="DeepSeek-R1-0528-FC",
-        display_name="DeepSeek-R1-0528 (FC)",
+        display_name="DeepSeek-R1-0528 (FC) (Reasoning)",
         url="https://api-docs.deepseek.com/news/news250528",
         org="DeepSeek",
         license="MIT",
@@ -162,7 +162,7 @@ api_inference_model_map = {
     ),
     "gpt-5-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-2025-08-07-FC",
-        display_name="GPT-5-2025-08-07 (FC)",
+        display_name="GPT-5-2025-08-07 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -174,7 +174,7 @@ api_inference_model_map = {
     ),
     "gpt-5-2025-08-07": ModelConfig(
         model_name="gpt-5-2025-08-07",
-        display_name="GPT-5-2025-08-07 (Prompt)",
+        display_name="GPT-5-2025-08-07 (Prompt) (Reasoning)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -186,7 +186,7 @@ api_inference_model_map = {
     ),
     "gpt-5-mini-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-mini-2025-08-07-FC",
-        display_name="GPT-5-mini-2025-08-07 (FC)",
+        display_name="GPT-5-mini-2025-08-07 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -198,7 +198,7 @@ api_inference_model_map = {
     ),
     "gpt-5-mini-2025-08-07": ModelConfig(
         model_name="gpt-5-mini-2025-08-07",
-        display_name="GPT-5-mini-2025-08-07 (Prompt)",
+        display_name="GPT-5-mini-2025-08-07 (Prompt) (Reasoning)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -210,7 +210,7 @@ api_inference_model_map = {
     ),
     "gpt-5-nano-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-nano-2025-08-07-FC",
-        display_name="GPT-5-nano-2025-08-07 (FC)",
+        display_name="GPT-5-nano-2025-08-07 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -222,7 +222,7 @@ api_inference_model_map = {
     ),
     "gpt-5-nano-2025-08-07": ModelConfig(
         model_name="gpt-5-nano-2025-08-07",
-        display_name="GPT-5-nano-2025-08-07 (Prompt)",
+        display_name="GPT-5-nano-2025-08-07 (Prompt) (Reasoning)",
         url="https://openai.com/index/introducing-gpt-5/",
         org="OpenAI",
         license="Proprietary",
@@ -354,7 +354,7 @@ api_inference_model_map = {
     ),
     "o3-2025-04-16": ModelConfig(
         model_name="o3-2025-04-16",
-        display_name="o3-2025-04-16 (Prompt)",
+        display_name="o3-2025-04-16 (Prompt) (Reasoning)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
         license="Proprietary",
@@ -366,7 +366,7 @@ api_inference_model_map = {
     ),
     "o3-2025-04-16-FC": ModelConfig(
         model_name="o3-2025-04-16-FC",
-        display_name="o3-2025-04-16 (FC)",
+        display_name="o3-2025-04-16 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
         license="Proprietary",
@@ -378,7 +378,7 @@ api_inference_model_map = {
     ),
     "o4-mini-2025-04-16": ModelConfig(
         model_name="o4-mini-2025-04-16",
-        display_name="o4-mini-2025-04-16 (Prompt)",
+        display_name="o4-mini-2025-04-16 (Prompt) (Reasoning)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
         license="Proprietary",
@@ -390,7 +390,7 @@ api_inference_model_map = {
     ),
     "o4-mini-2025-04-16-FC": ModelConfig(
         model_name="o4-mini-2025-04-16-FC",
-        display_name="o4-mini-2025-04-16 (FC)",
+        display_name="o4-mini-2025-04-16 (FC) (Reasoning)",
         url="https://openai.com/index/introducing-o3-and-o4-mini/",
         org="OpenAI",
         license="Proprietary",
@@ -402,7 +402,7 @@ api_inference_model_map = {
     ),
     "claude-opus-4-1-20250805": ModelConfig(
         model_name="claude-opus-4-1-20250805",
-        display_name="Claude-Opus-4-1-20250805 (Prompt)",
+        display_name="Claude-Opus-4-1-20250805 (Prompt) (Reasoning)",
         url="https://www.anthropic.com/news/claude-4",
         org="Anthropic",
         license="Proprietary",
@@ -414,7 +414,7 @@ api_inference_model_map = {
     ),
     "claude-opus-4-1-20250805-FC": ModelConfig(
         model_name="claude-opus-4-1-20250805",
-        display_name="Claude-Opus-4-1-20250805 (FC)",
+        display_name="Claude-Opus-4-1-20250805 (FC) (Reasoning)",
         url="https://www.anthropic.com/news/claude-4",
         org="Anthropic",
         license="Proprietary",
@@ -426,7 +426,7 @@ api_inference_model_map = {
     ),
     "claude-sonnet-4-20250514": ModelConfig(
         model_name="claude-sonnet-4-20250514",
-        display_name="Claude-Sonnet-4-20250514 (Prompt)",
+        display_name="Claude-Sonnet-4-20250514 (Prompt) (Reasoning)",
         url="https://www.anthropic.com/news/claude-4",
         org="Anthropic",
         license="Proprietary",
@@ -438,7 +438,7 @@ api_inference_model_map = {
     ),
     "claude-sonnet-4-20250514-FC": ModelConfig(
         model_name="claude-sonnet-4-20250514",
-        display_name="Claude-Sonnet-4-20250514 (FC)",
+        display_name="Claude-Sonnet-4-20250514 (FC) (Reasoning)",
         url="https://www.anthropic.com/news/claude-4",
         org="Anthropic",
         license="Proprietary",
@@ -534,7 +534,7 @@ api_inference_model_map = {
     ),
     "mistral-large-2411": ModelConfig(
         model_name="mistral-large-2411",
-        display_name="mistral-large-2411 (Prompt)",
+        display_name="mistral-large-2411 (Prompt) (Reasoning)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -546,7 +546,7 @@ api_inference_model_map = {
     ),
     "mistral-large-2411-FC": ModelConfig(
         model_name="mistral-large-2411-FC",
-        display_name="mistral-large-2411 (FC)",
+        display_name="mistral-large-2411 (FC) (Reasoning)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -618,7 +618,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash-lite-preview-06-17-FC": ModelConfig(
         model_name="gemini-2.5-flash-lite-preview-06-17-FC",
-        display_name="Gemini-2.5-Flash-Lite-Preview-06-17 (FC)",
+        display_name="Gemini-2.5-Flash-Lite-Preview-06-17 (FC) (Reasoning)",
         url="https://deepmind.google/technologies/gemini/flash-lite/",
         org="Google",
         license="Proprietary",
@@ -630,7 +630,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash-lite-preview-06-17": ModelConfig(
         model_name="gemini-2.5-flash-lite-preview-06-17",
-        display_name="Gemini-2.5-Flash-Lite-Preview-06-17 (Prompt)",
+        display_name="Gemini-2.5-Flash-Lite-Preview-06-17 (Prompt) (Reasoning)",
         url="https://deepmind.google/technologies/gemini/flash-lite/",
         org="Google",
         license="Proprietary",
@@ -642,7 +642,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash-FC": ModelConfig(
         model_name="gemini-2.5-flash-FC",
-        display_name="Gemini-2.5-Flash (FC)",
+        display_name="Gemini-2.5-Flash (FC) (Reasoning)",
         url="https://deepmind.google/technologies/gemini/flash/",
         org="Google",
         license="Proprietary",
@@ -654,7 +654,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash": ModelConfig(
         model_name="gemini-2.5-flash",
-        display_name="Gemini-2.5-Flash (Prompt)",
+        display_name="Gemini-2.5-Flash (Prompt) (Reasoning)",
         url="https://deepmind.google/technologies/gemini/flash/",
         org="Google",
         license="Proprietary",
@@ -666,7 +666,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-pro-FC": ModelConfig(
         model_name="gemini-2.5-pro-FC",
-        display_name="Gemini-2.5-Pro (FC)",
+        display_name="Gemini-2.5-Pro (FC) (Reasoning)",
         url="https://deepmind.google/technologies/gemini/pro/",
         org="Google",
         license="Proprietary",
@@ -678,7 +678,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-pro": ModelConfig(
         model_name="gemini-2.5-pro",
-        display_name="Gemini-2.5-Pro (Prompt)",
+        display_name="Gemini-2.5-Pro (Prompt) (Reasoning)",
         url="https://deepmind.google/technologies/gemini/pro/",
         org="Google",
         license="Proprietary",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -558,7 +558,7 @@ api_inference_model_map = {
     ),
     "mistral-small-2506": ModelConfig(
         model_name="mistral-small-2506",
-        display_name="Mistral-Small-2506 (Prompt)",
+        display_name="Mistral-Small-2506 (Prompt) (Reasoning)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -570,7 +570,7 @@ api_inference_model_map = {
     ),
     "mistral-small-2506-FC": ModelConfig(
         model_name="mistral-small-2506-FC",
-        display_name="Mistral-small-2506 (FC)",
+        display_name="Mistral-small-2506 (FC) (Reasoning)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -582,7 +582,7 @@ api_inference_model_map = {
     ),
     "mistral-medium-2505": ModelConfig(
         model_name="mistral-medium-2505",
-        display_name="Mistral-Medium-2505",
+        display_name="Mistral-Medium-2505 (Reasoning)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -594,7 +594,7 @@ api_inference_model_map = {
     ),
     "mistral-medium-2505-FC": ModelConfig(
         model_name="mistral-medium-2505-FC",
-        display_name="Mistral-Medium-2505 (FC)",
+        display_name="Mistral-Medium-2505 (FC) (Reasoning)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -618,7 +618,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash-lite-preview-06-17-FC": ModelConfig(
         model_name="gemini-2.5-flash-lite-preview-06-17-FC",
-        display_name="Gemini-2.5-Flash-Lite-Preview-06-17 (FC) (Reasoning)",
+        display_name="Gemini-2.5-Flash-Lite-Preview-06-17 (FC)",
         url="https://deepmind.google/technologies/gemini/flash-lite/",
         org="Google",
         license="Proprietary",
@@ -642,7 +642,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash-FC": ModelConfig(
         model_name="gemini-2.5-flash-FC",
-        display_name="Gemini-2.5-Flash (FC) (Reasoning)",
+        display_name="Gemini-2.5-Flash (FC)",
         url="https://deepmind.google/technologies/gemini/flash/",
         org="Google",
         license="Proprietary",
@@ -654,7 +654,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash": ModelConfig(
         model_name="gemini-2.5-flash",
-        display_name="Gemini-2.5-Flash (Prompt) (Reasoning)",
+        display_name="Gemini-2.5-Flash (Prompt)",
         url="https://deepmind.google/technologies/gemini/flash/",
         org="Google",
         license="Proprietary",
@@ -714,7 +714,7 @@ api_inference_model_map = {
     ),
     "command-r7b-12-2024-FC": ModelConfig(
         model_name="command-r7b-12-2024-FC",
-        display_name="Command R7B (FC)",
+        display_name="Command R7B (FC) (Reasoning)",
         url="https://cohere.com/blog/command-r7b",
         org="Cohere",
         license="cc-by-nc-4.0",
@@ -738,7 +738,7 @@ api_inference_model_map = {
     ),
     "nvidia/llama-3.1-nemotron-ultra-253b-v1": ModelConfig(
         model_name="nvidia/llama-3.1-nemotron-ultra-253b-v1",
-        display_name="Llama-3.1-Nemotron-Ultra-253B-v1 (FC)",
+        display_name="Llama-3.1-Nemotron-Ultra-253B-v1 (FC) (Reasoning)",
         url="https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
         org="NVIDIA",
         license="nvidia-open-model-license",
@@ -774,7 +774,7 @@ api_inference_model_map = {
     ),
     "palmyra-x-004": ModelConfig(
         model_name="palmyra-x-004",
-        display_name="palmyra-x-004 (FC)",
+        display_name="palmyra-x-004 (FC) (Reasoning)",
         url="https://writer.com/engineering/actions-with-palmyra-x-004/",
         org="Writer",
         license="Proprietary",
@@ -786,7 +786,7 @@ api_inference_model_map = {
     ),
     "grok-4-0709-FC": ModelConfig(
         model_name="grok-4-0709-FC",
-        display_name="Grok-4-0709 (FC)",
+        display_name="Grok-4-0709 (FC) (Reasoning)",
         url="https://docs.x.ai/docs/models",
         org="xAI",
         license="Proprietary",
@@ -798,7 +798,7 @@ api_inference_model_map = {
     ),
     "grok-4-0709": ModelConfig(
         model_name="grok-4-0709",
-        display_name="Grok-4-0709 (Prompt)",
+        display_name="Grok-4-0709 (Prompt) (Reasoning)",
         url="https://docs.x.ai/docs/models",
         org="xAI",
         license="Proprietary",
@@ -810,7 +810,7 @@ api_inference_model_map = {
     ),
     "qwen3-0.6b-FC": ModelConfig(
         model_name="qwen3-0.6b-FC",
-        display_name="Qwen3-0.6B (FC)",
+        display_name="Qwen3-0.6B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-0.6B",
         org="Qwen",
         license="apache-2.0",
@@ -822,7 +822,7 @@ api_inference_model_map = {
     ),
     "qwen3-0.6b": ModelConfig(
         model_name="qwen3-0.6b",
-        display_name="Qwen3-0.6B (Prompt)",
+        display_name="Qwen3-0.6B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-0.6B",
         org="Qwen",
         license="apache-2.0",
@@ -834,7 +834,7 @@ api_inference_model_map = {
     ),
     "qwen3-1.7b-FC": ModelConfig(
         model_name="qwen3-1.7b-FC",
-        display_name="Qwen3-1.7B (FC)",
+        display_name="Qwen3-1.7B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
         license="apache-2.0",
@@ -846,7 +846,7 @@ api_inference_model_map = {
     ),
     "qwen3-1.7b": ModelConfig(
         model_name="qwen3-1.7b",
-        display_name="Qwen3-1.7B (Prompt)",
+        display_name="Qwen3-1.7B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
         license="apache-2.0",
@@ -858,7 +858,7 @@ api_inference_model_map = {
     ),
     "qwen3-4b-FC": ModelConfig(
         model_name="qwen3-4b-FC",
-        display_name="Qwen3-4B (FC)",
+        display_name="Qwen3-4B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-4B",
         org="Qwen",
         license="apache-2.0",
@@ -870,7 +870,7 @@ api_inference_model_map = {
     ),
     "qwen3-4b": ModelConfig(
         model_name="qwen3-4b",
-        display_name="Qwen3-4B (Prompt)",
+        display_name="Qwen3-4B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-4B",
         org="Qwen",
         license="apache-2.0",
@@ -882,7 +882,7 @@ api_inference_model_map = {
     ),
     "qwen3-8b-FC": ModelConfig(
         model_name="qwen3-8b-FC",
-        display_name="Qwen3-8B (FC)",
+        display_name="Qwen3-8B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
         license="apache-2.0",
@@ -894,7 +894,7 @@ api_inference_model_map = {
     ),
     "qwen3-8b": ModelConfig(
         model_name="qwen3-8b",
-        display_name="Qwen3-8B (Prompt)",
+        display_name="Qwen3-8B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
         license="apache-2.0",
@@ -906,7 +906,7 @@ api_inference_model_map = {
     ),
     "qwen3-14b-FC": ModelConfig(
         model_name="qwen3-14b-FC",
-        display_name="Qwen3-14B (FC)",
+        display_name="Qwen3-14B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
         license="apache-2.0",
@@ -918,7 +918,7 @@ api_inference_model_map = {
     ),
     "qwen3-14b": ModelConfig(
         model_name="qwen3-14b",
-        display_name="Qwen3-14B (Prompt)",
+        display_name="Qwen3-14B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
         license="apache-2.0",
@@ -930,7 +930,7 @@ api_inference_model_map = {
     ),
     "qwen3-32b-FC": ModelConfig(
         model_name="qwen3-32b-FC",
-        display_name="Qwen3-32B (FC)",
+        display_name="Qwen3-32B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
         license="apache-2.0",
@@ -942,7 +942,7 @@ api_inference_model_map = {
     ),
     "qwen3-32b": ModelConfig(
         model_name="qwen3-32b",
-        display_name="Qwen3-32B (Prompt)",
+        display_name="Qwen3-32B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
         license="apache-2.0",
@@ -954,7 +954,7 @@ api_inference_model_map = {
     ),
     "qwen3-30b-a3b-instruct-2507-FC": ModelConfig(
         model_name="qwen3-30b-a3b-instruct-2507",
-        display_name="Qwen3-30B-A3B-Instruct-2507 (FC)",
+        display_name="Qwen3-30B-A3B-Instruct-2507 (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-30B-A3B-Instruct-2507",
         org="Qwen",
         license="apache-2.0",
@@ -966,7 +966,7 @@ api_inference_model_map = {
     ),
     "qwen3-30b-a3b-instruct-2507": ModelConfig(
         model_name="qwen3-30b-a3b-instruct-2507",
-        display_name="Qwen3-30B-A3B-Instruct-2507 (Prompt)",
+        display_name="Qwen3-30B-A3B-Instruct-2507 (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-30B-A3B-Instruct-2507",
         org="Qwen",
         license="apache-2.0",
@@ -978,7 +978,7 @@ api_inference_model_map = {
     ),
     "qwen3-235b-a22b-instruct-2507-FC": ModelConfig(
         model_name="qwen3-235b-a22b-instruct-2507-FC",
-        display_name="Qwen3-235B-A22B-Instruct-2507 (FC)",
+        display_name="Qwen3-235B-A22B-Instruct-2507 (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507",
         org="Qwen",
         license="apache-2.0",
@@ -990,7 +990,7 @@ api_inference_model_map = {
     ),
     "qwen3-235b-a22b-instruct-2507": ModelConfig(
         model_name="qwen3-235b-a22b-instruct-2507",
-        display_name="Qwen3-235B-A22B-Instruct-2507 (Prompt)",
+        display_name="Qwen3-235B-A22B-Instruct-2507 (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507",
         org="Qwen",
         license="apache-2.0",
@@ -1002,7 +1002,7 @@ api_inference_model_map = {
     ),
     "qwq-32b-FC": ModelConfig(
         model_name="qwq-32b-FC",
-        display_name="QwQ-32B (FC)",
+        display_name="QwQ-32B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
         license="apache-2.0",
@@ -1014,7 +1014,7 @@ api_inference_model_map = {
     ),
     "qwq-32b": ModelConfig(
         model_name="qwq-32b",
-        display_name="QwQ-32B (Prompt)",
+        display_name="QwQ-32B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
         license="apache-2.0",
@@ -1062,7 +1062,7 @@ api_inference_model_map = {
     ),
     "glm-4.5-FC": ModelConfig(
         model_name="glm-4.5-FC",
-        display_name="GLM-4.5 (FC)",
+        display_name="GLM-4.5 (FC) (Reasoning)",
         url="https://huggingface.co/zai-org/GLM-4.5",
         org="Zhipu AI",
         license="MIT",
@@ -1074,7 +1074,7 @@ api_inference_model_map = {
     ),
     "glm-4.5-air-FC": ModelConfig(
         model_name="glm-4.5-air-FC",
-        display_name="GLM-4.5-Air (FC)",
+        display_name="GLM-4.5-Air (FC) (Reasoning)",
         url="https://huggingface.co/zai-org/GLM-4.5-Air",
         org="Zhipu AI",
         license="MIT",
@@ -1086,7 +1086,7 @@ api_inference_model_map = {
     ),
     "kimi-k2-0711-preview-FC": ModelConfig(
         model_name="moonshotai/Kimi-K2-Instruct-FC",
-        display_name="Moonshotai-Kimi-K2-Instruct (FC)",
+        display_name="Moonshotai-Kimi-K2-Instruct (FC) (Reasoning)",
         url="https://huggingface.co/moonshotai/Kimi-K2-Instruct",
         org="MoonshotAI",
         license="modified-mit",
@@ -1098,7 +1098,7 @@ api_inference_model_map = {
     ),
     "kimi-k2-0711-preview": ModelConfig(
         model_name="moonshotai/Kimi-K2-Instruct",
-        display_name="Moonshotai-Kimi-K2-Instruct (Prompt)",
+        display_name="Moonshotai-Kimi-K2-Instruct (Prompt) (Reasoning)",
         url="https://huggingface.co/moonshotai/Kimi-K2-Instruct",
         org="MoonshotAI",
         license="modified-mit",
@@ -1114,7 +1114,7 @@ api_inference_model_map = {
 local_inference_model_map = {
     "deepseek-ai/DeepSeek-R1": ModelConfig(
         model_name="deepseek-ai/DeepSeek-R1",
-        display_name="DeepSeek-R1 (Prompt) (Local)",
+        display_name="DeepSeek-R1 (Prompt) (Local) (Reasoning)",
         url="https://huggingface.co/deepseek-ai/DeepSeek-R1",
         org="DeepSeek",
         license="MIT",
@@ -1174,7 +1174,7 @@ local_inference_model_map = {
     ),
     "meta-llama/Llama-3.1-8B-Instruct-FC": ModelConfig(
         model_name="meta-llama/Llama-3.1-8B-Instruct-FC",
-        display_name="Llama-3.1-8B-Instruct (FC)",
+        display_name="Llama-3.1-8B-Instruct (FC) (Reasoning)",
         url="https://llama.meta.com/llama3",
         org="Meta",
         license="Meta Llama 3 Community",
@@ -1186,7 +1186,7 @@ local_inference_model_map = {
     ),
     "meta-llama/Llama-3.1-8B-Instruct": ModelConfig(
         model_name="meta-llama/Llama-3.1-8B-Instruct",
-        display_name="Llama-3.1-8B-Instruct (Prompt)",
+        display_name="Llama-3.1-8B-Instruct (Prompt) (Reasoning)",
         url="https://llama.meta.com/llama3",
         org="Meta",
         license="Meta Llama 3 Community",
@@ -1198,7 +1198,7 @@ local_inference_model_map = {
     ),
     "meta-llama/Llama-3.1-70B-Instruct-FC": ModelConfig(
         model_name="meta-llama/Llama-3.1-70B-Instruct-FC",
-        display_name="Llama-3.1-70B-Instruct (FC)",
+        display_name="Llama-3.1-70B-Instruct (FC) (Reasoning)",
         url="https://llama.meta.com/llama3",
         org="Meta",
         license="Meta Llama 3 Community",
@@ -1210,7 +1210,7 @@ local_inference_model_map = {
     ),
     "meta-llama/Llama-3.1-70B-Instruct": ModelConfig(
         model_name="meta-llama/Llama-3.1-70B-Instruct",
-        display_name="Llama-3.1-70B-Instruct (Prompt)",
+        display_name="Llama-3.1-70B-Instruct (Prompt) (Reasoning)",
         url="https://llama.meta.com/llama3",
         org="Meta",
         license="Meta Llama 3 Community",
@@ -1282,7 +1282,7 @@ local_inference_model_map = {
     ),
     "Salesforce/Llama-xLAM-2-70b-fc-r": ModelConfig(
         model_name="Salesforce/Llama-xLAM-2-70b-fc-r",
-        display_name="xLAM-2-70b-fc-r (FC)",
+        display_name="xLAM-2-70b-fc-r (FC) (Reasoning)",
         url="https://huggingface.co/Salesforce/Llama-xLAM-2-70b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1294,7 +1294,7 @@ local_inference_model_map = {
     ),
     "Salesforce/Llama-xLAM-2-8b-fc-r": ModelConfig(
         model_name="Salesforce/Llama-xLAM-2-8b-fc-r",
-        display_name="xLAM-2-8b-fc-r (FC)",
+        display_name="xLAM-2-8b-fc-r (FC) (Reasoning)",
         url="https://huggingface.co/Salesforce/Llama-xLAM-2-8b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1306,7 +1306,7 @@ local_inference_model_map = {
     ),
     "Salesforce/xLAM-2-32b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-32b-fc-r",
-        display_name="xLAM-2-32b-fc-r (FC)",
+        display_name="xLAM-2-32b-fc-r (FC) (Reasoning)",
         url="https://huggingface.co/Salesforce/xLAM-2-32b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1318,7 +1318,7 @@ local_inference_model_map = {
     ),
     "Salesforce/xLAM-2-3b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-3b-fc-r",
-        display_name="xLAM-2-3b-fc-r (FC)",
+        display_name="xLAM-2-3b-fc-r (FC) (Reasoning)",
         url="https://huggingface.co/Salesforce/xLAM-2-3b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1330,7 +1330,7 @@ local_inference_model_map = {
     ),
     "Salesforce/xLAM-2-1b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-1b-fc-r",
-        display_name="xLAM-2-1b-fc-r (FC)",
+        display_name="xLAM-2-1b-fc-r (FC) (Reasoning)",
         url="https://huggingface.co/Salesforce/xLAM-2-1b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1342,7 +1342,7 @@ local_inference_model_map = {
     ),
     "mistralai/Ministral-8B-Instruct-2410": ModelConfig(
         model_name="mistralai/Ministral-8B-Instruct-2410",
-        display_name="Ministral-8B-Instruct-2410 (FC)",
+        display_name="Ministral-8B-Instruct-2410 (FC) (Reasoning)",
         url="https://huggingface.co/mistralai/Ministral-8B-Instruct-2410",
         org="Mistral AI",
         license="Mistral AI Research License",
@@ -1354,7 +1354,7 @@ local_inference_model_map = {
     ),
     "microsoft/phi-4": ModelConfig(
         model_name="microsoft/phi-4",
-        display_name="Phi-4 (Prompt)",
+        display_name="Phi-4 (Prompt) (Reasoning)",
         url="https://huggingface.co/microsoft/phi-4",
         org="Microsoft",
         license="MIT",
@@ -1366,7 +1366,7 @@ local_inference_model_map = {
     ),
     "microsoft/Phi-4-mini-instruct": ModelConfig(
         model_name="microsoft/Phi-4-mini-instruct",
-        display_name="Phi-4-mini-instruct (Prompt)",
+        display_name="Phi-4-mini-instruct (Prompt) (Reasoning)",
         url="https://huggingface.co/microsoft/Phi-4-mini-instruct",
         org="Microsoft",
         license="MIT",
@@ -1378,7 +1378,7 @@ local_inference_model_map = {
     ),
     "microsoft/Phi-4-mini-instruct-FC": ModelConfig(
         model_name="microsoft/Phi-4-mini-instruct-FC",
-        display_name="Phi-4-mini-instruct (FC)",
+        display_name="Phi-4-mini-instruct (FC) (Reasoning)",
         url="https://huggingface.co/microsoft/Phi-4-mini-instruct",
         org="Microsoft",
         license="MIT",
@@ -1390,7 +1390,7 @@ local_inference_model_map = {
     ),
     "ibm-granite/granite-3.2-8b-instruct": ModelConfig(
         model_name="ibm-granite/granite-3.2-8b-instruct",
-        display_name="Granite-3.2-8B-Instruct (FC)",
+        display_name="Granite-3.2-8B-Instruct (FC) (Reasoning)",
         url="https://huggingface.co/ibm-granite/granite-3.2-8b-instruct",
         org="IBM",
         license="Apache-2.0",
@@ -1402,7 +1402,7 @@ local_inference_model_map = {
     ),
     "ibm-granite/granite-3.1-8b-instruct": ModelConfig(
         model_name="ibm-granite/granite-3.1-8b-instruct",
-        display_name="Granite-3.1-8B-Instruct (FC)",
+        display_name="Granite-3.1-8B-Instruct (FC) (Reasoning)",
         url="https://huggingface.co/ibm-granite/granite-3.1-8b-instruct",
         org="IBM",
         license="Apache-2.0",
@@ -1498,7 +1498,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-0.6B": ModelConfig(
         model_name="Qwen/Qwen3-0.6B",
-        display_name="Qwen3-0.6B (Prompt)",
+        display_name="Qwen3-0.6B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-0.6B",
         org="Qwen",
         license="apache-2.0",
@@ -1510,7 +1510,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-1.7B-FC": ModelConfig(
         model_name="Qwen/Qwen3-1.7B-FC",
-        display_name="Qwen3-1.7B (FC)",
+        display_name="Qwen3-1.7B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
         license="apache-2.0",
@@ -1522,7 +1522,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-1.7B": ModelConfig(
         model_name="Qwen/Qwen3-1.7B",
-        display_name="Qwen3-1.7B (Prompt)",
+        display_name="Qwen3-1.7B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
         license="apache-2.0",
@@ -1558,7 +1558,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-8B-FC": ModelConfig(
         model_name="Qwen/Qwen3-8B-FC",
-        display_name="Qwen3-8B (FC)",
+        display_name="Qwen3-8B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
         license="apache-2.0",
@@ -1570,7 +1570,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-8B": ModelConfig(
         model_name="Qwen/Qwen3-8B",
-        display_name="Qwen3-8B (Prompt)",
+        display_name="Qwen3-8B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
         license="apache-2.0",
@@ -1582,7 +1582,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-14B-FC": ModelConfig(
         model_name="Qwen/Qwen3-14B-FC",
-        display_name="Qwen3-14B (FC)",
+        display_name="Qwen3-14B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
         license="apache-2.0",
@@ -1594,7 +1594,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-14B": ModelConfig(
         model_name="Qwen/Qwen3-14B",
-        display_name="Qwen3-14B (Prompt)",
+        display_name="Qwen3-14B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
         license="apache-2.0",
@@ -1606,7 +1606,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-32B-FC": ModelConfig(
         model_name="Qwen/Qwen3-32B-FC",
-        display_name="Qwen3-32B (FC)",
+        display_name="Qwen3-32B (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
         license="apache-2.0",
@@ -1618,7 +1618,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-32B": ModelConfig(
         model_name="Qwen/Qwen3-32B",
-        display_name="Qwen3-32B (Prompt)",
+        display_name="Qwen3-32B (Prompt) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
         license="apache-2.0",
@@ -1762,7 +1762,7 @@ local_inference_model_map = {
     ),
     "NovaSky-AI/Sky-T1-32B-Preview": ModelConfig(
         model_name="NovaSky-AI/Sky-T1-32B-Preview",
-        display_name="Sky-T1-32B-Preview (Prompt)",
+        display_name="Sky-T1-32B-Preview (Prompt) (Reasoning)",
         url="https://huggingface.co/NovaSky-AI/Sky-T1-32B-Preview",
         org="NovaSky-AI",
         license="apache-2.0",
@@ -1846,7 +1846,7 @@ local_inference_model_map = {
     ),
     "uiuc-convai/CoALM-405B": ModelConfig(
         model_name="uiuc-convai/CoALM-405B",
-        display_name="CoALM-405B",
+        display_name="CoALM-405B (Reasoning)",
         url="https://huggingface.co/uiuc-convai/CoALM-405B",
         org="UIUC + Oumi",
         license="Meta Llama 3 Community",
@@ -1942,7 +1942,7 @@ local_inference_model_map = {
     ),
     "phronetic-ai/RZN-T": ModelConfig(
         model_name="phronetic-ai/RZN-T",
-        display_name="RZN-T (Prompt)",
+        display_name="RZN-T (Prompt) (Reasoning)",
         url="https://huggingface.co/phronetic-ai/RZN-T",
         org="Phronetic AI",
         license="apache-2.0",
@@ -2007,7 +2007,7 @@ third_party_inference_model_map = {
     ),
     "qwen/qwq-32b-FC-novita": ModelConfig(
         model_name="qwen/qwq-32b-FC-novita",
-        display_name="Qwen/QwQ-32B (FC) (Novita)",
+        display_name="Qwen/QwQ-32B (FC) (Novita) (Reasoning)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
         license="apache-2.0",
@@ -2019,7 +2019,7 @@ third_party_inference_model_map = {
     ),
     "qwen/qwq-32b-novita": ModelConfig(
         model_name="qwen/qwq-32b-novita",
-        display_name="Qwen/QwQ-32B (Prompt) (Novita)",
+        display_name="Qwen/QwQ-32B (Prompt) (Novita) (Reasoning)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
         license="apache-2.0",
@@ -2032,7 +2032,7 @@ third_party_inference_model_map = {
     # Via Qwen Agent Framework
     "qwen3-4b-think-FC": ModelConfig(
         model_name="qwen3-4b-think-FC",
-        display_name="Qwen3-4B-Think (FC)",
+        display_name="Qwen3-4B-Think (FC) (Reasoning)",
         url="https://huggingface.co/Qwen/Qwen3-4B",
         org="Qwen",
         license="apache-2.0",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -558,7 +558,7 @@ api_inference_model_map = {
     ),
     "mistral-small-2506": ModelConfig(
         model_name="mistral-small-2506",
-        display_name="Mistral-Small-2506 (Prompt) (Reasoning)",
+        display_name="Mistral-Small-2506 (Prompt)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -570,7 +570,7 @@ api_inference_model_map = {
     ),
     "mistral-small-2506-FC": ModelConfig(
         model_name="mistral-small-2506",
-        display_name="Mistral-small-2506 (FC) (Reasoning)",
+        display_name="Mistral-small-2506 (FC)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -582,7 +582,7 @@ api_inference_model_map = {
     ),
     "mistral-medium-2505": ModelConfig(
         model_name="mistral-medium-2505",
-        display_name="Mistral-Medium-2505 (Reasoning)",
+        display_name="Mistral-Medium-2505",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -594,7 +594,7 @@ api_inference_model_map = {
     ),
     "mistral-medium-2505-FC": ModelConfig(
         model_name="mistral-medium-2505",
-        display_name="Mistral-Medium-2505 (FC) (Reasoning)",
+        display_name="Mistral-Medium-2505 (FC)",
         url="https://docs.mistral.ai/guides/model-selection/",
         org="Mistral AI",
         license="Proprietary",
@@ -654,7 +654,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-flash": ModelConfig(
         model_name="gemini-2.5-flash",
-        display_name="Gemini-2.5-Flash (Prompt)",
+        display_name="Gemini-2.5-Flash (Prompt) (Reasoning)",
         url="https://deepmind.google/technologies/gemini/flash/",
         org="Google",
         license="Proprietary",
@@ -714,7 +714,7 @@ api_inference_model_map = {
     ),
     "command-r7b-12-2024-FC": ModelConfig(
         model_name="command-r7b-12-2024",
-        display_name="Command R7B (FC) (Reasoning)",
+        display_name="Command R7B (FC)",
         url="https://cohere.com/blog/command-r7b",
         org="Cohere",
         license="cc-by-nc-4.0",
@@ -738,7 +738,7 @@ api_inference_model_map = {
     ),
     "nvidia/llama-3.1-nemotron-ultra-253b-v1": ModelConfig(
         model_name="nvidia/llama-3.1-nemotron-ultra-253b-v1",
-        display_name="Llama-3.1-Nemotron-Ultra-253B-v1 (FC) (Reasoning)",
+        display_name="Llama-3.1-Nemotron-Ultra-253B-v1 (FC)",
         url="https://huggingface.co/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
         org="NVIDIA",
         license="nvidia-open-model-license",
@@ -774,7 +774,7 @@ api_inference_model_map = {
     ),
     "palmyra-x-004": ModelConfig(
         model_name="palmyra-x-004",
-        display_name="palmyra-x-004 (FC) (Reasoning)",
+        display_name="palmyra-x-004 (FC)",
         url="https://writer.com/engineering/actions-with-palmyra-x-004/",
         org="Writer",
         license="Proprietary",
@@ -786,7 +786,7 @@ api_inference_model_map = {
     ),
     "grok-4-0709-FC": ModelConfig(
         model_name="grok-4-0709",
-        display_name="Grok-4-0709 (FC) (Reasoning)",
+        display_name="Grok-4-0709 (FC)",
         url="https://docs.x.ai/docs/models",
         org="xAI",
         license="Proprietary",
@@ -798,7 +798,7 @@ api_inference_model_map = {
     ),
     "grok-4-0709": ModelConfig(
         model_name="grok-4-0709",
-        display_name="Grok-4-0709 (Prompt) (Reasoning)",
+        display_name="Grok-4-0709 (Prompt)",
         url="https://docs.x.ai/docs/models",
         org="xAI",
         license="Proprietary",
@@ -810,7 +810,7 @@ api_inference_model_map = {
     ),
     "qwen3-0.6b-FC": ModelConfig(
         model_name="qwen3-0.6b",
-        display_name="Qwen3-0.6B (FC) (Reasoning)",
+        display_name="Qwen3-0.6B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-0.6B",
         org="Qwen",
         license="apache-2.0",
@@ -822,7 +822,7 @@ api_inference_model_map = {
     ),
     "qwen3-0.6b": ModelConfig(
         model_name="qwen3-0.6b",
-        display_name="Qwen3-0.6B (Prompt) (Reasoning)",
+        display_name="Qwen3-0.6B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-0.6B",
         org="Qwen",
         license="apache-2.0",
@@ -834,7 +834,7 @@ api_inference_model_map = {
     ),
     "qwen3-1.7b-FC": ModelConfig(
         model_name="qwen3-1.7b",
-        display_name="Qwen3-1.7B (FC) (Reasoning)",
+        display_name="Qwen3-1.7B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
         license="apache-2.0",
@@ -846,7 +846,7 @@ api_inference_model_map = {
     ),
     "qwen3-1.7b": ModelConfig(
         model_name="qwen3-1.7b",
-        display_name="Qwen3-1.7B (Prompt) (Reasoning)",
+        display_name="Qwen3-1.7B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
         license="apache-2.0",
@@ -858,7 +858,7 @@ api_inference_model_map = {
     ),
     "qwen3-4b-FC": ModelConfig(
         model_name="qwen3-4b",
-        display_name="Qwen3-4B (FC) (Reasoning)",
+        display_name="Qwen3-4B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-4B",
         org="Qwen",
         license="apache-2.0",
@@ -870,7 +870,7 @@ api_inference_model_map = {
     ),
     "qwen3-4b": ModelConfig(
         model_name="qwen3-4b",
-        display_name="Qwen3-4B (Prompt) (Reasoning)",
+        display_name="Qwen3-4B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-4B",
         org="Qwen",
         license="apache-2.0",
@@ -882,7 +882,7 @@ api_inference_model_map = {
     ),
     "qwen3-8b-FC": ModelConfig(
         model_name="qwen3-8b",
-        display_name="Qwen3-8B (FC) (Reasoning)",
+        display_name="Qwen3-8B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
         license="apache-2.0",
@@ -894,7 +894,7 @@ api_inference_model_map = {
     ),
     "qwen3-8b": ModelConfig(
         model_name="qwen3-8b",
-        display_name="Qwen3-8B (Prompt) (Reasoning)",
+        display_name="Qwen3-8B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
         license="apache-2.0",
@@ -906,7 +906,7 @@ api_inference_model_map = {
     ),
     "qwen3-14b-FC": ModelConfig(
         model_name="qwen3-14b",
-        display_name="Qwen3-14B (FC) (Reasoning)",
+        display_name="Qwen3-14B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
         license="apache-2.0",
@@ -918,7 +918,7 @@ api_inference_model_map = {
     ),
     "qwen3-14b": ModelConfig(
         model_name="qwen3-14b",
-        display_name="Qwen3-14B (Prompt) (Reasoning)",
+        display_name="Qwen3-14B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
         license="apache-2.0",
@@ -930,7 +930,7 @@ api_inference_model_map = {
     ),
     "qwen3-32b-FC": ModelConfig(
         model_name="qwen3-32b",
-        display_name="Qwen3-32B (FC) (Reasoning)",
+        display_name="Qwen3-32B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
         license="apache-2.0",
@@ -942,7 +942,7 @@ api_inference_model_map = {
     ),
     "qwen3-32b": ModelConfig(
         model_name="qwen3-32b",
-        display_name="Qwen3-32B (Prompt) (Reasoning)",
+        display_name="Qwen3-32B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
         license="apache-2.0",
@@ -954,7 +954,7 @@ api_inference_model_map = {
     ),
     "qwen3-30b-a3b-instruct-2507-FC": ModelConfig(
         model_name="qwen3-30b-a3b-instruct-2507",
-        display_name="Qwen3-30B-A3B-Instruct-2507 (FC) (Reasoning)",
+        display_name="Qwen3-30B-A3B-Instruct-2507 (FC)",
         url="https://huggingface.co/Qwen/Qwen3-30B-A3B-Instruct-2507",
         org="Qwen",
         license="apache-2.0",
@@ -966,7 +966,7 @@ api_inference_model_map = {
     ),
     "qwen3-30b-a3b-instruct-2507": ModelConfig(
         model_name="qwen3-30b-a3b-instruct-2507",
-        display_name="Qwen3-30B-A3B-Instruct-2507 (Prompt) (Reasoning)",
+        display_name="Qwen3-30B-A3B-Instruct-2507 (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-30B-A3B-Instruct-2507",
         org="Qwen",
         license="apache-2.0",
@@ -978,7 +978,7 @@ api_inference_model_map = {
     ),
     "qwen3-235b-a22b-instruct-2507-FC": ModelConfig(
         model_name="qwen3-235b-a22b-instruct-2507",
-        display_name="Qwen3-235B-A22B-Instruct-2507 (FC) (Reasoning)",
+        display_name="Qwen3-235B-A22B-Instruct-2507 (FC)",
         url="https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507",
         org="Qwen",
         license="apache-2.0",
@@ -990,7 +990,7 @@ api_inference_model_map = {
     ),
     "qwen3-235b-a22b-instruct-2507": ModelConfig(
         model_name="qwen3-235b-a22b-instruct-2507",
-        display_name="Qwen3-235B-A22B-Instruct-2507 (Prompt) (Reasoning)",
+        display_name="Qwen3-235B-A22B-Instruct-2507 (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507",
         org="Qwen",
         license="apache-2.0",
@@ -1002,7 +1002,7 @@ api_inference_model_map = {
     ),
     "qwq-32b-FC": ModelConfig(
         model_name="qwq-32b",
-        display_name="QwQ-32B (FC) (Reasoning)",
+        display_name="QwQ-32B (FC)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
         license="apache-2.0",
@@ -1014,7 +1014,7 @@ api_inference_model_map = {
     ),
     "qwq-32b": ModelConfig(
         model_name="qwq-32b",
-        display_name="QwQ-32B (Prompt) (Reasoning)",
+        display_name="QwQ-32B (Prompt)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
         license="apache-2.0",
@@ -1062,7 +1062,7 @@ api_inference_model_map = {
     ),
     "glm-4.5-FC": ModelConfig(
         model_name="glm-4.5",
-        display_name="GLM-4.5 (FC) (Reasoning)",
+        display_name="GLM-4.5 (FC)",
         url="https://huggingface.co/zai-org/GLM-4.5",
         org="Zhipu AI",
         license="MIT",
@@ -1074,7 +1074,7 @@ api_inference_model_map = {
     ),
     "glm-4.5-air-FC": ModelConfig(
         model_name="glm-4.5-air",
-        display_name="GLM-4.5-Air (FC) (Reasoning)",
+        display_name="GLM-4.5-Air (FC)",
         url="https://huggingface.co/zai-org/GLM-4.5-Air",
         org="Zhipu AI",
         license="MIT",
@@ -1086,7 +1086,7 @@ api_inference_model_map = {
     ),
     "kimi-k2-0711-preview-FC": ModelConfig(
         model_name="moonshotai/Kimi-K2-Instruct",
-        display_name="Moonshotai-Kimi-K2-Instruct (FC) (Reasoning)",
+        display_name="Moonshotai-Kimi-K2-Instruct (FC)",
         url="https://huggingface.co/moonshotai/Kimi-K2-Instruct",
         org="MoonshotAI",
         license="modified-mit",
@@ -1098,7 +1098,7 @@ api_inference_model_map = {
     ),
     "kimi-k2-0711-preview": ModelConfig(
         model_name="moonshotai/Kimi-K2-Instruct",
-        display_name="Moonshotai-Kimi-K2-Instruct (Prompt) (Reasoning)",
+        display_name="Moonshotai-Kimi-K2-Instruct (Prompt)",
         url="https://huggingface.co/moonshotai/Kimi-K2-Instruct",
         org="MoonshotAI",
         license="modified-mit",
@@ -1114,7 +1114,7 @@ api_inference_model_map = {
 local_inference_model_map = {
     "deepseek-ai/DeepSeek-R1": ModelConfig(
         model_name="deepseek-ai/DeepSeek-R1",
-        display_name="DeepSeek-R1 (Prompt) (Local) (Reasoning)",
+        display_name="DeepSeek-R1 (Prompt) (Local)",
         url="https://huggingface.co/deepseek-ai/DeepSeek-R1",
         org="DeepSeek",
         license="MIT",
@@ -1174,7 +1174,7 @@ local_inference_model_map = {
     ),
     "meta-llama/Llama-3.1-8B-Instruct-FC": ModelConfig(
         model_name="meta-llama/Llama-3.1-8B-Instruct",
-        display_name="Llama-3.1-8B-Instruct (FC) (Reasoning)",
+        display_name="Llama-3.1-8B-Instruct (FC)",
         url="https://llama.meta.com/llama3",
         org="Meta",
         license="Meta Llama 3 Community",
@@ -1186,7 +1186,7 @@ local_inference_model_map = {
     ),
     "meta-llama/Llama-3.1-8B-Instruct": ModelConfig(
         model_name="meta-llama/Llama-3.1-8B-Instruct",
-        display_name="Llama-3.1-8B-Instruct (Prompt) (Reasoning)",
+        display_name="Llama-3.1-8B-Instruct (Prompt)",
         url="https://llama.meta.com/llama3",
         org="Meta",
         license="Meta Llama 3 Community",
@@ -1198,7 +1198,7 @@ local_inference_model_map = {
     ),
     "meta-llama/Llama-3.1-70B-Instruct-FC": ModelConfig(
         model_name="meta-llama/Llama-3.1-70B-Instruct",
-        display_name="Llama-3.1-70B-Instruct (FC) (Reasoning)",
+        display_name="Llama-3.1-70B-Instruct (FC)",
         url="https://llama.meta.com/llama3",
         org="Meta",
         license="Meta Llama 3 Community",
@@ -1210,7 +1210,7 @@ local_inference_model_map = {
     ),
     "meta-llama/Llama-3.1-70B-Instruct": ModelConfig(
         model_name="meta-llama/Llama-3.1-70B-Instruct",
-        display_name="Llama-3.1-70B-Instruct (Prompt) (Reasoning)",
+        display_name="Llama-3.1-70B-Instruct (Prompt)",
         url="https://llama.meta.com/llama3",
         org="Meta",
         license="Meta Llama 3 Community",
@@ -1282,7 +1282,7 @@ local_inference_model_map = {
     ),
     "Salesforce/Llama-xLAM-2-70b-fc-r": ModelConfig(
         model_name="Salesforce/Llama-xLAM-2-70b-fc-r",
-        display_name="xLAM-2-70b-fc-r (FC) (Reasoning)",
+        display_name="xLAM-2-70b-fc-r (FC)",
         url="https://huggingface.co/Salesforce/Llama-xLAM-2-70b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1294,7 +1294,7 @@ local_inference_model_map = {
     ),
     "Salesforce/Llama-xLAM-2-8b-fc-r": ModelConfig(
         model_name="Salesforce/Llama-xLAM-2-8b-fc-r",
-        display_name="xLAM-2-8b-fc-r (FC) (Reasoning)",
+        display_name="xLAM-2-8b-fc-r (FC)",
         url="https://huggingface.co/Salesforce/Llama-xLAM-2-8b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1306,7 +1306,7 @@ local_inference_model_map = {
     ),
     "Salesforce/xLAM-2-32b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-32b-fc-r",
-        display_name="xLAM-2-32b-fc-r (FC) (Reasoning)",
+        display_name="xLAM-2-32b-fc-r (FC)",
         url="https://huggingface.co/Salesforce/xLAM-2-32b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1318,7 +1318,7 @@ local_inference_model_map = {
     ),
     "Salesforce/xLAM-2-3b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-3b-fc-r",
-        display_name="xLAM-2-3b-fc-r (FC) (Reasoning)",
+        display_name="xLAM-2-3b-fc-r (FC)",
         url="https://huggingface.co/Salesforce/xLAM-2-3b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1330,7 +1330,7 @@ local_inference_model_map = {
     ),
     "Salesforce/xLAM-2-1b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-1b-fc-r",
-        display_name="xLAM-2-1b-fc-r (FC) (Reasoning)",
+        display_name="xLAM-2-1b-fc-r (FC)",
         url="https://huggingface.co/Salesforce/xLAM-2-1b-fc-r",
         org="Salesforce",
         license="cc-by-nc-4.0",
@@ -1342,7 +1342,7 @@ local_inference_model_map = {
     ),
     "mistralai/Ministral-8B-Instruct-2410": ModelConfig(
         model_name="mistralai/Ministral-8B-Instruct-2410",
-        display_name="Ministral-8B-Instruct-2410 (FC) (Reasoning)",
+        display_name="Ministral-8B-Instruct-2410 (FC)",
         url="https://huggingface.co/mistralai/Ministral-8B-Instruct-2410",
         org="Mistral AI",
         license="Mistral AI Research License",
@@ -1354,7 +1354,7 @@ local_inference_model_map = {
     ),
     "microsoft/phi-4": ModelConfig(
         model_name="microsoft/phi-4",
-        display_name="Phi-4 (Prompt) (Reasoning)",
+        display_name="Phi-4 (Prompt)",
         url="https://huggingface.co/microsoft/phi-4",
         org="Microsoft",
         license="MIT",
@@ -1366,7 +1366,7 @@ local_inference_model_map = {
     ),
     "microsoft/Phi-4-mini-instruct": ModelConfig(
         model_name="microsoft/Phi-4-mini-instruct",
-        display_name="Phi-4-mini-instruct (Prompt) (Reasoning)",
+        display_name="Phi-4-mini-instruct (Prompt)",
         url="https://huggingface.co/microsoft/Phi-4-mini-instruct",
         org="Microsoft",
         license="MIT",
@@ -1378,7 +1378,7 @@ local_inference_model_map = {
     ),
     "microsoft/Phi-4-mini-instruct-FC": ModelConfig(
         model_name="microsoft/Phi-4-mini-instruct",
-        display_name="Phi-4-mini-instruct (FC) (Reasoning)",
+        display_name="Phi-4-mini-instruct (FC)",
         url="https://huggingface.co/microsoft/Phi-4-mini-instruct",
         org="Microsoft",
         license="MIT",
@@ -1390,7 +1390,7 @@ local_inference_model_map = {
     ),
     "ibm-granite/granite-3.2-8b-instruct": ModelConfig(
         model_name="ibm-granite/granite-3.2-8b-instruct",
-        display_name="Granite-3.2-8B-Instruct (FC) (Reasoning)",
+        display_name="Granite-3.2-8B-Instruct (FC)",
         url="https://huggingface.co/ibm-granite/granite-3.2-8b-instruct",
         org="IBM",
         license="Apache-2.0",
@@ -1402,7 +1402,7 @@ local_inference_model_map = {
     ),
     "ibm-granite/granite-3.1-8b-instruct": ModelConfig(
         model_name="ibm-granite/granite-3.1-8b-instruct",
-        display_name="Granite-3.1-8B-Instruct (FC) (Reasoning)",
+        display_name="Granite-3.1-8B-Instruct (FC)",
         url="https://huggingface.co/ibm-granite/granite-3.1-8b-instruct",
         org="IBM",
         license="Apache-2.0",
@@ -1498,7 +1498,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-0.6B": ModelConfig(
         model_name="Qwen/Qwen3-0.6B",
-        display_name="Qwen3-0.6B (Prompt) (Reasoning)",
+        display_name="Qwen3-0.6B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-0.6B",
         org="Qwen",
         license="apache-2.0",
@@ -1510,7 +1510,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-1.7B-FC": ModelConfig(
         model_name="Qwen/Qwen3-1.7B",
-        display_name="Qwen3-1.7B (FC) (Reasoning)",
+        display_name="Qwen3-1.7B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
         license="apache-2.0",
@@ -1522,7 +1522,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-1.7B": ModelConfig(
         model_name="Qwen/Qwen3-1.7B",
-        display_name="Qwen3-1.7B (Prompt) (Reasoning)",
+        display_name="Qwen3-1.7B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-1.7B",
         org="Qwen",
         license="apache-2.0",
@@ -1558,7 +1558,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-8B-FC": ModelConfig(
         model_name="Qwen/Qwen3-8B",
-        display_name="Qwen3-8B (FC) (Reasoning)",
+        display_name="Qwen3-8B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
         license="apache-2.0",
@@ -1570,7 +1570,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-8B": ModelConfig(
         model_name="Qwen/Qwen3-8B",
-        display_name="Qwen3-8B (Prompt) (Reasoning)",
+        display_name="Qwen3-8B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-8B",
         org="Qwen",
         license="apache-2.0",
@@ -1582,7 +1582,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-14B-FC": ModelConfig(
         model_name="Qwen/Qwen3-14B",
-        display_name="Qwen3-14B (FC) (Reasoning)",
+        display_name="Qwen3-14B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
         license="apache-2.0",
@@ -1594,7 +1594,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-14B": ModelConfig(
         model_name="Qwen/Qwen3-14B",
-        display_name="Qwen3-14B (Prompt) (Reasoning)",
+        display_name="Qwen3-14B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-14B",
         org="Qwen",
         license="apache-2.0",
@@ -1606,7 +1606,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-32B-FC": ModelConfig(
         model_name="Qwen/Qwen3-32B",
-        display_name="Qwen3-32B (FC) (Reasoning)",
+        display_name="Qwen3-32B (FC)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
         license="apache-2.0",
@@ -1618,7 +1618,7 @@ local_inference_model_map = {
     ),
     "Qwen/Qwen3-32B": ModelConfig(
         model_name="Qwen/Qwen3-32B",
-        display_name="Qwen3-32B (Prompt) (Reasoning)",
+        display_name="Qwen3-32B (Prompt)",
         url="https://huggingface.co/Qwen/Qwen3-32B",
         org="Qwen",
         license="apache-2.0",
@@ -1762,7 +1762,7 @@ local_inference_model_map = {
     ),
     "NovaSky-AI/Sky-T1-32B-Preview": ModelConfig(
         model_name="NovaSky-AI/Sky-T1-32B-Preview",
-        display_name="Sky-T1-32B-Preview (Prompt) (Reasoning)",
+        display_name="Sky-T1-32B-Preview (Prompt)",
         url="https://huggingface.co/NovaSky-AI/Sky-T1-32B-Preview",
         org="NovaSky-AI",
         license="apache-2.0",
@@ -1846,7 +1846,7 @@ local_inference_model_map = {
     ),
     "uiuc-convai/CoALM-405B": ModelConfig(
         model_name="uiuc-convai/CoALM-405B",
-        display_name="CoALM-405B (Reasoning)",
+        display_name="CoALM-405B",
         url="https://huggingface.co/uiuc-convai/CoALM-405B",
         org="UIUC + Oumi",
         license="Meta Llama 3 Community",
@@ -1942,7 +1942,7 @@ local_inference_model_map = {
     ),
     "phronetic-ai/RZN-T": ModelConfig(
         model_name="phronetic-ai/RZN-T",
-        display_name="RZN-T (Prompt) (Reasoning)",
+        display_name="RZN-T (Prompt)",
         url="https://huggingface.co/phronetic-ai/RZN-T",
         org="Phronetic AI",
         license="apache-2.0",
@@ -2007,7 +2007,7 @@ third_party_inference_model_map = {
     ),
     "qwen/qwq-32b-FC-novita": ModelConfig(
         model_name="qwen/qwq-32b",
-        display_name="Qwen/QwQ-32B (FC) (Novita) (Reasoning)",
+        display_name="Qwen/QwQ-32B (FC) (Novita)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
         license="apache-2.0",
@@ -2019,7 +2019,7 @@ third_party_inference_model_map = {
     ),
     "qwen/qwq-32b-novita": ModelConfig(
         model_name="qwen/qwq-32b",
-        display_name="Qwen/QwQ-32B (Prompt) (Novita) (Reasoning)",
+        display_name="Qwen/QwQ-32B (Prompt) (Novita)",
         url="https://huggingface.co/Qwen/QwQ-32B",
         org="Qwen",
         license="apache-2.0",
@@ -2032,7 +2032,7 @@ third_party_inference_model_map = {
     # Via Qwen Agent Framework
     "qwen3-4b-think-FC": ModelConfig(
         model_name="qwen3-4b-think-FC",
-        display_name="Qwen3-4B-Think (FC) (Reasoning)",
+        display_name="Qwen3-4B-Think (FC)",
         url="https://huggingface.co/Qwen/Qwen3-4B",
         org="Qwen",
         license="apache-2.0",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -666,7 +666,7 @@ api_inference_model_map = {
     ),
     "gemini-2.5-pro-FC": ModelConfig(
         model_name="gemini-2.5-pro",
-        display_name="Gemini-2.5-Pro (FC) (Reasoning)",
+        display_name="Gemini-2.5-Pro (FC)",
         url="https://deepmind.google/technologies/gemini/pro/",
         org="Google",
         license="Proprietary",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -109,6 +109,8 @@ class ModelConfig:
     # True if this model does not allow '.' in function names
     underscore_to_dot: bool = False
 
+    reasoning_mode: bool = False
+
 
 # Inference through API calls
 api_inference_model_map = {
@@ -135,6 +137,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "DeepSeek-R1-0528-FC": ModelConfig(
         model_name="DeepSeek-R1-0528-FC",
@@ -147,6 +150,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "DeepSeek-V3-0324-FC": ModelConfig(
         model_name="DeepSeek-V3-0324",
@@ -171,6 +175,7 @@ api_inference_model_map = {
         output_price=10,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "gpt-5-2025-08-07": ModelConfig(
         model_name="gpt-5-2025-08-07",
@@ -183,6 +188,7 @@ api_inference_model_map = {
         output_price=10,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "gpt-5-mini-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-mini-2025-08-07-FC",
@@ -195,6 +201,7 @@ api_inference_model_map = {
         output_price=2,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "gpt-5-mini-2025-08-07": ModelConfig(
         model_name="gpt-5-mini-2025-08-07",
@@ -207,6 +214,7 @@ api_inference_model_map = {
         output_price=2,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "gpt-5-nano-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-nano-2025-08-07-FC",
@@ -219,6 +227,7 @@ api_inference_model_map = {
         output_price=0.4,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "gpt-5-nano-2025-08-07": ModelConfig(
         model_name="gpt-5-nano-2025-08-07",
@@ -231,6 +240,7 @@ api_inference_model_map = {
         output_price=0.4,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "gpt-4.1-2025-04-14-FC": ModelConfig(
         model_name="gpt-4.1-2025-04-14-FC",
@@ -363,6 +373,7 @@ api_inference_model_map = {
         output_price=8,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "o3-2025-04-16-FC": ModelConfig(
         model_name="o3-2025-04-16-FC",
@@ -375,6 +386,7 @@ api_inference_model_map = {
         output_price=8,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "o4-mini-2025-04-16": ModelConfig(
         model_name="o4-mini-2025-04-16",
@@ -387,6 +399,7 @@ api_inference_model_map = {
         output_price=4.40,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "o4-mini-2025-04-16-FC": ModelConfig(
         model_name="o4-mini-2025-04-16-FC",
@@ -399,6 +412,7 @@ api_inference_model_map = {
         output_price=4.40,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "claude-opus-4-1-20250805": ModelConfig(
         model_name="claude-opus-4-1-20250805",
@@ -411,6 +425,7 @@ api_inference_model_map = {
         output_price=75,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "claude-opus-4-1-20250805-FC": ModelConfig(
         model_name="claude-opus-4-1-20250805",
@@ -423,6 +438,7 @@ api_inference_model_map = {
         output_price=75,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "claude-sonnet-4-20250514": ModelConfig(
         model_name="claude-sonnet-4-20250514",
@@ -435,6 +451,7 @@ api_inference_model_map = {
         output_price=15,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "claude-sonnet-4-20250514-FC": ModelConfig(
         model_name="claude-sonnet-4-20250514",
@@ -447,6 +464,7 @@ api_inference_model_map = {
         output_price=15,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "claude-3-5-haiku-20241022": ModelConfig(
         model_name="claude-3-5-haiku-20241022",
@@ -543,6 +561,7 @@ api_inference_model_map = {
         output_price=6,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "mistral-large-2411-FC": ModelConfig(
         model_name="mistral-large-2411-FC",
@@ -555,6 +574,7 @@ api_inference_model_map = {
         output_price=6,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "mistral-small-2506": ModelConfig(
         model_name="mistral-small-2506",
@@ -567,6 +587,7 @@ api_inference_model_map = {
         output_price=0.3,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "mistral-small-2506-FC": ModelConfig(
         model_name="mistral-small-2506-FC",
@@ -579,6 +600,7 @@ api_inference_model_map = {
         output_price=0.3,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "mistral-medium-2505": ModelConfig(
         model_name="mistral-medium-2505",
@@ -591,6 +613,7 @@ api_inference_model_map = {
         output_price=2,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "mistral-medium-2505-FC": ModelConfig(
         model_name="mistral-medium-2505-FC",
@@ -603,6 +626,7 @@ api_inference_model_map = {
         output_price=2,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "firefunction-v2-FC": ModelConfig(
         model_name="firefunction-v2-FC",
@@ -639,6 +663,7 @@ api_inference_model_map = {
         output_price=0.4,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "gemini-2.5-flash-FC": ModelConfig(
         model_name="gemini-2.5-flash-FC",
@@ -675,6 +700,7 @@ api_inference_model_map = {
         output_price=10,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "gemini-2.5-pro": ModelConfig(
         model_name="gemini-2.5-pro",
@@ -687,6 +713,7 @@ api_inference_model_map = {
         output_price=10,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "meetkai/functionary-small-v3.1-FC": ModelConfig(
         model_name="meetkai/functionary-small-v3.1-FC",
@@ -723,6 +750,7 @@ api_inference_model_map = {
         output_price=0.15,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "command-a-03-2025-FC": ModelConfig(
         model_name="command-a-03-2025-FC",
@@ -747,6 +775,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "nvidia/nemotron-4-340b-instruct": ModelConfig(
         model_name="nvidia/nemotron-4-340b-instruct",
@@ -783,6 +812,7 @@ api_inference_model_map = {
         output_price=12,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "grok-4-0709-FC": ModelConfig(
         model_name="grok-4-0709-FC",
@@ -795,6 +825,7 @@ api_inference_model_map = {
         output_price=15,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "grok-4-0709": ModelConfig(
         model_name="grok-4-0709",
@@ -807,6 +838,7 @@ api_inference_model_map = {
         output_price=15,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwen3-0.6b-FC": ModelConfig(
         model_name="qwen3-0.6b-FC",
@@ -819,6 +851,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwen3-0.6b": ModelConfig(
         model_name="qwen3-0.6b",
@@ -831,6 +864,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwen3-1.7b-FC": ModelConfig(
         model_name="qwen3-1.7b-FC",
@@ -843,6 +877,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwen3-1.7b": ModelConfig(
         model_name="qwen3-1.7b",
@@ -855,6 +890,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwen3-4b-FC": ModelConfig(
         model_name="qwen3-4b-FC",
@@ -867,6 +903,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwen3-4b": ModelConfig(
         model_name="qwen3-4b",
@@ -879,6 +916,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwen3-8b-FC": ModelConfig(
         model_name="qwen3-8b-FC",
@@ -891,6 +929,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwen3-8b": ModelConfig(
         model_name="qwen3-8b",
@@ -903,6 +942,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwen3-14b-FC": ModelConfig(
         model_name="qwen3-14b-FC",
@@ -915,6 +955,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwen3-14b": ModelConfig(
         model_name="qwen3-14b",
@@ -927,6 +968,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwen3-32b-FC": ModelConfig(
         model_name="qwen3-32b-FC",
@@ -939,6 +981,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwen3-32b": ModelConfig(
         model_name="qwen3-32b",
@@ -951,6 +994,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwen3-30b-a3b-instruct-2507-FC": ModelConfig(
         model_name="qwen3-30b-a3b-instruct-2507",
@@ -963,6 +1007,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwen3-30b-a3b-instruct-2507": ModelConfig(
         model_name="qwen3-30b-a3b-instruct-2507",
@@ -975,6 +1020,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwen3-235b-a22b-instruct-2507-FC": ModelConfig(
         model_name="qwen3-235b-a22b-instruct-2507-FC",
@@ -987,6 +1033,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwen3-235b-a22b-instruct-2507": ModelConfig(
         model_name="qwen3-235b-a22b-instruct-2507",
@@ -999,6 +1046,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "qwq-32b-FC": ModelConfig(
         model_name="qwq-32b-FC",
@@ -1011,6 +1059,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwq-32b": ModelConfig(
         model_name="qwq-32b",
@@ -1023,6 +1072,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "xiaoming-14B": ModelConfig(
         model_name="xiaoming-14B",
@@ -1071,6 +1121,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "glm-4.5-air-FC": ModelConfig(
         model_name="glm-4.5-air-FC",
@@ -1083,6 +1134,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "kimi-k2-0711-preview-FC": ModelConfig(
         model_name="moonshotai/Kimi-K2-Instruct-FC",
@@ -1095,6 +1147,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "kimi-k2-0711-preview": ModelConfig(
         model_name="moonshotai/Kimi-K2-Instruct",
@@ -1107,6 +1160,7 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
 }
 
@@ -1123,6 +1177,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "google/gemma-3-1b-it": ModelConfig(
         model_name="google/gemma-3-1b-it",
@@ -1183,6 +1238,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "meta-llama/Llama-3.1-8B-Instruct": ModelConfig(
         model_name="meta-llama/Llama-3.1-8B-Instruct",
@@ -1195,6 +1251,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "meta-llama/Llama-3.1-70B-Instruct-FC": ModelConfig(
         model_name="meta-llama/Llama-3.1-70B-Instruct-FC",
@@ -1207,6 +1264,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "meta-llama/Llama-3.1-70B-Instruct": ModelConfig(
         model_name="meta-llama/Llama-3.1-70B-Instruct",
@@ -1219,6 +1277,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "meta-llama/Llama-3.2-1B-Instruct-FC": ModelConfig(
         model_name="meta-llama/Llama-3.2-1B-Instruct-FC",
@@ -1291,6 +1350,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Salesforce/Llama-xLAM-2-8b-fc-r": ModelConfig(
         model_name="Salesforce/Llama-xLAM-2-8b-fc-r",
@@ -1303,6 +1363,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Salesforce/xLAM-2-32b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-32b-fc-r",
@@ -1315,6 +1376,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Salesforce/xLAM-2-3b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-3b-fc-r",
@@ -1327,6 +1389,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Salesforce/xLAM-2-1b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-1b-fc-r",
@@ -1339,6 +1402,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "mistralai/Ministral-8B-Instruct-2410": ModelConfig(
         model_name="mistralai/Ministral-8B-Instruct-2410",
@@ -1351,6 +1415,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "microsoft/phi-4": ModelConfig(
         model_name="microsoft/phi-4",
@@ -1363,6 +1428,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "microsoft/Phi-4-mini-instruct": ModelConfig(
         model_name="microsoft/Phi-4-mini-instruct",
@@ -1375,6 +1441,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "microsoft/Phi-4-mini-instruct-FC": ModelConfig(
         model_name="microsoft/Phi-4-mini-instruct-FC",
@@ -1387,6 +1454,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "ibm-granite/granite-3.2-8b-instruct": ModelConfig(
         model_name="ibm-granite/granite-3.2-8b-instruct",
@@ -1399,6 +1467,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "ibm-granite/granite-3.1-8b-instruct": ModelConfig(
         model_name="ibm-granite/granite-3.1-8b-instruct",
@@ -1411,6 +1480,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "ibm-granite/granite-20b-functioncalling": ModelConfig(
         model_name="ibm-granite/granite-20b-functioncalling",
@@ -1507,6 +1577,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Qwen/Qwen3-1.7B-FC": ModelConfig(
         model_name="Qwen/Qwen3-1.7B-FC",
@@ -1519,6 +1590,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Qwen/Qwen3-1.7B": ModelConfig(
         model_name="Qwen/Qwen3-1.7B",
@@ -1531,6 +1603,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Qwen/Qwen3-4B-Instruct-2507-FC": ModelConfig(
         model_name="Qwen/Qwen3-4B-Instruct-2507-FC",
@@ -1567,6 +1640,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Qwen/Qwen3-8B": ModelConfig(
         model_name="Qwen/Qwen3-8B",
@@ -1579,6 +1653,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Qwen/Qwen3-14B-FC": ModelConfig(
         model_name="Qwen/Qwen3-14B-FC",
@@ -1591,6 +1666,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Qwen/Qwen3-14B": ModelConfig(
         model_name="Qwen/Qwen3-14B",
@@ -1603,6 +1679,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Qwen/Qwen3-32B-FC": ModelConfig(
         model_name="Qwen/Qwen3-32B-FC",
@@ -1615,6 +1692,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Qwen/Qwen3-32B": ModelConfig(
         model_name="Qwen/Qwen3-32B",
@@ -1627,6 +1705,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "Qwen/Qwen3-30B-A3B-Instruct-2507-FC": ModelConfig(
         model_name="Qwen/Qwen3-30B-A3B-Instruct-2507-FC",
@@ -1771,6 +1850,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "tiiuae/Falcon3-10B-Instruct-FC": ModelConfig(
         model_name="tiiuae/Falcon3-10B-Instruct-FC",
@@ -1855,6 +1935,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     "katanemo/Arch-Agent-1.5B": ModelConfig(
         model_name="katanemo/Arch-Agent-1.5B",
@@ -1951,6 +2032,7 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
 }
 
@@ -2016,6 +2098,7 @@ third_party_inference_model_map = {
         output_price=0.2,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwen/qwq-32b-novita": ModelConfig(
         model_name="qwen/qwq-32b-novita",
@@ -2028,6 +2111,7 @@ third_party_inference_model_map = {
         output_price=0.2,
         is_fc_model=False,
         underscore_to_dot=False,
+        reasoning_mode=True,
     ),
     # Via Qwen Agent Framework
     "qwen3-4b-think-FC": ModelConfig(
@@ -2041,6 +2125,7 @@ third_party_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
+        reasoning_mode=True,
     ),
     "qwen3-4b-nothink-FC": ModelConfig(
         model_name="qwen3-4b-nothink-FC",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -109,8 +109,6 @@ class ModelConfig:
     # True if this model does not allow '.' in function names
     underscore_to_dot: bool = False
 
-    reasoning_mode: bool = False
-
 
 # Inference through API calls
 api_inference_model_map = {
@@ -137,7 +135,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "DeepSeek-R1-0528-FC": ModelConfig(
         model_name="DeepSeek-R1-0528-FC",
@@ -150,7 +147,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "DeepSeek-V3-0324-FC": ModelConfig(
         model_name="DeepSeek-V3-0324",
@@ -175,7 +171,6 @@ api_inference_model_map = {
         output_price=10,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "gpt-5-2025-08-07": ModelConfig(
         model_name="gpt-5-2025-08-07",
@@ -188,7 +183,6 @@ api_inference_model_map = {
         output_price=10,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "gpt-5-mini-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-mini-2025-08-07",
@@ -201,7 +195,6 @@ api_inference_model_map = {
         output_price=2,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "gpt-5-mini-2025-08-07": ModelConfig(
         model_name="gpt-5-mini-2025-08-07",
@@ -214,7 +207,6 @@ api_inference_model_map = {
         output_price=2,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "gpt-5-nano-2025-08-07-FC": ModelConfig(
         model_name="gpt-5-nano-2025-08-07",
@@ -227,7 +219,6 @@ api_inference_model_map = {
         output_price=0.4,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "gpt-5-nano-2025-08-07": ModelConfig(
         model_name="gpt-5-nano-2025-08-07",
@@ -240,7 +231,6 @@ api_inference_model_map = {
         output_price=0.4,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "gpt-4.1-2025-04-14-FC": ModelConfig(
         model_name="gpt-4.1-2025-04-14",
@@ -373,7 +363,6 @@ api_inference_model_map = {
         output_price=8,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "o3-2025-04-16-FC": ModelConfig(
         model_name="o3-2025-04-16",
@@ -386,7 +375,6 @@ api_inference_model_map = {
         output_price=8,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "o4-mini-2025-04-16": ModelConfig(
         model_name="o4-mini-2025-04-16",
@@ -399,7 +387,6 @@ api_inference_model_map = {
         output_price=4.40,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "o4-mini-2025-04-16-FC": ModelConfig(
         model_name="o4-mini-2025-04-16",
@@ -412,7 +399,6 @@ api_inference_model_map = {
         output_price=4.40,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "claude-opus-4-1-20250805": ModelConfig(
         model_name="claude-opus-4-1-20250805",
@@ -425,7 +411,6 @@ api_inference_model_map = {
         output_price=75,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "claude-opus-4-1-20250805-FC": ModelConfig(
         model_name="claude-opus-4-1-20250805",
@@ -438,7 +423,6 @@ api_inference_model_map = {
         output_price=75,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "claude-sonnet-4-20250514": ModelConfig(
         model_name="claude-sonnet-4-20250514",
@@ -451,7 +435,6 @@ api_inference_model_map = {
         output_price=15,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "claude-sonnet-4-20250514-FC": ModelConfig(
         model_name="claude-sonnet-4-20250514",
@@ -464,7 +447,6 @@ api_inference_model_map = {
         output_price=15,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "claude-3-5-haiku-20241022": ModelConfig(
         model_name="claude-3-5-haiku-20241022",
@@ -561,7 +543,6 @@ api_inference_model_map = {
         output_price=6,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "mistral-large-2411-FC": ModelConfig(
         model_name="mistral-large-2411",
@@ -574,7 +555,6 @@ api_inference_model_map = {
         output_price=6,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "mistral-small-2506": ModelConfig(
         model_name="mistral-small-2506",
@@ -587,7 +567,6 @@ api_inference_model_map = {
         output_price=0.3,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "mistral-small-2506-FC": ModelConfig(
         model_name="mistral-small-2506",
@@ -600,7 +579,6 @@ api_inference_model_map = {
         output_price=0.3,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "mistral-medium-2505": ModelConfig(
         model_name="mistral-medium-2505",
@@ -613,7 +591,6 @@ api_inference_model_map = {
         output_price=2,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "mistral-medium-2505-FC": ModelConfig(
         model_name="mistral-medium-2505",
@@ -626,7 +603,6 @@ api_inference_model_map = {
         output_price=2,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "firefunction-v2-FC": ModelConfig(
         model_name="firefunction-v2",
@@ -663,7 +639,6 @@ api_inference_model_map = {
         output_price=0.4,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "gemini-2.5-flash-FC": ModelConfig(
         model_name="gemini-2.5-flash",
@@ -700,7 +675,6 @@ api_inference_model_map = {
         output_price=10,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "gemini-2.5-pro": ModelConfig(
         model_name="gemini-2.5-pro",
@@ -713,7 +687,6 @@ api_inference_model_map = {
         output_price=10,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "meetkai/functionary-small-v3.1-FC": ModelConfig(
         model_name="meetkai/functionary-small-v3.1",
@@ -750,7 +723,6 @@ api_inference_model_map = {
         output_price=0.15,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "command-a-03-2025-FC": ModelConfig(
         model_name="command-a-03-2025",
@@ -775,7 +747,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "nvidia/nemotron-4-340b-instruct": ModelConfig(
         model_name="nvidia/nemotron-4-340b-instruct",
@@ -812,7 +783,6 @@ api_inference_model_map = {
         output_price=12,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "grok-4-0709-FC": ModelConfig(
         model_name="grok-4-0709",
@@ -825,7 +795,6 @@ api_inference_model_map = {
         output_price=15,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "grok-4-0709": ModelConfig(
         model_name="grok-4-0709",
@@ -838,7 +807,6 @@ api_inference_model_map = {
         output_price=15,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwen3-0.6b-FC": ModelConfig(
         model_name="qwen3-0.6b",
@@ -851,7 +819,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwen3-0.6b": ModelConfig(
         model_name="qwen3-0.6b",
@@ -864,7 +831,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwen3-1.7b-FC": ModelConfig(
         model_name="qwen3-1.7b",
@@ -877,7 +843,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwen3-1.7b": ModelConfig(
         model_name="qwen3-1.7b",
@@ -890,7 +855,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwen3-4b-FC": ModelConfig(
         model_name="qwen3-4b",
@@ -903,7 +867,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwen3-4b": ModelConfig(
         model_name="qwen3-4b",
@@ -916,7 +879,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwen3-8b-FC": ModelConfig(
         model_name="qwen3-8b",
@@ -929,7 +891,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwen3-8b": ModelConfig(
         model_name="qwen3-8b",
@@ -942,7 +903,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwen3-14b-FC": ModelConfig(
         model_name="qwen3-14b",
@@ -955,7 +915,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwen3-14b": ModelConfig(
         model_name="qwen3-14b",
@@ -968,7 +927,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwen3-32b-FC": ModelConfig(
         model_name="qwen3-32b",
@@ -981,7 +939,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwen3-32b": ModelConfig(
         model_name="qwen3-32b",
@@ -994,7 +951,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwen3-30b-a3b-instruct-2507-FC": ModelConfig(
         model_name="qwen3-30b-a3b-instruct-2507",
@@ -1007,7 +963,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwen3-30b-a3b-instruct-2507": ModelConfig(
         model_name="qwen3-30b-a3b-instruct-2507",
@@ -1020,7 +975,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwen3-235b-a22b-instruct-2507-FC": ModelConfig(
         model_name="qwen3-235b-a22b-instruct-2507",
@@ -1033,7 +987,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwen3-235b-a22b-instruct-2507": ModelConfig(
         model_name="qwen3-235b-a22b-instruct-2507",
@@ -1046,7 +999,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "qwq-32b-FC": ModelConfig(
         model_name="qwq-32b",
@@ -1059,7 +1011,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwq-32b": ModelConfig(
         model_name="qwq-32b",
@@ -1072,7 +1023,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "xiaoming-14B": ModelConfig(
         model_name="xiaoming-14B",
@@ -1121,7 +1071,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "glm-4.5-air-FC": ModelConfig(
         model_name="glm-4.5-air",
@@ -1134,7 +1083,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "kimi-k2-0711-preview-FC": ModelConfig(
         model_name="moonshotai/Kimi-K2-Instruct",
@@ -1147,7 +1095,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "kimi-k2-0711-preview": ModelConfig(
         model_name="moonshotai/Kimi-K2-Instruct",
@@ -1160,7 +1107,6 @@ api_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
 }
 
@@ -1177,7 +1123,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "google/gemma-3-1b-it": ModelConfig(
         model_name="google/gemma-3-1b-it",
@@ -1238,7 +1183,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "meta-llama/Llama-3.1-8B-Instruct": ModelConfig(
         model_name="meta-llama/Llama-3.1-8B-Instruct",
@@ -1251,7 +1195,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "meta-llama/Llama-3.1-70B-Instruct-FC": ModelConfig(
         model_name="meta-llama/Llama-3.1-70B-Instruct",
@@ -1264,7 +1207,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "meta-llama/Llama-3.1-70B-Instruct": ModelConfig(
         model_name="meta-llama/Llama-3.1-70B-Instruct",
@@ -1277,7 +1219,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "meta-llama/Llama-3.2-1B-Instruct-FC": ModelConfig(
         model_name="meta-llama/Llama-3.2-1B-Instruct",
@@ -1350,7 +1291,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Salesforce/Llama-xLAM-2-8b-fc-r": ModelConfig(
         model_name="Salesforce/Llama-xLAM-2-8b-fc-r",
@@ -1363,7 +1303,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Salesforce/xLAM-2-32b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-32b-fc-r",
@@ -1376,7 +1315,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Salesforce/xLAM-2-3b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-3b-fc-r",
@@ -1389,7 +1327,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Salesforce/xLAM-2-1b-fc-r": ModelConfig(
         model_name="Salesforce/xLAM-2-1b-fc-r",
@@ -1402,7 +1339,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "mistralai/Ministral-8B-Instruct-2410": ModelConfig(
         model_name="mistralai/Ministral-8B-Instruct-2410",
@@ -1415,7 +1351,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "microsoft/phi-4": ModelConfig(
         model_name="microsoft/phi-4",
@@ -1428,7 +1363,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "microsoft/Phi-4-mini-instruct": ModelConfig(
         model_name="microsoft/Phi-4-mini-instruct",
@@ -1441,7 +1375,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "microsoft/Phi-4-mini-instruct-FC": ModelConfig(
         model_name="microsoft/Phi-4-mini-instruct",
@@ -1454,7 +1387,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "ibm-granite/granite-3.2-8b-instruct": ModelConfig(
         model_name="ibm-granite/granite-3.2-8b-instruct",
@@ -1467,7 +1399,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "ibm-granite/granite-3.1-8b-instruct": ModelConfig(
         model_name="ibm-granite/granite-3.1-8b-instruct",
@@ -1480,7 +1411,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "ibm-granite/granite-20b-functioncalling": ModelConfig(
         model_name="ibm-granite/granite-20b-functioncalling",
@@ -1577,7 +1507,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Qwen/Qwen3-1.7B-FC": ModelConfig(
         model_name="Qwen/Qwen3-1.7B",
@@ -1590,7 +1519,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Qwen/Qwen3-1.7B": ModelConfig(
         model_name="Qwen/Qwen3-1.7B",
@@ -1603,7 +1531,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Qwen/Qwen3-4B-Instruct-2507-FC": ModelConfig(
         model_name="Qwen/Qwen3-4B-Instruct-2507",
@@ -1640,7 +1567,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Qwen/Qwen3-8B": ModelConfig(
         model_name="Qwen/Qwen3-8B",
@@ -1653,7 +1579,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Qwen/Qwen3-14B-FC": ModelConfig(
         model_name="Qwen/Qwen3-14B",
@@ -1666,7 +1591,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Qwen/Qwen3-14B": ModelConfig(
         model_name="Qwen/Qwen3-14B",
@@ -1679,7 +1603,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Qwen/Qwen3-32B-FC": ModelConfig(
         model_name="Qwen/Qwen3-32B",
@@ -1692,7 +1615,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Qwen/Qwen3-32B": ModelConfig(
         model_name="Qwen/Qwen3-32B",
@@ -1705,7 +1627,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "Qwen/Qwen3-30B-A3B-Instruct-2507-FC": ModelConfig(
         model_name="Qwen/Qwen3-30B-A3B-Instruct-2507",
@@ -1850,7 +1771,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "tiiuae/Falcon3-10B-Instruct-FC": ModelConfig(
         model_name="tiiuae/Falcon3-10B-Instruct",
@@ -1935,7 +1855,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     "katanemo/Arch-Agent-1.5B": ModelConfig(
         model_name="katanemo/Arch-Agent-1.5B",
@@ -2032,7 +1951,6 @@ local_inference_model_map = {
         output_price=None,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
 }
 
@@ -2098,7 +2016,6 @@ third_party_inference_model_map = {
         output_price=0.2,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwen/qwq-32b-novita": ModelConfig(
         model_name="qwen/qwq-32b",
@@ -2111,7 +2028,6 @@ third_party_inference_model_map = {
         output_price=0.2,
         is_fc_model=False,
         underscore_to_dot=False,
-        reasoning_mode=True,
     ),
     # Via Qwen Agent Framework
     "qwen3-4b-think-FC": ModelConfig(
@@ -2125,7 +2041,6 @@ third_party_inference_model_map = {
         output_price=None,
         is_fc_model=True,
         underscore_to_dot=True,
-        reasoning_mode=True,
     ),
     "qwen3-4b-nothink-FC": ModelConfig(
         model_name="qwen3-4b-nothink-FC",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -75,10 +75,10 @@ from bfcl_eval.model_handler.local_inference.think_agent import ThinkAgentHandle
 @dataclass
 class ModelConfig:
     """
-    Model configuration class for storing model metadata and settings.
+    Model configuration class for storing model metadata and settings. 
 
     Attributes:
-        model_name (str): [Not Used] Name of the model as used in the API or on Hugging Face.
+        model_name (str): Name of the model as used in the vendor API or on Hugging Face (may not be unique).
         display_name (str): Model name as it should appear on the leaderboard.
         url (str): Reference URL for the model or hosting service.
         org (str): Organization providing the model.
@@ -473,7 +473,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "nova-pro-v1.0": ModelConfig(
-        model_name="nova-pro-v1:0",
+        model_name="us.amazon.nova-pro-v1:0",
         display_name="Amazon-Nova-Pro-v1:0 (FC)",
         url="https://aws.amazon.com/cn/ai/generative-ai/nova/",
         org="Amazon",
@@ -485,7 +485,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "nova-lite-v1.0": ModelConfig(
-        model_name="nova-lite-v1:0",
+        model_name="us.amazon.nova-lite-v1:0",
         display_name="Amazon-Nova-Lite-v1:0 (FC)",
         url="https://aws.amazon.com/cn/ai/generative-ai/nova/",
         org="Amazon",
@@ -497,7 +497,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "nova-micro-v1.0": ModelConfig(
-        model_name="nova-micro-v1:0",
+        model_name="us.amazon.nova-micro-v1:0",
         display_name="Amazon-Nova-Micro-v1:0 (FC)",
         url="https://aws.amazon.com/cn/ai/generative-ai/nova/",
         org="Amazon",
@@ -605,7 +605,7 @@ api_inference_model_map = {
         underscore_to_dot=True,
     ),
     "firefunction-v2-FC": ModelConfig(
-        model_name="firefunction-v2",
+        model_name="accounts/fireworks/models/firefunction-v2",
         display_name="FireFunction-v2 (FC)",
         url="https://huggingface.co/fireworks-ai/firefunction-v2",
         org="Fireworks",

--- a/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/eval_runner.py
@@ -25,8 +25,11 @@ from tqdm import tqdm
 def get_handler(model_name: str) -> BaseHandler:
     config = MODEL_CONFIG_MAPPING[model_name]
     handler: BaseHandler = config.model_handler(
-        model_name, temperature=0
-    )  # Temperature doesn't matter for evaluation
+        config.model_name, temperature=0
+    )
+    # handler: BaseHandler = config.model_handler(
+    #     model_name, temperature=0
+    # )  # Temperature doesn't matter for evaluation
     handler.is_fc_model = config.is_fc_model
     return handler
 

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/claude.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/claude.py
@@ -23,13 +23,20 @@ from bfcl_eval.utils import contain_multi_turn_interaction
 
 
 class ClaudeHandler(BaseHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.ANTHROPIC
         self.client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
     def decode_ast(self, result, language, has_tool_call_tag):
-        if "FC" not in self.model_name  or not self.is_fc_model:
+        if not self.is_fc_model:
             return default_decode_ast_prompting(result, language, has_tool_call_tag)
 
         else:
@@ -41,7 +48,7 @@ class ClaudeHandler(BaseHandler):
             return decoded_output
 
     def decode_execute(self, result, has_tool_call_tag):
-        if "FC" not in self.model_name or not self.is_fc_model:
+        if not self.is_fc_model:
             return default_decode_execute_prompting(result, has_tool_call_tag)
 
         else:

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/claude.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/claude.py
@@ -29,7 +29,7 @@ class ClaudeHandler(BaseHandler):
         self.client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
     def decode_ast(self, result, language, has_tool_call_tag):
-        if "FC" not in self.model_name:
+        if "FC" not in self.model_name  or not self.is_fc_model:
             return default_decode_ast_prompting(result, language, has_tool_call_tag)
 
         else:
@@ -41,7 +41,7 @@ class ClaudeHandler(BaseHandler):
             return decoded_output
 
     def decode_execute(self, result, has_tool_call_tag):
-        if "FC" not in self.model_name:
+        if "FC" not in self.model_name or not self.is_fc_model:
             return default_decode_execute_prompting(result, has_tool_call_tag)
 
         else:

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/cohere.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/cohere.py
@@ -19,8 +19,15 @@ from tenacity.stop import stop_after_attempt
 class CohereHandler(BaseHandler):
     client: cohere.ClientV2
 
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.COHERE
         self.is_fc_model = True
         self.client = cohere.ClientV2(api_key=os.getenv("COHERE_API_KEY"))
@@ -40,8 +47,14 @@ class CohereHandler(BaseHandler):
             for tool_call in result:
                 parameter_key_value_list = []
                 for parameter_name, parameter_value in tool_call["parameters"].items():
-                    parameter_key_value_list.append("{}={}".format(parameter_name, repr(parameter_value)))
-                execution_list.append("{}({})".format(tool_call["tool_name"], ",".join(parameter_key_value_list)))
+                    parameter_key_value_list.append(
+                        "{}={}".format(parameter_name, repr(parameter_value))
+                    )
+                execution_list.append(
+                    "{}({})".format(
+                        tool_call["tool_name"], ",".join(parameter_key_value_list)
+                    )
+                )
         return execution_list
 
     #### FC methods ####
@@ -93,7 +106,9 @@ class CohereHandler(BaseHandler):
             output_token = response.usage.billed_units.output_tokens
 
         metadata = {
-            "model_responses": chat_turn_to_append.content if chat_turn_to_append.content else None,
+            "model_responses": (
+                chat_turn_to_append.content if chat_turn_to_append.content else None
+            ),
             "tool_calls": model_tool_calls,
             "chat_history": [],
             "input_token": input_token or 0,
@@ -103,9 +118,7 @@ class CohereHandler(BaseHandler):
 
     @retry_with_backoff(error_type=Exception, stop=stop_after_attempt(5), reraise=True)
     def generate_with_backoff(
-        self,
-        messages: list,
-        tools: list[cohere.types.ToolV2]
+        self, messages: list, tools: list[cohere.types.ToolV2]
     ) -> tuple[cohere.types.ChatResponse, float]:
         start_time = time.time()
         api_response = self.client.chat(
@@ -125,11 +138,15 @@ class CohereHandler(BaseHandler):
             if turn_idx == 0:  # we only extract system message from the first turn
                 system_message = extract_system_prompt(turn)
                 if system_message:
-                    inference_data["system_message"] = system_message  # we log system message if necessary
+                    inference_data["system_message"] = (
+                        system_message  # we log system message if necessary
+                    )
             if len(turn) > 0:
                 turns.append(preprocess_chat_turns(turn))
             else:
-                turns.append([])  # for miss_func categories, the turn to supplement function will be empty
+                turns.append(
+                    []
+                )  # for miss_func categories, the turn to supplement function will be empty
         assert len(turns) == len(test_entry["question"])
         test_entry["question"] = turns
         return inference_data
@@ -144,7 +161,9 @@ class CohereHandler(BaseHandler):
 
     def _parse_query_response_FC(self, api_response: Any) -> dict:
         if len(api_response["tool_calls"]) > 0:  # non empty tool call list
-            model_responses = api_response["tool_calls"]  # list: {"tool_name": , "parameters"}
+            model_responses = api_response[
+                "tool_calls"
+            ]  # list: {"tool_name": , "parameters"}
         else:
             if isinstance(api_response["model_responses"], list):
                 model_responses = []
@@ -171,9 +190,14 @@ class CohereHandler(BaseHandler):
         chat_turns = []
         for message in first_turn_message:
             message_role = message["role"]
-            assert message_role in ["user", "assistant"], "message role must be in ['user', 'assistant']"
+            assert message_role in [
+                "user",
+                "assistant",
+            ], "message role must be in ['user', 'assistant']"
             if message_role == "user":
-                chat_turns.append(cohere.UserChatMessageV2(role="user", content=message["content"]))
+                chat_turns.append(
+                    cohere.UserChatMessageV2(role="user", content=message["content"])
+                )
             else:
                 chat_turns.append(
                     cohere.AssistantChatMessageV2(
@@ -194,7 +218,8 @@ class CohereHandler(BaseHandler):
             message_role = message["role"]
             if message_role == "user":
                 inference_data["chat_turns"].append(
-                    cohere.UserChatMessageV2(role="user", content=message["content"]))
+                    cohere.UserChatMessageV2(role="user", content=message["content"])
+                )
             elif message_role == "assistant":
                 inference_data["chat_turns"].append(
                     cohere.AssistantChatMessageV2(
@@ -206,7 +231,9 @@ class CohereHandler(BaseHandler):
                 raise Exception(f"Role {message_role} is undefined!")
         if inference_data["chat_turns"][-1].role != "user":
             # if last turn is not user turn - we suffixing a user turn at the end of the conversation history
-            inference_data["chat_turns"].append(cohere.UserChatMessageV2(role="user", content=""))
+            inference_data["chat_turns"].append(
+                cohere.UserChatMessageV2(role="user", content="")
+            )
         return inference_data
 
     def _add_assistant_message_FC(
@@ -224,12 +251,16 @@ class CohereHandler(BaseHandler):
             assert (
                 inference_data["chat_turns"][-1].role == "assistant"
             ), "last turn must be tool use turn and from the assistant"
-            assert inference_data["chat_turns"][-1].tool_calls, "last turn must have tool calls"
+            assert inference_data["chat_turns"][
+                -1
+            ].tool_calls, "last turn must have tool calls"
             assert len(inference_data["chat_turns"][-1].tool_calls) == len(
                 execution_results
             ), "Number of execution result must match number of tool calls from last turn!"
             tool_call_messages = []
-            for tool_call, execution_result in zip(inference_data["chat_turns"][-1].tool_calls, execution_results):
+            for tool_call, execution_result in zip(
+                inference_data["chat_turns"][-1].tool_calls, execution_results
+            ):
                 tool_call_id = tool_call.id
                 try:
                     tool_execution_result = ast.literal_eval(execution_result)

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/deepseek.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/deepseek.py
@@ -15,8 +15,15 @@ from overrides import override
 
 
 class DeepSeekAPIHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_COMPLETIONS
         self.client = OpenAI(
             base_url="https://api.deepseek.com", api_key=os.getenv("DEEPSEEK_API_KEY")

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/dm_cito.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/dm_cito.py
@@ -4,8 +4,15 @@ from openai import OpenAI
 from bfcl_eval.model_handler.api_inference.mining import MiningHandler
 
 class DMCitoHandler(MiningHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_COMPLETIONS
         self.client = OpenAI(
             base_url= os.getenv("DMCITO_BASE_URL"),

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/fireworks.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/fireworks.py
@@ -10,8 +10,15 @@ from openai import OpenAI
 
 
 class FireworksHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.FIREWORK_AI
 
         self.client = OpenAI(
@@ -30,16 +37,14 @@ class FireworksHandler(OpenAICompletionsHandler):
         if len(tools) > 0:
             api_response = self.client.chat.completions.create(
                 messages=message,
-                # model=f"accounts/fireworks/models/{self.model_name.replace('-FC', '')}",
-                model=f"accounts/fireworks/models/{self.model_name}",
+                model=self.model_name,
                 temperature=self.temperature,
                 tools=tools,
             )
         else:
             api_response = self.client.chat.completions.create(
                 messages=message,
-                # model=f"accounts/fireworks/models/{self.model_name.replace('-FC', '')}",
-                model=f"accounts/fireworks/models/{self.model_name}",
+                model=self.model_name,
                 temperature=self.temperature,
             )
         end_time = time.time()

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/fireworks.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/fireworks.py
@@ -30,14 +30,16 @@ class FireworksHandler(OpenAICompletionsHandler):
         if len(tools) > 0:
             api_response = self.client.chat.completions.create(
                 messages=message,
-                model=f"accounts/fireworks/models/{self.model_name.replace('-FC', '')}",
+                # model=f"accounts/fireworks/models/{self.model_name.replace('-FC', '')}",
+                model=f"accounts/fireworks/models/{self.model_name}",
                 temperature=self.temperature,
                 tools=tools,
             )
         else:
             api_response = self.client.chat.completions.create(
                 messages=message,
-                model=f"accounts/fireworks/models/{self.model_name.replace('-FC', '')}",
+                # model=f"accounts/fireworks/models/{self.model_name.replace('-FC', '')}",
+                model=f"accounts/fireworks/models/{self.model_name}",
                 temperature=self.temperature,
             )
         end_time = time.time()

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/functionary.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/functionary.py
@@ -2,10 +2,18 @@ from bfcl_eval.model_handler.api_inference.openai_completion import OpenAIComple
 from bfcl_eval.constants.enums import ModelStyle
 from openai import OpenAI
 
-# For setup instructions, please refer to https://github.com/MeetKai/functionary for setup details. 
+
+# For setup instructions, please refer to https://github.com/MeetKai/functionary for setup details.
 class FunctionaryHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_COMPLETIONS
 
         self.client = OpenAI(base_url="http://localhost:8000/v1", api_key="functionary")

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gemini.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gemini.py
@@ -26,8 +26,15 @@ from google.genai.types import (
 
 
 class GeminiHandler(BaseHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.GOOGLE
         api_key = os.getenv("GOOGLE_API_KEY")
         if not api_key:
@@ -48,7 +55,7 @@ class GeminiHandler(BaseHandler):
         return prompts
 
     def decode_ast(self, result, language, has_tool_call_tag):
-        if "FC" not in self.model_name or not self.is_fc_model:
+        if not self.is_fc_model:
             result = result.replace("```tool_code\n", "").replace("\n```", "")
             return default_decode_ast_prompting(result, language, has_tool_call_tag)
         else:
@@ -57,7 +64,7 @@ class GeminiHandler(BaseHandler):
             return result
 
     def decode_execute(self, result, has_tool_call_tag):
-        if "FC" not in self.model_name or not self.is_fc_model:
+        if not self.is_fc_model:
             result = result.replace("```tool_code\n", "").replace("\n```", "")
             return default_decode_execute_prompting(result, has_tool_call_tag)
         else:

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gemini.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gemini.py
@@ -48,7 +48,7 @@ class GeminiHandler(BaseHandler):
         return prompts
 
     def decode_ast(self, result, language, has_tool_call_tag):
-        if "FC" not in self.model_name:
+        if "FC" not in self.model_name or not self.is_fc_model:
             result = result.replace("```tool_code\n", "").replace("\n```", "")
             return default_decode_ast_prompting(result, language, has_tool_call_tag)
         else:
@@ -57,7 +57,7 @@ class GeminiHandler(BaseHandler):
             return result
 
     def decode_execute(self, result, has_tool_call_tag):
-        if "FC" not in self.model_name:
+        if "FC" not in self.model_name or not self.is_fc_model:
             result = result.replace("```tool_code\n", "").replace("\n```", "")
             return default_decode_execute_prompting(result, has_tool_call_tag)
         else:
@@ -101,7 +101,7 @@ class GeminiHandler(BaseHandler):
             config.tools = [Tool(function_declarations=inference_data["tools"])]
 
         return self.generate_with_backoff(
-            model=self.model_name.replace("-FC", ""),
+            model=self.model_name,
             contents=inference_data["message"],
             config=config,
         )
@@ -248,7 +248,7 @@ class GeminiHandler(BaseHandler):
             config.system_instruction = inference_data["system_prompt"]
 
         api_response = self.generate_with_backoff(
-            model=self.model_name.replace("-FC", ""),
+            model=self.model_name,
             contents=inference_data["message"],
             config=config,
         )

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/glm.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/glm.py
@@ -2,17 +2,21 @@ import os
 
 from bfcl_eval.model_handler.api_inference.openai_completion import OpenAICompletionsHandler
 from openai import OpenAI
-from overrides import override
-from typing import Any
 import httpx
 
 
 class GLMAPIHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.client = OpenAI(
             api_key=os.getenv("GLM_API_KEY"),
             base_url="https://open.bigmodel.cn/api/paas/v4/",
-            timeout=httpx.Timeout(timeout=300.0, connect=8.0)
+            timeout=httpx.Timeout(timeout=300.0, connect=8.0),
         )
-        self.is_fc_model = True

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gogoagent.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gogoagent.py
@@ -5,8 +5,15 @@ from openai import OpenAI
 
 
 class GoGoAgentHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.is_fc_model = False
 
         self.client = OpenAI(

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gorilla.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/gorilla.py
@@ -9,8 +9,15 @@ from bfcl_eval.model_handler.utils import ast_parse
 
 
 class GorillaHandler(BaseHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.GORILLA
 
     def decode_ast(self, result, language, has_tool_call_tag):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/grok.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/grok.py
@@ -15,7 +15,7 @@ class GrokHandler(OpenAICompletionsHandler):
             base_url="https://api.x.ai/v1",
             api_key=os.getenv("GROK_API_KEY"),
         )
-        self.is_fc_model = "FC" in self.model_name
+        # self.is_fc_model = "FC" in self.model_name
 
     @override
     def _parse_query_response_prompting(self, api_response: Any) -> dict:

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/grok.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/grok.py
@@ -9,13 +9,19 @@ from overrides import override
 
 
 class GrokHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.client = OpenAI(
             base_url="https://api.x.ai/v1",
             api_key=os.getenv("GROK_API_KEY"),
         )
-        # self.is_fc_model = "FC" in self.model_name
 
     @override
     def _parse_query_response_prompting(self, api_response: Any) -> dict:

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/kimi.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/kimi.py
@@ -4,8 +4,15 @@ from openai import OpenAI
 
 
 class KimiHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name: str, temperature: float) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
         self.client = OpenAI(
             # base_url="https://api.moonshot.ai/v1", 

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/ling.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/ling.py
@@ -17,8 +17,15 @@ from overrides import override
 
 
 class LingAPIHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_COMPLETIONS
         api_url = "https://bailingchat.alipay.com"
         self.client = OpenAI(base_url=api_url, api_key=os.getenv("LING_API_KEY"))

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mining.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mining.py
@@ -11,8 +11,15 @@ from openai import OpenAI
 
 
 class MiningHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_COMPLETIONS
         self.client = OpenAI(
             base_url= os.getenv("MINING_BASE_URL"),

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mistral.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mistral.py
@@ -26,7 +26,7 @@ class MistralHandler(BaseHandler):
         self.client = Mistral(api_key=os.getenv("MISTRAL_API_KEY"))
 
     def decode_ast(self, result, language, has_tool_call_tag):
-        if "FC" in self.model_name:
+        if "FC" in self.model_name or self.is_fc_model:
             decoded_output = []
             for invoked_function in result:
                 name = list(invoked_function.keys())[0]
@@ -37,7 +37,7 @@ class MistralHandler(BaseHandler):
             return default_decode_ast_prompting(result, language, has_tool_call_tag)
 
     def decode_execute(self, result, has_tool_call_tag):
-        if "FC" in self.model_name:
+        if "FC" in self.model_name or self.is_fc_model:
             function_call = convert_to_function_call(result)
             return function_call
         else:
@@ -62,7 +62,7 @@ class MistralHandler(BaseHandler):
         }
 
         return self.generate_with_backoff(
-            model=self.model_name.replace("-FC", ""),
+            model=self.model_name,
             messages=message,
             tools=tool,
             temperature=self.temperature,

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mistral.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mistral.py
@@ -19,14 +19,21 @@ from mistralai import Mistral
 
 
 class MistralHandler(BaseHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.MISTRAL
 
         self.client = Mistral(api_key=os.getenv("MISTRAL_API_KEY"))
 
     def decode_ast(self, result, language, has_tool_call_tag):
-        if "FC" in self.model_name or self.is_fc_model:
+        if self.is_fc_model:
             decoded_output = []
             for invoked_function in result:
                 name = list(invoked_function.keys())[0]
@@ -37,7 +44,7 @@ class MistralHandler(BaseHandler):
             return default_decode_ast_prompting(result, language, has_tool_call_tag)
 
     def decode_execute(self, result, has_tool_call_tag):
-        if "FC" in self.model_name or self.is_fc_model:
+        if self.is_fc_model:
             function_call = convert_to_function_call(result)
             return function_call
         else:

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nemotron.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nemotron.py
@@ -23,8 +23,15 @@ class NemotronHandler(OpenAICompletionsHandler):
     - <AVAILABLE_TOOLS>{functions}</AVAILABLE_TOOLS> for function documentation
     """
 
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.client = OpenAI(
             base_url="https://integrate.api.nvidia.com/v1",
             api_key=os.getenv("NVIDIA_API_KEY"),

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nexus.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nexus.py
@@ -8,8 +8,15 @@ from bfcl_eval.model_handler.utils import ast_parse
 
 
 class NexusHandler(BaseHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.NEXUS
         self.is_fc_model = True
 

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nova.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nova.py
@@ -16,8 +16,15 @@ from bfcl_eval.model_handler.utils import (
 
 
 class NovaHandler(BaseHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.AMAZON
         self.is_fc_model = True
         _session = boto3.Session(
@@ -64,7 +71,7 @@ class NovaHandler(BaseHandler):
             # toolConfig requires minimum number of 1 item.
             return self.generate_with_backoff(
                 # modelId=f"us.amazon.{self.model_name.replace('.', ':')}",
-                modelId=f"us.amazon.{self.model_name}",
+                modelId=self.model_name,
                 messages=message,
                 system=system_prompt,
                 inferenceConfig={"temperature": self.temperature},
@@ -72,8 +79,7 @@ class NovaHandler(BaseHandler):
             )
         else:
             return self.generate_with_backoff(
-                # modelId=f"us.amazon.{self.model_name.replace('.', ':')}"
-                modelId=f"us.amazon.{self.model_name}",
+                modelId=self.model_name,
                 messages=message,
                 system=system_prompt,
                 inferenceConfig={"temperature": self.temperature},

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nova.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nova.py
@@ -63,7 +63,8 @@ class NovaHandler(BaseHandler):
         if len(tools) > 0:
             # toolConfig requires minimum number of 1 item.
             return self.generate_with_backoff(
-                modelId=f"us.amazon.{self.model_name.replace('.', ':')}",
+                # modelId=f"us.amazon.{self.model_name.replace('.', ':')}",
+                modelId=f"us.amazon.{self.model_name}",
                 messages=message,
                 system=system_prompt,
                 inferenceConfig={"temperature": self.temperature},
@@ -71,7 +72,8 @@ class NovaHandler(BaseHandler):
             )
         else:
             return self.generate_with_backoff(
-                modelId=f"us.amazon.{self.model_name.replace('.', ':')}",
+                # modelId=f"us.amazon.{self.model_name.replace('.', ':')}"
+                modelId=f"us.amazon.{self.model_name}",
                 messages=message,
                 system=system_prompt,
                 inferenceConfig={"temperature": self.temperature},

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/novita.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/novita.py
@@ -27,7 +27,7 @@ class NovitaHandler(OpenAICompletionsHandler):
         if len(tools) > 0:
             return self.generate_with_backoff(
                 messages=message,
-                model=self.model_name.replace("-FC", "").replace("-novita", ""),
+                model=self.model_name,
                 temperature=self.temperature,
                 tools=tools,
             )
@@ -35,7 +35,7 @@ class NovitaHandler(OpenAICompletionsHandler):
 
             return self.generate_with_backoff(
                 messages=message,
-                model=self.model_name.replace("-FC", "").replace("-novita", ""),
+                model=self.model_name,
                 temperature=self.temperature,
             )
 
@@ -46,6 +46,6 @@ class NovitaHandler(OpenAICompletionsHandler):
 
         return self.generate_with_backoff(
             messages=inference_data["message"],
-            model=self.model_name.replace("-novita", ""),
+            model=self.model_name,
             temperature=self.temperature,
         )

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/novita.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/novita.py
@@ -6,8 +6,15 @@ from openai import OpenAI
 
 
 class NovitaHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.NOVITA_AI
         self.client = OpenAI(
             base_url="https://api.novita.ai/v3/openai",

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nvidia.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/nvidia.py
@@ -14,8 +14,15 @@ from openai import OpenAI
 
 
 class NvidiaHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_COMPLETIONS
         self.client = OpenAI(
             base_url="https://integrate.api.nvidia.com/v1",

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
@@ -19,13 +19,38 @@ from openai import OpenAI, RateLimitError
 
 
 class OpenAICompletionsHandler(BaseHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_COMPLETIONS
-        self.client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        self.client = OpenAI(**self._build_client_kwargs())
+
+    def _build_client_kwargs(self):
+        """Collect OpenAI client keyword arguments from environment variables, but only
+        include them if they are actually present so that we keep the call minimal
+        and rely on the OpenAI SDK's own defaults when possible."""
+
+        kwargs = {}
+
+        if api_key := os.getenv("OPENAI_API_KEY"):
+            kwargs["api_key"] = api_key
+
+        if base_url := os.getenv("OPENAI_BASE_URL"):
+            kwargs["base_url"] = base_url
+
+        if headers_env := os.getenv("OPENAI_DEFAULT_HEADERS"):
+            kwargs["default_headers"] = json.loads(headers_env)
+
+        return kwargs
 
     def decode_ast(self, result, language, has_tool_call_tag):
-        if "FC" in self.model_name or self.is_fc_model:
+        if self.is_fc_model:
             decoded_output = []
             for invoked_function in result:
                 name = list(invoked_function.keys())[0]
@@ -36,7 +61,7 @@ class OpenAICompletionsHandler(BaseHandler):
             return default_decode_ast_prompting(result, language, has_tool_call_tag)
 
     def decode_execute(self, result, has_tool_call_tag):
-        if "FC" in self.model_name or self.is_fc_model:
+        if self.is_fc_model:
             return convert_to_function_call(result)
         else:
             return default_decode_execute_prompting(result)

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
@@ -58,7 +58,7 @@ class OpenAICompletionsHandler(BaseHandler):
 
         kwargs = {
             "messages": message,
-            "model": self.model_name.replace("-FC", ""),
+            "model": self.model_name,
             "temperature": self.temperature,
             "store": False,
         }

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_response.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_response.py
@@ -19,10 +19,35 @@ from openai.types.responses import Response
 
 
 class OpenAIResponsesHandler(BaseHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_RESPONSES
-        self.client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        self.client = OpenAI(**self._build_client_kwargs())
+
+    def _build_client_kwargs(self):
+        """Collect OpenAI client keyword arguments from environment variables, but only
+        include them if they are actually present so that we keep the call minimal
+        and rely on the OpenAI SDK's own defaults when possible."""
+
+        kwargs = {}
+
+        if api_key := os.getenv("OPENAI_API_KEY"):
+            kwargs["api_key"] = api_key
+
+        if base_url := os.getenv("OPENAI_BASE_URL"):
+            kwargs["base_url"] = base_url
+
+        if headers_env := os.getenv("OPENAI_DEFAULT_HEADERS"):
+            kwargs["default_headers"] = json.loads(headers_env)
+
+        return kwargs
 
     @staticmethod
     def _substitute_prompt_role(prompts: list[dict]) -> list[dict]:
@@ -36,7 +61,7 @@ class OpenAIResponsesHandler(BaseHandler):
         return prompts
 
     def decode_ast(self, result, language, has_tool_call_tag):
-        if "FC" in self.model_name or self.is_fc_model:
+        if self.is_fc_model:
             decoded_output = []
             for invoked_function in result:
                 name = list(invoked_function.keys())[0]
@@ -47,7 +72,7 @@ class OpenAIResponsesHandler(BaseHandler):
             return default_decode_ast_prompting(result, language, has_tool_call_tag)
 
     def decode_execute(self, result, has_tool_call_tag):
-        if "FC" in self.model_name or self.is_fc_model:
+        if self.is_fc_model:
             return convert_to_function_call(result)
         else:
             return default_decode_execute_prompting(result, has_tool_call_tag)
@@ -81,7 +106,11 @@ class OpenAIResponsesHandler(BaseHandler):
         }
 
         # OpenAI reasoning models don't support temperature parameter
-        if "o3" in self.model_name or "o4-mini" in self.model_name or "gpt-5" in self.model_name:
+        if (
+            "o3" in self.model_name
+            or "o4-mini" in self.model_name
+            or "gpt-5" in self.model_name
+        ):
             del kwargs["temperature"]
 
         # Non-reasoning models don't support reasoning parameter
@@ -196,7 +225,11 @@ class OpenAIResponsesHandler(BaseHandler):
         }
 
         # OpenAI reasoning models don't support temperature parameter
-        if "o3" in self.model_name or "o4-mini" in self.model_name or "gpt-5" in self.model_name:
+        if (
+            "o3" in self.model_name
+            or "o4-mini" in self.model_name
+            or "gpt-5" in self.model_name
+        ):
             del kwargs["temperature"]
 
         # Non-reasoning models don't support reasoning parameter

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_response.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_response.py
@@ -73,7 +73,7 @@ class OpenAIResponsesHandler(BaseHandler):
 
         kwargs = {
             "input": message,
-            "model": self.model_name.replace("-FC", ""),
+            "model": self.model_name,
             "store": False,
             "include": ["reasoning.encrypted_content"],
             "reasoning": {"summary": "auto"},
@@ -188,7 +188,7 @@ class OpenAIResponsesHandler(BaseHandler):
 
         kwargs = {
             "input": inference_data["message"],
-            "model": self.model_name.replace("-FC", ""),
+            "model": self.model_name,
             "store": False,
             "include": ["reasoning.encrypted_content"],
             "reasoning": {"summary": "auto"},

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/qwen.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/qwen.py
@@ -17,8 +17,15 @@ class QwenAPIHandler(OpenAICompletionsHandler):
 
     """
 
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_COMPLETIONS
         self.client = OpenAI(
             base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
@@ -205,8 +212,15 @@ class QwenAPIHandler(OpenAICompletionsHandler):
 
 class QwenAgentThinkHandler(OpenAICompletionsHandler):
 
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.OPENAI_COMPLETIONS
         """
         Note: Need to start vllm server first with command:

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/writer.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/writer.py
@@ -7,8 +7,15 @@ from writerai import Writer
 
 
 class WriterHandler(OpenAICompletionsHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_style = ModelStyle.WRITER
         self.client = Writer(api_key=os.getenv("WRITER_API_KEY"))
 

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/arch.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/arch.py
@@ -8,8 +8,16 @@ from overrides import override
 
 
 class ArchHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.is_fc_model = True
 
     @override

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/base_oss_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/base_oss_handler.py
@@ -20,8 +20,16 @@ from overrides import EnforceOverrides, final, override
 
 
 class OSSHandler(BaseHandler, EnforceOverrides):
-    def __init__(self, model_name, temperature, dtype="bfloat16") -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_name_huggingface = model_name
         self.model_style = ModelStyle.OSSMODEL
         self.dtype = dtype

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/bielik.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/bielik.py
@@ -5,8 +5,16 @@ from overrides import override
 
 
 class BielikHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/bitagent.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/bitagent.py
@@ -5,8 +5,16 @@ from overrides import override
 
 
 class BitAgentHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/deepseek_reasoning.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/deepseek_reasoning.py
@@ -15,8 +15,16 @@ class DeepseekReasoningHandler(OSSHandler):
     We DO also support the benchmark/inference for DeepSeek-R1 model through their official hosted API. The `api_inference/deepseek.py` file contains the implementation for the API inference handler.
     """
 
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _pre_query_processing_prompting(self, test_entry: dict) -> dict:

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/falcon_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/falcon_fc.py
@@ -5,8 +5,16 @@ from overrides import override
 
 
 class Falcon3FCHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_name_huggingface = model_name
 
     @override

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/falcon_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/falcon_fc.py
@@ -7,7 +7,7 @@ from overrides import override
 class Falcon3FCHandler(OSSHandler):
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)
-        self.model_name_huggingface = model_name.replace("-FC", "")
+        self.model_name_huggingface = model_name
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gemma.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gemma.py
@@ -7,8 +7,16 @@ from overrides import override
 
 
 class GemmaHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/glm.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/glm.py
@@ -8,8 +8,16 @@ from overrides import override
 
 
 class GLMHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.stop_token_ids = [151329, 151336, 151338]
 
     @override

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/granite.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/granite.py
@@ -8,8 +8,16 @@ from overrides import override
 
 
 class GraniteFunctionCallingHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/granite_3.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/granite_3.py
@@ -16,8 +16,16 @@ class Granite3FCHandler(OSSHandler):
     - Granite-3.2-8B-Instruct (https://huggingface.co/ibm-granite/granite-3.2-8b-instruct)
     """
 
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_name_huggingface = model_name.replace("-FC", "")
 
     # copied from phi_fc.py

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/hammer.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/hammer.py
@@ -26,8 +26,16 @@ The example format is as follows. Please make sure the parameter type is correct
 
 
 class HammerHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/llama.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/llama.py
@@ -17,8 +17,16 @@ class LlamaHandler(OSSHandler):
     As a result, we will not have separate "prompt mode" for Llama models to avoid confusion.
     """
 
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_name_huggingface = model_name.replace("-FC", "")
 
     @override

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/llama_3_1.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/llama_3_1.py
@@ -13,8 +13,16 @@ class LlamaHandler_3_1(OSSHandler):
     
     For all other Llama models, see the LlamaHandler class.
     """
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_name_huggingface = model_name.replace("-FC", "")
 
     @override

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/minicpm.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/minicpm.py
@@ -3,8 +3,16 @@ from overrides import override
 
 
 class MiniCPMHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/minicpm_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/minicpm_fc.py
@@ -17,7 +17,7 @@ class MiniCPMFCHandler(OSSHandler):
         super().__init__(model_name, temperature)
         self.stop_token_ids = [2, 73440]
         self.skip_special_tokens = False
-        self.model_name_huggingface = model_name.replace("-FC", "")
+        self.model_name_huggingface = model_name
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/minicpm_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/minicpm_fc.py
@@ -13,8 +13,16 @@ from overrides import override
 
 
 class MiniCPMFCHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.stop_token_ids = [2, 73440]
         self.skip_special_tokens = False
         self.model_name_huggingface = model_name

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/mistral_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/mistral_fc.py
@@ -9,8 +9,16 @@ from overrides import override
 
 
 class MistralFCHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def decode_ast(self, result, language, has_tool_call_tag):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/phi.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/phi.py
@@ -3,8 +3,16 @@ from overrides import override
 
 
 class PhiHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def decode_ast(self, result, language, has_tool_call_tag):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/phi_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/phi_fc.py
@@ -15,8 +15,16 @@ class PhiFCHandler(OSSHandler):
     - microsoft/Phi-4-mini-instruct
     """
 
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_name_huggingface = model_name
         self.is_fc_model = True
 

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/phi_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/phi_fc.py
@@ -17,7 +17,7 @@ class PhiFCHandler(OSSHandler):
 
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)
-        self.model_name_huggingface = model_name.replace("-FC", "")
+        self.model_name_huggingface = model_name
         self.is_fc_model = True
 
     @override

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/quick_testing_oss.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/quick_testing_oss.py
@@ -10,8 +10,16 @@ Formatting the prompt manually give us better control over the final formatted p
 
 
 class QuickTestingOSSHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen.py
@@ -5,9 +5,16 @@ from overrides import override
 
 
 class QwenHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
-        self.is_fc_model = False
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen_fc.py
@@ -8,9 +8,16 @@ from overrides import override
 
 
 class QwenFCHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
-        self.is_fc_model = True
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.model_name_huggingface = model_name
 
     @override

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen_fc.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/qwen_fc.py
@@ -11,7 +11,7 @@ class QwenFCHandler(OSSHandler):
     def __init__(self, model_name, temperature) -> None:
         super().__init__(model_name, temperature)
         self.is_fc_model = True
-        self.model_name_huggingface = model_name.replace("-FC", "")
+        self.model_name_huggingface = model_name
 
     @override
     def decode_ast(self, result, language, has_tool_call_tag):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/salesforce_llama.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/salesforce_llama.py
@@ -5,8 +5,16 @@ from overrides import override
 
 
 class SalesforceLlamaHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/salesforce_qwen.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/salesforce_qwen.py
@@ -5,8 +5,16 @@ from overrides import override
 
 
 class SalesforceQwenHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     @override
     def _format_prompt(self, messages, function):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/think_agent.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/think_agent.py
@@ -5,8 +5,16 @@ from overrides import override
 
 
 class ThinkAgentHandler(OSSHandler):
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
 
     def _convert_functions_format(self, functions):
         if isinstance(functions, dict):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/java_parser.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/java_parser.py
@@ -1,18 +1,10 @@
 from tree_sitter import Language, Parser
 import tree_sitter_java
 
-# JAVA_LANGUAGE = Language(tree_sitter_java.language(), "java")
+JAVA_LANGUAGE = Language(tree_sitter_java.language(), "java")
 
-# parser = Parser()
-# parser.set_language(JAVA_LANGUAGE)
-
-try:
-    JAVA_LANGUAGE = Language(tree_sitter_java.language())
-    parser = Parser(JAVA_LANGUAGE)
-except TypeError:
-    JAVA_LANGUAGE = Language(tree_sitter_java.language(), "java")
-    parser = Parser()
-    parser.set_language(JAVA_LANGUAGE)
+parser = Parser()
+parser.set_language(JAVA_LANGUAGE)
 
 
 def parse_java_function_call(source_code):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/java_parser.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/java_parser.py
@@ -1,10 +1,18 @@
 from tree_sitter import Language, Parser
 import tree_sitter_java
 
-JAVA_LANGUAGE = Language(tree_sitter_java.language(), "java")
+# JAVA_LANGUAGE = Language(tree_sitter_java.language(), "java")
 
-parser = Parser()
-parser.set_language(JAVA_LANGUAGE)
+# parser = Parser()
+# parser.set_language(JAVA_LANGUAGE)
+
+try:
+    JAVA_LANGUAGE = Language(tree_sitter_java.language())
+    parser = Parser(JAVA_LANGUAGE)
+except TypeError:
+    JAVA_LANGUAGE = Language(tree_sitter_java.language(), "java")
+    parser = Parser()
+    parser.set_language(JAVA_LANGUAGE)
 
 
 def parse_java_function_call(source_code):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/js_parser.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/js_parser.py
@@ -1,10 +1,22 @@
 from tree_sitter import Language, Parser
 import tree_sitter_javascript
 
-JS_LANGUAGE = Language(tree_sitter_javascript.language(), "javascript")
+# JS_LANGUAGE = Language(tree_sitter_javascript.language(), "javascript")
 
-parser = Parser()
-parser.set_language(JS_LANGUAGE)
+# parser = Parser()
+# parser.set_language(JS_LANGUAGE)
+
+from tree_sitter import Language, Parser
+import tree_sitter_javascript
+
+# Get a Language from the capsule (new API) or fall back to old API.
+try:
+    JS_LANGUAGE = Language(tree_sitter_javascript.language())
+    parser = Parser(JS_LANGUAGE)
+except TypeError:
+    JS_LANGUAGE = Language(tree_sitter_javascript.language(), "javascript")
+    parser = Parser()
+    parser.set_language(JS_LANGUAGE)
 
 
 def parse_javascript_function_call(source_code):

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/js_parser.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/parser/js_parser.py
@@ -1,22 +1,10 @@
 from tree_sitter import Language, Parser
 import tree_sitter_javascript
 
-# JS_LANGUAGE = Language(tree_sitter_javascript.language(), "javascript")
+JS_LANGUAGE = Language(tree_sitter_javascript.language(), "javascript")
 
-# parser = Parser()
-# parser.set_language(JS_LANGUAGE)
-
-from tree_sitter import Language, Parser
-import tree_sitter_javascript
-
-# Get a Language from the capsule (new API) or fall back to old API.
-try:
-    JS_LANGUAGE = Language(tree_sitter_javascript.language())
-    parser = Parser(JS_LANGUAGE)
-except TypeError:
-    JS_LANGUAGE = Language(tree_sitter_javascript.language(), "javascript")
-    parser = Parser()
-    parser.set_language(JS_LANGUAGE)
+parser = Parser()
+parser.set_language(JS_LANGUAGE)
 
 
 def parse_javascript_function_call(source_code):


### PR DESCRIPTION
Standardize and make use of the `model_name` attribute in `model_config.py` to indicate the name of the model as used in the vendor API or on Hugging Face (may not be unique). This avoids any further processing within each handler (eg, `self.model_name.replace("-FC", "")`).