### PR TITLE
Add model Nanbeige4.1-3B

### DIFF
--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -108,6 +108,7 @@ For model names containing `{...}`, multiple versions are available. For example
 | Moonshotai-Kimi-K2-Instruct            | Prompt           | MoonshotAI     | kimi-k2-0905-preview                                        |
 | Nanbeige3.5-Pro-Thinking               | Function Calling | Nanbeige       | Nanbeige3.5-Pro-Thinking-FC                                 |
 | Nanbeige4-3B-Thinking-2511             | Function Calling | Self-hosted 💻 | Nanbeige/Nanbeige4-3B-Thinking-2511                         |
+| Nanbeige4.1-3B                         | Function Calling | Self-hosted 💻 | Nanbeige/Nanbeige4.1-3B                                     |
 | Nemotron-4-340b-instruct               | Prompt           | NVIDIA         | nvidia/nemotron-4-340b-instruct                             |
 | o3-2025-04-16                          | Function Calling | OpenAI         | o3-2025-04-16-FC                                            |
 | o3-2025-04-16                          | Prompt           | OpenAI         | o3-2025-04-16                                               |

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -2089,6 +2089,18 @@ local_inference_model_map = {
         is_fc_model=True,
         underscore_to_dot=False,
     ),
+    "Nanbeige/Nanbeige4.1-3B": ModelConfig(
+        model_name="Nanbeige/Nanbeige4.1-3B",
+        display_name="Nanbeige4.1-3B",
+        url="https://huggingface.co/Nanbeige/Nanbeige4.1-3B",
+        org="Nanbeige",
+        license="apache-2.0",
+        model_handler=NanbeigeFCHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=True,
+        underscore_to_dot=False,
+    ),
 }
 
 # Inference through third-party inference platforms for open-source models


### PR DESCRIPTION
Hi, thanks for the great work on BFCL!

This PR adds new Nanbeige models:

Nanbeige4.1-3B: The weights are available on Hugging Face: (https://huggingface.co/Nanbeige/Nanbeige4.1-3B).

If there's a preferred format for adding new model results or any additional checks you'd like me to run, I'm happy to update the PR accordingly.

Thank you very much!