### PR TITLE
Add missing brotli dependency to fix web_search task corruption

### DIFF
--- a/berkeley-function-call-leaderboard/pyproject.toml
+++ b/berkeley-function-call-leaderboard/pyproject.toml
@@ -16,6 +16,7 @@ requires-python = ">=3.10"
 license = { "text" = "Apache 2.0" }
 dependencies = [
     "requests",
+    "brotli",  # Brotli decompression support for the requests package
     "tqdm",
     "numpy==1.26.4",
     "pandas",


### PR DESCRIPTION
## Summary
- Adds the `brotli` package as a dependency in `pyproject.toml` to fix silent decompression failures in `fetch_url_content()` for Brotli-compressed HTTP responses
- Without this dependency, the `requests` library cannot decompress Brotli-encoded responses, causing `web_search_base` and `web_search_no_snippet` tasks to produce garbage binary output

## Details
The HTTP headers used by `fetch_url_content()` include `Accept-Encoding: gzip, deflate, br`, advertising Brotli support. However, the `requests` library requires the `brotli` package to actually decode Brotli responses. Without it, compressed data is passed through `html2text`/`BeautifulSoup` as raw bytes, producing corrupted Unicode escapes in the LLM input.

Fixes #1310

## Test plan
- [ ] Install `bfcl_eval` in a fresh Python environment and verify `brotli` is included
- [ ] Run a `web_search_base` evaluation and confirm `fetch_url_content()` returns readable text for Brotli-compressed sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)