### PR TITLE
Fix typos in BFCL and RAFT modules

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/__main__.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/__main__.py
@@ -42,7 +42,7 @@ cli = typer.Typer(
 
 def handle_multiple_input(input_str):
     """
-    Input is like 'a,b,c,d', we need to transform it to ['a', 'b', 'c', 'd'] because that's the expected format in the actual main funciton
+    Input is like 'a,b,c,d', we need to transform it to ['a', 'b', 'c', 'd'] because that's the expected format in the actual main function
     """
     if input_str is None:
         """

--- a/raft/format.py
+++ b/raft/format.py
@@ -78,10 +78,10 @@ class DatasetConverter():
 
     def convert(self, ds: Dataset, format: DatasetFormat, output_path: str, output_type: OutputDatasetType, params: Dict[str, str]):
         if not format in self.formats:
-            raise Exception(f"Output Format {format} is not supported, pleased select one of {self.formats.keys()}")
+            raise Exception(f"Output Format {format} is not supported, please select one of {self.formats.keys()}")
         
         if not output_type in self.exporters:
-            raise Exception(f"Output Type {output_type} is not supported, pleased select one of {self.exporters.keys()}")
+            raise Exception(f"Output Type {output_type} is not supported, please select one of {self.exporters.keys()}")
 
         formatter = self.formats[format]
         newds = formatter.format(ds, **params)


### PR DESCRIPTION
## Summary
- Fix `funciton` -> `function` in `berkeley-function-call-leaderboard/bfcl_eval/__main__.py` docstring
- Fix `pleased select` -> `please select` in `raft/format.py` error messages (2 occurrences)

## Test plan
- No functional changes; only comments and error message strings are corrected
- Verified the fixes are limited to string literals