### PR TITLE
[BFCL] Add partial_eval parameter to evaluate function in __main__.py

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/__main__.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/__main__.py
@@ -262,7 +262,7 @@ def evaluate(
     """
 
     load_dotenv(dotenv_path=DOTENV_PATH, verbose=True, override=True)  # Load the .env file
-    evaluation_main(model, test_category, result_dir, score_dir)
+    evaluation_main(model, test_category, result_dir, score_dir, partial_eval)
 
 
 @cli.command()


### PR DESCRIPTION
In __main__.py, when using CLI: "bfcl evaluate --model xx --test-category xx --partial-eval", the function evaluation_main does not add the partial_eval parameter, which will cause " --partial-eval" not take effect.