### PR TITLE
fix: relax memory_kv key validation to allow digits after first letter

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/multi_turn_eval/func_source_code/memory_kv.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/multi_turn_eval/func_source_code/memory_kv.py
@@ -92,7 +92,7 @@ class MemoryAPI_kv(MemoryAPI):
         """
         Check if the key is in snake_case format and does not contain spaces.
         """
-        pattern = r"^[a-z]+(_[a-z0-9]+)*$"
+        pattern = r"^[a-z][a-z0-9]*(_[a-z0-9]+)*$"
         return bool(re.match(pattern, s))
 
     def core_memory_add(self, key: str, value: str) -> Dict[str, str]:


### PR DESCRIPTION
Fixes #1272

## Problem
The `_is_valid_key_format` method in `memory_kv.py` used a regex pattern `^[a-z]+(_[a-z0-9]+)*$` that required the first segment of a key to contain **only lowercase letters**. This incorrectly rejected valid snake_case keys that contain digits after the first character, such as:
- `q1_report` (quarterly reports)
- `user123_profile` (user profiles with IDs)
- `v2_config` (versioned configurations)
- `s3_bucket_name` (cloud resource names)

This caused false negative evaluation results during BFCL v4 multi-turn evaluation.

## Solution
Updated the regex pattern from:
```python
pattern = r"^[a-z]+(_[a-z0-9]+)*$"
```
to:
```python
pattern = r"^[a-z][a-z0-9]*(_[a-z0-9]+)*$"
```

This change:
- Still requires the first character to be a lowercase letter (no digit-first keys)
- Allows digits after the first character in any segment
- Still rejects keys starting with uppercase, digits, spaces, or underscores
- Aligns with Python PEP 8 naming guidelines and real-world API naming patterns

## Testing
Verified with manual tests:
- `q1_report`, `user123_profile`, `v2_config`, `s3_bucket_name` → now correctly accepted ✓
- `MyKey`, `my key`, `_key`, `1key`, `key_` → still correctly rejected ✓