### PR TITLE
fix: remove invalid enum value from ground truth in live_multiple_190-84-0

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/data/possible_answer/BFCL_v4_live_multiple.json
+++ b/berkeley-function-call-leaderboard/bfcl_eval/data/possible_answer/BFCL_v4_live_multiple.json
@@ -8,19 +8,19 @@
 {"id": "live_multiple_7-3-2", "ground_truth": [{"create_workspace": {"name": ["DevelopersHub"], "base_branch": ["master"]}}]}
 {"id": "live_multiple_8-4-0", "ground_truth": [{"cookbook.search_recipe": {"keyword": ["steak"], "cuisine": ["Indian"], "max_results": ["", 10]}}]}
 {"id": "live_multiple_9-4-1", "ground_truth": [{"HNA_WQA.search": {"keyword": ["Imjin war"], "result_format": ["", "text"], "language": ["", "EN"], "max_results": ["", 10]}}]}
-{"id": "live_multiple_10-4-2", "ground_truth": [{"ControlAppliance.execute": {"command": ["\ub2e4\uc6a9\ub3c4\uc2e4, \ud1b5\ub3cc\uc774, \uc911\uc9c0"]}}]}
+{"id": "live_multiple_10-4-2", "ground_truth": [{"ControlAppliance.execute": {"command": ["다용도실, 통돌이, 중지"]}}]}
 {"id": "live_multiple_11-4-3", "ground_truth": [{"HNA_WQA.search": {"keyword": ["Ji Sung Park", "Park Ji Sung", "Ji Sung Park footballer", "Park Ji-sung footballer"], "result_format": ["", "text"], "language": ["", "EN"], "max_results": ["", 10]}}]}
 {"id": "live_multiple_12-4-4", "ground_truth": [{"HNA_WQA.search": {"keyword": ["Ji Sung Park", "Park Ji Sung", "Ji Sung Park footballer", "Park Ji-sung footballer"], "result_format": ["", "text"], "language": ["", "EN"], "max_results": ["", 10]}}]}
 {"id": "live_multiple_13-4-5", "ground_truth": [{"OpenWeatherMap.get_current_weather": {"location": ["Santa Cruz, USA"], "units": ["imperial"], "api_key": ["", "YOUR_API_KEY_HERE"]}}]}
-{"id": "live_multiple_14-4-6", "ground_truth": [{"ControlAppliance.execute": {"command": ["\ub2e4\uc6a9\ub3c4\uc2e4, \ud1b5\ub3cc\uc774, \uc911\uc9c0"]}}]}
+{"id": "live_multiple_14-4-6", "ground_truth": [{"ControlAppliance.execute": {"command": ["다용도실, 통돌이, 중지"]}}]}
 {"id": "live_multiple_15-4-7", "ground_truth": [{"HNA_NEWS.search": {"keyword": ["Son's latest goal"], "category": ["Sports"], "date_range": ["", "null"], "sort_by": ["", "date"], "language": ["", "EN"]}}]}
-{"id": "live_multiple_16-4-8", "ground_truth": [{"HNA_NEWS.search": {"keyword": ["\ubc15\uc9c0\uc131"], "category": ["", "General"], "date_range": ["", "null"], "sort_by": ["", "date"], "language": ["", "EN"]}}]}
+{"id": "live_multiple_16-4-8", "ground_truth": [{"HNA_NEWS.search": {"keyword": ["박지성"], "category": ["", "General"], "date_range": ["", "null"], "sort_by": ["", "date"], "language": ["", "EN"]}}]}
 {"id": "live_multiple_17-4-9", "ground_truth": [{"cookbook.search_recipe": {"keyword": ["sikhae"], "cuisine": ["", "Italian"], "max_results": ["", 10]}}]}
 {"id": "live_multiple_18-4-10", "ground_truth": [{"HNA_NEWS.search": {"keyword": ["artificial intelligence", "ai"], "category": ["", "General"], "date_range": ["2023-10-01 to 2023-10-07"], "sort_by": ["", "date"], "language": ["", "EN"]}}]}
