### PR TITLE
Add  Model DM-Cito-9B (FC) & DM-Cito-27B (FC)

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -2227,6 +2227,30 @@ third_party_inference_model_map = {
         is_fc_model=True,
         underscore_to_dot=True,
     ),
+    "DM-Cito-9B-FC": ModelConfig(
+        model_name="DM-Cito-9B",
+        display_name="DM-Cito-9B (FC)",
+        url="https://www.mininglamp.com/",
+        org="Mininglamp",
+        license="Proprietary",
+        model_handler=DMCitoHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=True,
+        underscore_to_dot=True,
+    ),
+    "DM-Cito-27B-FC": ModelConfig(
+        model_name="DM-Cito-27B",
+        display_name="DM-Cito-27B (FC)",
+        url="https://www.mininglamp.com/",
+        org="Mininglamp",
+        license="Proprietary",
+        model_handler=DMCitoHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=True,
+        underscore_to_dot=True,
+    ),
 }
 
 

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
@@ -187,4 +187,6 @@ SUPPORTED_MODELS = [
     "qwen3-4b-think-FC",
     "qwen3-4b-nothink-FC",
     "DM-Cito-32B-v1",
+    "DM-Cito-9B-FC",
+    "DM-Cito-27B-FC",
 ]

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mining.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mining.py
@@ -7,6 +7,7 @@ from bfcl_eval.model_handler.api_inference.openai_completion import (
     OpenAICompletionsHandler,
 )
 from bfcl_eval.constants.enums import ModelStyle
+from bfcl_eval.model_handler.utils import convert_to_function_call
 from openai import OpenAI
 
 
@@ -27,24 +28,35 @@ class MiningHandler(OpenAICompletionsHandler):
         )
 
     def decode_ast(self, result, language, has_tool_call_tag):
-        decoded_output = []
-        for invoked_function in result:
-            name = invoked_function["name"]
-            params = invoked_function["arguments"]
-            decoded_output.append({name: params})
-        return decoded_output
+        if self.is_fc_model:
+            decoded_output = []
+            for invoked_function in result:
+                name = list(invoked_function.keys())[0]
+                params = json.loads(invoked_function[name])
+                decoded_output.append({name: params})
+            return decoded_output
+        else:
+            decoded_output = []
+            for invoked_function in result:
+                name = invoked_function["name"]
+                params = invoked_function["arguments"]
+                decoded_output.append({name: params})
+            return decoded_output
 
     def decode_execute(self, result, has_tool_call_tag):
-        too_call_format = []
-        for tool_call in result:
-            if isinstance(tool_call, dict):
-                name = tool_call.get("name", "")
-                arguments = tool_call.get("arguments", {})
-                args_str = ", ".join(
-                    [f"{key}={repr(value)}" for key, value in arguments.items()]
-                )
-                too_call_format.append(f"{name}({args_str})")
-        return too_call_format
+        if self.is_fc_model:
+            return convert_to_function_call(result)
+        else:
+            too_call_format = []
+            for tool_call in result:
+                if isinstance(tool_call, dict):
+                    name = tool_call.get("name", "")
+                    arguments = tool_call.get("arguments", {})
+                    args_str = ", ".join(
+                        [f"{key}={repr(value)}" for key, value in arguments.items()]
+                    )
+                    too_call_format.append(f"{name}({args_str})")
+            return too_call_format
 
     #### Prompting methods ####
 

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mining.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mining.py
@@ -57,6 +57,35 @@ class MiningHandler(OpenAICompletionsHandler):
                     )
                     too_call_format.append(f"{name}({args_str})")
             return too_call_format
+    
+    #### FC methods ####
+    
+    def _parse_query_response_FC(self, api_response: Any) -> dict:
+        try:
+            model_responses = [
+                {func_call.function.name: func_call.function.arguments}
+                for func_call in api_response.choices[0].message.tool_calls
+            ]
+            tool_call_ids = [
+                func_call.id for func_call in api_response.choices[0].message.tool_calls
+            ]
+            
+            if not model_responses:
+                model_responses = api_response.choices[0].message.content
+                tool_call_ids = []
+        except:
+            model_responses = api_response.choices[0].message.content
+            tool_call_ids = []
+
+        model_responses_message_for_chat_history = api_response.choices[0].message
+        return {
+            "model_responses": model_responses,
+            "model_responses_message_for_chat_history": model_responses_message_for_chat_history,
+            "tool_call_ids": tool_call_ids,
+            "input_token": api_response.usage.prompt_tokens,
+            "output_token": api_response.usage.completion_tokens,
+        }
+
 
     #### Prompting methods ####
 


### PR DESCRIPTION
This PR adds support for Mininglamp's **DM-Cito-9B (FC)** and **DM-Cito-27B (FC)** models.
API endpoints:
- DM-Cito-9B (FC): https://rapidapi.com/kechengkevin/api/dm-cito-9b1
- DM-Cito-27B (FC): https://rapidapi.com/kechengkevin/api/dm-cito-27b