### PR TITLE
[BFCL] Fix silent drop of text responses when tool_calls is empty list

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
@@ -107,15 +107,14 @@ class OpenAICompletionsHandler(BaseHandler):
         return inference_data
 
     def _parse_query_response_FC(self, api_response: Any) -> dict:
-        try:
+        tool_calls = api_response.choices[0].message.tool_calls
+        if tool_calls:
             model_responses = [
                 {func_call.function.name: func_call.function.arguments}
-                for func_call in api_response.choices[0].message.tool_calls
+                for func_call in tool_calls
             ]
-            tool_call_ids = [
-                func_call.id for func_call in api_response.choices[0].message.tool_calls
-            ]
-        except:
+            tool_call_ids = [func_call.id for func_call in tool_calls]
+        else:
             model_responses = api_response.choices[0].message.content
             tool_call_ids = []
 


### PR DESCRIPTION
When an OpenAI-compatible server (e.g. vLLM) returns `"tool_calls": []` instead of `"tool_calls": null` for a text-only response, `_parse_query_response_FC` iterated over the empty list successfully, producing `model_responses = []` and silently discarding the actual text in `message.content`. This broke all agentic and multi-turn tasks where the model needs to return a final text answer after using tools.

Replace the `try/except` (which relied on `TypeError` from iterating over `None`) with an explicit truthiness check. Both `None` and `[]` produce `false`, so the `else` branch now correctly falls back to `message.content` in either case. A populated tool_calls list is processed as before - no regressions for the normal path.