-{"id": "live_multiple_19-4-11", "ground_truth": [{"ControlAppliance.execute": {"command": ["\uac70\uc2e4, \uc5d0\uc5b4\ucee8, \uc2e4\ud589"]}}]}
-{"id": "live_multiple_20-4-12", "ground_truth": [{"ControlAppliance.execute": {"command": ["\ub2e4\uc6a9\ub3c4\uc2e4, \ud1b5\ub3cc\uc774, \uc911\uc9c0"]}}]}
-{"id": "live_multiple_21-4-13", "ground_truth": [{"cookbook.search_recipe": {"keyword": ["\uc2a4\ud14c\uc774\ud06c"], "cuisine": ["", "Italian"], "max_results": ["", 10]}}]}
-{"id": "live_multiple_22-4-14", "ground_truth": [{"HNA_WQA.search": {"keyword": ["\uc784\uc9c4\uc65c\ub780"], "result_format": ["", "text"], "language": ["", "EN"], "max_results": ["", 10]}}]}
+{"id": "live_multiple_19-4-11", "ground_truth": [{"ControlAppliance.execute": {"command": ["거실, 에어컨, 실행"]}}]}
+{"id": "live_multiple_20-4-12", "ground_truth": [{"ControlAppliance.execute": {"command": ["다용도실, 통돌이, 중지"]}}]}
+{"id": "live_multiple_21-4-13", "ground_truth": [{"cookbook.search_recipe": {"keyword": ["스테이크"], "cuisine": ["", "Italian"], "max_results": ["", 10]}}]}
+{"id": "live_multiple_22-4-14", "ground_truth": [{"HNA_WQA.search": {"keyword": ["임진왜란"], "result_format": ["", "text"], "language": ["", "EN"], "max_results": ["", 10]}}]}
 {"id": "live_multiple_23-5-0", "ground_truth": [{"search_products": {"color": ["red"], "size": ["8"], "category": ["shoes"], "price_min": ["", 0.0], "price_max": ["", null], "brand": ["", null]}}]}
 {"id": "live_multiple_24-5-1", "ground_truth": [{"search_products": {"color": ["", null], "size": ["XL", "Extra Large"], "category": ["clothing"], "price_min": ["", 0.0], "price_max": ["", null], "brand": ["", null]}}]}
 {"id": "live_multiple_25-6-0", "ground_truth": [{"recall_memory_search": {"query": ["when is shishir's birthday", "when's shishir's birthday", "shishir birthday", "shishir's birthday"], "page": ["", 0], "request_heartbeat": ["", false]}}]}
@@ -129,7 +129,7 @@
 {"id": "live_multiple_128-50-0", "ground_truth": [{"generate_human_image": {"prompt": ["a man wearing a red dress"], "image_quality": ["high", ""], "image_format": ["PNG", ""], "include_metadata": ["", false]}}]}
 {"id": "live_multiple_129-50-1", "ground_truth": [{"search_engine.query": {"prompt": ["current prime minister of India"], "include_after_year": [true], "source": ["", "Google"]}}]}
 {"id": "live_multiple_130-50-2", "ground_truth": [{"english_llm": {"q": ["I'd like to read a poem about kites. Could you generate one with a creative touch?"], "max_tokens": ["", 50], "temperature": [0.8], "return_probabilities": ["", false]}}]}
-{"id": "live_multiple_131-50-3", "ground_truth": [{"multilingual_llm": {"q": ["\u091a\u093e\u092f \u0915\u0948\u0938\u0947 \u092c\u0928\u093e\u090f\u0902?"], "language": ["Hindi"], "max_length": ["", 150], "temperature": ["", 0.5]}}]}
+{"id": "live_multiple_131-50-3", "ground_truth": [{"multilingual_llm": {"q": ["चाय कैसे बनाएं?"], "language": ["Hindi"], "max_length": ["", 150], "temperature": ["", 0.5]}}]}
 {"id": "live_multiple_132-50-4", "ground_truth": [{"search_engine.query": {"prompt": ["who is the current pm of india"], "include_after_year": [true], "source": ["", "Google"]}}]}
 {"id": "live_multiple_133-50-5", "ground_truth": [{"multilingual_llm": {"q": ["chai kaise bnaye"], "language": ["", "Hindi"], "max_length": ["", 150], "temperature": ["", 0.5]}}]}
 {"id": "live_multiple_134-51-0", "ground_truth": [{"stock_price.get": {"ticker": ["AAPL"], "exchange": ["NYSE"]}}]}
@@ -184,18 +184,18 @@
 {"id": "live_multiple_183-78-0", "ground_truth": [{"finish": {"input_text": ["The quick brown fox jumps over the lazy dog."], "tgt_lang": ["da"], "src_lang": ["en"], "max_length": ["", 500], "access_token": ["", "example_token"]}}]}
 {"id": "live_multiple_184-79-0", "ground_truth": [{"search_advice": {"query": ["career growth"], "language": ["", "EN"]}}]}
 {"id": "live_multiple_185-80-0", "ground_truth": [{"get_activity_by_participants": {"participant_count": [5], "activity_type": ["education"], "price": ["", 0.0], "accessibility": ["", 0.0]}}]}
-{"id": "live_multiple_186-81-0", "ground_truth": [{"weather_forecast.get": {"location": ["\u5317\u4eac", "Beijing"], "date": ["the day after tomorrow"], "unit": ["celsius"]}}]}
+{"id": "live_multiple_186-81-0", "ground_truth": [{"weather_forecast.get": {"location": ["北京", "Beijing"], "date": ["the day after tomorrow"], "unit": ["celsius"]}}]}
 {"id": "live_multiple_187-82-0", "ground_truth": [{"quarterly_earnings": {"company_name": ["Berkshire Hathaway"], "cik": ["0001067983"]}}]}
 {"id": "live_multiple_188-82-1", "ground_truth": [{"holdings.get_13F_HR": {"company_name": ["Berkshire Hathaway"], "cik": ["0001067983"]}}]}
 {"id": "live_multiple_189-83-0", "ground_truth": [{"sendHttpRequest": {"method": ["POST"], "url": ["https://httpbin.org/post"], "headers": [{"Content-Type": ["application/json"]}], "data": [{"name": ["John Doe"], "email": ["john.doe@example.com"]}]}}]}
