### PR TITLE
fix(bfcl): use message.content when tool_calls is empty (OpenAI-APIs)

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
@@ -107,15 +107,14 @@ class OpenAICompletionsHandler(BaseHandler):
         return inference_data
 
     def _parse_query_response_FC(self, api_response: Any) -> dict:
-        try:
+        tool_calls = api_response.choices[0].message.tool_calls
+        if tool_calls:
             model_responses = [
                 {func_call.function.name: func_call.function.arguments}
-                for func_call in api_response.choices[0].message.tool_calls
+                for func_call in tool_calls
             ]
-            tool_call_ids = [
-                func_call.id for func_call in api_response.choices[0].message.tool_calls
-            ]
-        except:
+            tool_call_ids = [func_call.id for func_call in tool_calls]
+        else:
             model_responses = api_response.choices[0].message.content
             tool_call_ids = []
 


### PR DESCRIPTION
## Summary
`_parse_query_response_FC` in `OpenAICompletionsHandler` used a `try`/`except` around iterating `message.tool_calls`. When `tool_calls` is `None`, iteration fails and the code correctly falls back to `message.content`. When some OpenAI-compatible servers (e.g. vLLM) return **`tool_calls: []`** for text-only assistant turns, the list comprehension succeeds and yields **`model_responses == []`**, so **`content` is never read**. That breaks multi-step FC flows (e.g. agentic / memory traces collapsing to empty steps).
## Change
- Read `tool_calls` once.
- If truthy, parse tool calls and IDs as before.
- Otherwise set `model_responses` from `message.content` and `tool_call_ids` to `[]`.
## Motivation / context
- OpenAI-style APIs often use `tool_calls: null` when there are no tool calls; some gateways use an **empty list** instead.
- Behavior is unchanged when there is at least one tool call.
## How to test
From `berkeley-function-call-leaderboard` after `pip install -e .`, with a configured FC model:
```bash
bfcl generate --model <MODEL_NAME> --test-category simple_python --num-threads 1