### PR TITLE
[BFCL] Support custom Base URL, API Key, and Tokenizer for remote OpenAI-compatible endpoints #1280

### DIFF
--- a/berkeley-function-call-leaderboard/README.md
+++ b/berkeley-function-call-leaderboard/README.md
@@ -250,6 +250,7 @@ For remote deployments (e.g., via RunPod, ngrok, or enterprise gateways) that re
 ```bash
 REMOTE_OPENAI_BASE_URL=https://your-vllm-server.com/v1
 REMOTE_OPENAI_API_KEY=your-api-key-here
+REMOTE_OPENAI_TOKENIZER_PATH=/path/to/local/tokenizer  # Optional: specify local tokenizer for local/remote endpoints
 ```
 
 #### (Alternate) Script Execution for Generation

--- a/berkeley-function-call-leaderboard/bfcl_eval/.env.example
+++ b/berkeley-function-call-leaderboard/bfcl_eval/.env.example
@@ -48,6 +48,7 @@ LOCAL_SERVER_PORT=1053
 # These allow custom base URL and API key for OpenAI-compatible endpoints
 # REMOTE_OPENAI_BASE_URL=https://your-vllm-server.com/v1
 # REMOTE_OPENAI_API_KEY=your-api-key-here
+# REMOTE_OPENAI_TOKENIZER_PATH=/path/to/local/tokenizer  # Optional: specify local tokenizer for local/remote endpoints
 
 # [OPTIONAL] For WandB to log the generated .csv in the format 'entity:project
 WANDB_BFCL_PROJECT=ENTITY:PROJECT


### PR DESCRIPTION
**Description** 
This PR addresses limitations when evaluating models served via remote OpenAI-compatible endpoints (e.g., vLLM deployed on cloud GPU clusters, RunPod, or behind enterprise gateways).
Previously, the handler assumed a rigid host:port structure and lacked authentication support. Additionally, when connecting to a remote endpoint, the handler would fail to load the tokenizer if it tried to access a path that only exists on the remote server.

**Key Changes**
Custom Authentication & Routing:
Added support for REMOTE_OPENAI_BASE_URL to allow full control over the endpoint URL (resolves issues with SSL/HTTPS and custom sub-paths).
Added support for REMOTE_OPENAI_API_KEY to enable authentication for secured endpoints.
Remote Tokenizer Support:
Added REMOTE_OPENAI_TOKENIZER_PATH. Since the OSSHandler needs to load the tokenizer locally for prompt formatting, this variable allows users to point to a local Hugging Face path or model ID, preventing OSError when the handler tries to load a non-existent local path derived from the remote server configuration.

Documentation:
Updated .env.example and README.md to document these new configuration options.

**Related Issue** Fixes #1280

**Type of Change**
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation accordingly
- [x] Existing local server setups remain backward compatible