### PR TITLE
add waiting for server to be ready message

### DIFF
--- a/goex/server.py
+++ b/goex/server.py
@@ -17,8 +17,15 @@ import exec_engine.credentials.credentials_utils as credentials_utils
 from exec_engine.utils import SQL_Type, RESTful_Type, Filesystem_Type
 import json
 import base64
+from contextlib import asynccontextmanager
 
-app = FastAPI()
+@asynccontextmanager
+async def lifespan(app):
+    print("Waiting for server to be ready...")
+    yield
+    print("Server is ready.")   
+    
+app = FastAPI(lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],


### PR DESCRIPTION
Added a `lifespan` function in `goex/server.py` to print waiting for server to be ready message
Now while waiting for the server, the terminal should output message like: 
“
Waiting for server to be ready...
...
Server is ready.
”
Helps confirm that the server is starting correctly