### PR TITLE
Fix typos in GoEx execution engine

### DIFF
--- a/goex/exec_engine/docker_sandbox.py
+++ b/goex/exec_engine/docker_sandbox.py
@@ -94,7 +94,7 @@ class DockerSandbox:
                 container.remove()
 
         except Exception as e:
-            print("Failure occured inside client.containers.run with the following error message:", e)
+            print("Failure occurred inside client.containers.run with the following error message:", e)
             return None
         
         return {"output": docker_out, "debug": docker_debug}

--- a/goex/exec_engine/pipeline.py
+++ b/goex/exec_engine/pipeline.py
@@ -168,7 +168,7 @@ def generate_command(content, credentials = None, api_type=RESTful_Type, generat
         )
 
         if response.choices[0].message.tool_calls == None:
-            raise Exception("Unable able to retreive the relevant command to perform the action from Function Calling.\n" +
+            raise Exception("Unable to retrieve the relevant command to perform the action from Function Calling.\n" +
                             "Try again with a different prompt or generate_mode setting")
             
         output = [


### PR DESCRIPTION
## Summary
- Fix spelling error `retreive` -> `retrieve` in `goex/exec_engine/pipeline.py` (also removes redundant word "able" from "Unable able to retreive")
- Fix spelling error `occured` -> `occurred` in `goex/exec_engine/docker_sandbox.py`

These are minor typo fixes in error messages within the GoEx execution engine.

## Test plan
- No functional changes; only error message strings are corrected
- Verified the fixes are limited to string literals in error messages