### PR TITLE
Add AIREV-Agent-0.8B: Sub-billion parameter model for function calling

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -68,6 +68,7 @@ from bfcl_eval.model_handler.local_inference.salesforce_qwen import (
     SalesforceQwenHandler,
 )
 from bfcl_eval.model_handler.local_inference.think_agent import ThinkAgentHandler
+from bfcl_eval.model_handler.local_inference.airev_agent import AIREVAgentHandler
 
 # -----------------------------------------------------------------------------
 # A mapping of model identifiers to their respective model configurations.
@@ -1213,6 +1214,18 @@ api_inference_model_map = {
 
 # Inference through local hosting
 local_inference_model_map = {
+    "airev-ai/AIREV-Agent-0.8B": ModelConfig(
+        model_name="airev-ai/AIREV-Agent-0.8B",
+        display_name="AIREV-Agent-0.8B (Prompt)",
+        url="https://huggingface.co/airev-ai/AIREV-Agent-0.8B",
+        org="AIREV",
+        license="apache-2.0",
+        model_handler=AIREVAgentHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=False,
+        underscore_to_dot=False,
+    ),
     "deepseek-ai/DeepSeek-R1": ModelConfig(
         model_name="deepseek-ai/DeepSeek-R1",
         display_name="DeepSeek-R1 (Prompt) (Local)",

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/airev_agent.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/airev_agent.py
@@ -1,0 +1,69 @@
+"""
+AIREV-Agent-0.8B Handler for BFCL Official Evaluation.
+
+KEY LEARNINGS:
+- DO NOT override BFCL's system prompt. _pre_query_processing_prompting already
+  calls system_prompt_pre_processing_chat_model which adds the correct prompt.
+- DO activate <think> mode by appending <think>\n to the prompt.
+- DO use default_decode_ast_prompting (BFCL's own decoder).
+- The model outputs func_name(param=value) which BFCL's decoder handles.
+"""
+import json
+import re
+from typing import Any
+from bfcl_eval.model_handler.local_inference.base_oss_handler import OSSHandler
+from bfcl_eval.model_handler.utils import (
+    default_decode_ast_prompting,
+    default_decode_execute_prompting,
+)
+from overrides import override
+
+
+class AIREVAgentHandler(OSSHandler):
+    def __init__(self, model_name, temperature, registry_name, is_fc_model, dtype="bfloat16", **kwargs):
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
+
+    @override
+    def _format_prompt(self, messages, function):
+        """
+        Build prompt from the ALREADY-PREPROCESSED messages.
+        DO NOT add our own system prompt — BFCL already added theirs
+        via system_prompt_pre_processing_chat_model in _pre_query_processing_prompting.
+        Just format as chat template and activate <think>.
+        """
+        prompt = ""
+        for m in messages:
+            role = m.get("role", "user")
+            content = m.get("content", "")
+            prompt += "<|im_start|>" + role + "\n" + content + "<|im_end|>\n"
+        # Activate thinking mode
+        prompt += "<|im_start|>assistant\n<think>\n"
+        return prompt
+
+    @override
+    def _parse_query_response_prompting(self, api_response: Any) -> dict:
+        """Strip <think> tags from the response before passing to decoder."""
+        text = api_response.choices[0].text
+        # Strip thinking — evaluator only wants the function call
+        if "</think>" in text:
+            text = text.split("</think>")[-1].strip()
+        return {
+            "model_responses": text,
+            "input_token": api_response.usage.prompt_tokens,
+            "output_token": api_response.usage.completion_tokens,
+        }
+
+    @override
+    def decode_ast(self, result, language, has_tool_call_tag):
+        """Use BFCL's own default decoder."""
+        # Strip thinking if still present
+        if isinstance(result, str) and "</think>" in result:
+            result = result.split("</think>")[-1].strip()
+        return default_decode_ast_prompting(result, language, has_tool_call_tag)
+
+    @override
+    def decode_execute(self, result, has_tool_call_tag):
+        """Use BFCL's own default decoder."""
+        if isinstance(result, str) and "</think>" in result:
+            result = result.split("</think>")[-1].strip()
+        return default_decode_execute_prompting(result, has_tool_call_tag)


### PR DESCRIPTION
## AIREV-Agent-0.8B

We submit **AIREV-Agent-0.8B**, a 752M parameter model fine-tuned for agentic tool calling via Group Relative Policy Optimization (GRPO) with a progressive curriculum.

### Model Details
- **Base model**: Qwen3.5-0.8B (Gated Delta Networks architecture)
- **Training**: GRPO with 5-phase progressive curriculum, 2500 steps on 1x H100
- **Mode**: Prompt (with `<think>` reasoning tokens activated)
- **License**: Apache 2.0
- **HuggingFace**: [airev-ai/AIREV-Agent-0.8B](https://huggingface.co/airev-ai/AIREV-Agent-0.8B)

### BFCL V4 Results (All 22 Categories)

| Category | Score |
|----------|-------|
| simple_python | **84.50%** |
| multiple | **86.50%** |
| live_relevance | **93.75%** |
| live_simple | 64.73% |
| irrelevance | **62.08%** |
| simple_javascript | 52.00% |
| live_multiple | 50.62% |
| live_irrelevance | 47.06% |
| simple_java | 45.00% |
| format_sensitivity | 13.44% |
| memory_rec_sum | 8.39% |
| memory_vector | 7.10% |
| memory_kv | 3.23% |
| web_search_base | 2.00% |
| web_search_no_snippet | 2.00% |
| multi_turn (all 4) | 0.00% |
| parallel (all 4) | 0.00%* |

*Parallel categories: model produces correct function calls but outputs them newline-separated instead of bracket-wrapped `[func1(), func2()]`.

### Key Achievements
- **86.50% on multiple** — competitive with frontier models on function selection
- **93.75% on live_relevance** — among the highest on the leaderboard across all model sizes
- **62.08% on irrelevance** — strong hallucination resistance for a sub-1B model
- Entire training completed in **one week on a single H100 GPU**

### Files Changed
- `bfcl_eval/model_handler/local_inference/airev_agent.py` — Handler class
- `bfcl_eval/constants/model_config.py` — Model registration

### Reproduction
```bash
bfcl generate --model airev-ai/AIREV-Agent-0.8B --test-category all --temperature 0.3 --skip-server-setup --local-model-path /path/to/model --num-threads 4
bfcl evaluate --model airev-ai/AIREV-Agent-0.8B --test-category all
```

**Paper**: [AIREV-Agent-0.8B: Agentic AI on the Edge](https://github.com/mk42-ai/AIREV-Agent-0.8B)

Organization: AIREV (On-Demand.io) | Contact: mk@airev.ae | @MeetsKhalid