-{"id": "live_multiple_190-84-0", "ground_truth": [{"game_rewards.get": {"game": ["Fortnite"], "platform": ["PlayStation"], "mission": ["", "All Missions"], "trophy": ["", "all levels"]}}]}
+{"id": "live_multiple_190-84-0", "ground_truth": [{"game_rewards.get": {"game": ["Fortnite"], "platform": ["PlayStation"], "mission": ["", "All Missions"], "trophy": [""]}}]}
 {"id": "live_multiple_191-85-0", "ground_truth": [{"sort_list": {"elements": [["Sam", "Alice", "Jack"]], "order": ["", "asc"]}}]}
 {"id": "live_multiple_192-86-0", "ground_truth": [{"analyze_image_with_question.pipeline": {"image_path": ["image.png"], "question": ["generate with technically complex attention to detail a description of what you see"]}}]}
 {"id": "live_multiple_193-87-0", "ground_truth": [{"CalcProduct": {"a": [394], "b": [213]}}]}
 {"id": "live_multiple_194-87-1", "ground_truth": [{"CalcProduct": {"a": [443], "b": [349]}}]}
 {"id": "live_multiple_195-87-2", "ground_truth": [{"getCurrentTime": {"timezone": ["America/Los_Angeles"], "include_date": [true]}}]}
-{"id": "live_multiple_196-88-0", "ground_truth": [{"get_tickets": {"customer": ["\u963f\u8fea\u8fbe\u65af"]}}]}
-{"id": "live_multiple_197-89-0", "ground_truth": [{"get_tickets": {"customer": ["\u963f\u8fea\u8fbe\u65af"], "priority": [4]}}]}
+{"id": "live_multiple_196-88-0", "ground_truth": [{"get_tickets": {"customer": ["阿迪达斯"]}}]}
+{"id": "live_multiple_197-89-0", "ground_truth": [{"get_tickets": {"customer": ["阿迪达斯"], "priority": [4]}}]}
 {"id": "live_multiple_198-90-0", "ground_truth": [{"adriel_contact": {}}]}
 {"id": "live_multiple_199-90-1", "ground_truth": [{"adriel_tech_stack": {}}]}
 {"id": "live_multiple_200-90-2", "ground_truth": [{"adriel_list_projects": {"user_id": ["3"], "include_completed": ["", false], "sort_order": ["", "asc"]}}]}
@@ -1049,5 +1049,5 @@
 {"id": "live_multiple_1048-275-0", "ground_truth": [{"Hotels_2_SearchHouse": {"where_to": ["Paris"], "number_of_adults": [2]}}]}
 {"id": "live_multiple_1049-276-0", "ground_truth": [{"Trains_1_FindTrains": {"_from": ["Anaheim, CA"], "to": ["Berkeley, CA"], "date_of_journey": ["04/10/2023"]}}]}
 {"id": "live_multiple_1050-277-0", "ground_truth": [{"Weather_1_GetWeather": {"city": ["Atlanta"], "date": ["2023-03-07"]}}]}
-{"id": "live_multiple_1051-278-0", "ground_truth": [{"set_alarm": {"alarm_time": ["2023-12-01 07:00:00"], "purpose": ["wake up",""]}}]}
+{"id": "live_multiple_1051-278-0", "ground_truth": [{"set_alarm": {"alarm_time": ["2023-12-01 07:00:00"], "purpose": ["wake up", ""]}}]}
 {"id": "live_multiple_1052-279-0", "ground_truth": [{"set_volume": {"volume": [50]}}]}


### PR DESCRIPTION
Fixes #1313

## Problem

The ground truth for `live_multiple_190-84-0` accepts `"all levels"` as a valid value for the `trophy` parameter of `game_rewards.get`, but `"all levels"` is **not** listed in the parameter's enum: `["bronze", "silver", "gold", "platinum"]`.

This means models that correctly omit `trophy` (or try to pass a valid enum value) could be unfairly penalized if the evaluator treats `"all levels"` as the only correct non-empty answer.

Root cause: `"all levels"` was the function definition's `default` value, but it falls outside the enum constraint — a schema inconsistency.

## Solution

The parameter description states: _"If omitted, rewards for all trophy levels will be returned."_ The correct model behavior when asked for rewards across all trophy levels is to **omit** the parameter, not to pass an out-of-enum string.

Removed `"all levels"` from the ground truth, keeping only `""` (parameter omitted) as the accepted value.

## Notes

- The function definition's `default: "all levels"` is also technically invalid per JSON Schema (default value must be a valid enum member). This PR only fixes the ground truth; a follow-up could also clean up the function definition's default value.
- The issue notes similar patterns exist elsewhere in the dataset (schemas with `default: null` that accept `null`). This PR fixes the specific entry called out in the issue title.

## Testing

Verified the updated ground truth entry by re-reading the modified JSONL file.