### PR TITLE
fix: correct typo 'occured' to 'occurred'

### DIFF
--- a/goex/cli.py
+++ b/goex/cli.py
@@ -193,7 +193,7 @@ def remove_creds_callback(services):
         remove_creds(services)
     except Exception as e:
         print(e)
-        print("An unexpected error occured while removing credentials")
+        print("An unexpected error occurred while removing credentials")
 
 def db_callback(prompt, generate_mode):
     config = {

--- a/goex/exec_engine/docker_sandbox.py
+++ b/goex/exec_engine/docker_sandbox.py
@@ -94,7 +94,7 @@ class DockerSandbox:
                 container.remove()
 
         except Exception as e:
-            print("Failure occured inside client.containers.run with the following error message:", e)
+            print("Failure occurred inside client.containers.run with the following error message:", e)
             return None
         
         return {"output": docker_out, "debug": docker_debug}

--- a/goex/main.py
+++ b/goex/main.py
@@ -274,5 +274,5 @@ class ExecutionEngine:
             else:
                 return response
         except Exception as e:
-            print("An error occured while trying to execute output locally {e}.\nAborted...".format(e=e))
+            print("An error occurred while trying to execute output locally {e}.\nAborted...".format(e=e))
             return


### PR DESCRIPTION
Fixed typos in goex module (docker_sandbox.py, cli.py, main.py).