### PR TITLE
feat(apizoo): add Oracle HCM, SCM, and Procurement Cloud REST APIs

### DIFF
--- a/data/apizoo/REST_API_for_Oracle_CX_Sales_Cloud.json
+++ b/data/apizoo/REST_API_for_Oracle_CX_Sales_Cloud.json
@@ -1,0 +1,394 @@
+[
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Accounts: List Accounts",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/accounts",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports OrganizationName, PartyNumber, Type, Status, PrimaryEmailAddress, SalesAccountStatus. Example: q=Type='CUSTOMER' and SalesAccountStatus='Active'",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: contacts, opportunities, addresses, phones, salesTeam, customFields",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort field and direction. Example: orderBy=OrganizationName:asc"
+        },
+        "functionality": "Retrieves a list of customer accounts from Oracle CX Sales. Supports filtering by type, status, and name.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-accounts-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Accounts: Get an Account",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/accounts/{PartyId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PartyId": "[REQUIRED] integer: The unique identifier of the account.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: contacts, opportunities, addresses, phones, salesTeam, revenue",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves full details of a specific customer account including address, contacts, and sales team assignments.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-accounts-partyid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Accounts: Create an Account",
+        "api_call": "POST /crmRestApi/resources/11.13.18.05/accounts",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "OrganizationName": "[REQUIRED] string: Name of the account.",
+            "Type": "string: Account type. Valid values: CUSTOMER, PARTNER, COMPETITOR, PROSPECT. Default: CUSTOMER.",
+            "IndustryCode": "string: Industry classification code. Example: 'TECHNOLOGY', 'MANUFACTURING'.",
+            "AnnualRevenue": "number: Estimated annual revenue of the account.",
+            "EmployeesTotal": "integer: Total number of employees.",
+            "PrimaryEmailAddress": "string: Primary email address for the account.",
+            "PrimaryPhoneNumber": "string: Primary phone number.",
+            "WebsiteURL": "string: Company website URL.",
+            "CurrencyCode": "string: Account currency. Example: 'USD'.",
+            "OwnerId": "integer: PersonId of the sales representative who owns this account.",
+            "ParentAccountPartyId": "integer: PartyId of the parent account for hierarchical account structures."
+        },
+        "functionality": "Creates a new customer account in Oracle CX Sales.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-accounts-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Contacts: List Contacts",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/contacts",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports LastName, FirstName, EmailAddress, AccountPartyId, JobTitle, Status. Example: q=AccountPartyId=300000001234567",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: phones, emails, addresses, relationships",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort order. Example: orderBy=LastName:asc"
+        },
+        "functionality": "Retrieves a list of contacts. Filter by account to get all contacts associated with a specific customer.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-contacts-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Contacts: Create a Contact",
+        "api_call": "POST /crmRestApi/resources/11.13.18.05/contacts",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "LastName": "[REQUIRED] string: Last name of the contact.",
+            "FirstName": "string: First name of the contact.",
+            "JobTitle": "string: Contact's job title.",
+            "AccountPartyId": "integer: PartyId of the account this contact belongs to.",
+            "EmailAddress": "string: Primary email address.",
+            "PhoneNumber": "string: Primary phone number.",
+            "PhoneCountryCode": "string: Country code for the phone number. Example: '1' for US.",
+            "PreferredContactMethod": "string: Preferred method of contact. Valid values: EMAIL, PHONE, MAIL.",
+            "DoNotContact": "boolean: If true, marks the contact as do-not-contact. Default is false.",
+            "OwnerId": "integer: PersonId of the sales rep who owns this contact."
+        },
+        "functionality": "Creates a new contact and optionally associates it with an existing account.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-contacts-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Opportunities: List Opportunities",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/opportunities",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports Name, Status, SalesStage, AccountPartyId, OwnerId, CloseDate, Amount. Example: q=SalesStage='Proposal' and CloseDate <= '2024-12-31'",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: contacts, revenue, salesTeam, competitors, leads, activities",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort order. Example: orderBy=CloseDate:asc"
+        },
+        "functionality": "Retrieves a list of sales opportunities. Filter by stage, owner, or close date to build pipeline views.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-opportunities-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Opportunities: Get an Opportunity",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/opportunities/{OptyId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "OptyId": "[REQUIRED] integer: The unique identifier of the opportunity.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: contacts, revenue, salesTeam, competitors, activities, assessments",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves full details of a specific sales opportunity including revenue lines, sales team, and linked contacts.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-opportunities-optyid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Opportunities: Create an Opportunity",
+        "api_call": "POST /crmRestApi/resources/11.13.18.05/opportunities",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "Name": "[REQUIRED] string: Name of the opportunity.",
+            "AccountPartyId": "[REQUIRED] integer: PartyId of the account associated with this opportunity.",
+            "SalesStage": "[REQUIRED] string: Current stage. Valid values: Qualification, Proposal, Negotiation, Closing.",
+            "WinProb": "integer: Probability of winning expressed as a percentage (0-100).",
+            "CloseDate": "[REQUIRED] string: Expected close date. Format: YYYY-MM-DD.",
+            "CurrencyCode": "[REQUIRED] string: Currency code. Example: 'USD'.",
+            "Revenue": "number: Expected revenue value for this opportunity.",
+            "OwnerId": "integer: PersonId of the sales rep who owns this opportunity.",
+            "Description": "string: Description or notes about the opportunity.",
+            "LeadSource": "string: Source of the opportunity. Example: 'WEB', 'REFERRAL', 'TRADE_SHOW'."
+        },
+        "functionality": "Creates a new sales opportunity linked to a customer account.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-opportunities-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Opportunities: Update an Opportunity",
+        "api_call": "PATCH /crmRestApi/resources/11.13.18.05/opportunities/{OptyId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "OptyId": "[REQUIRED] integer: The unique identifier of the opportunity to update.",
+            "SalesStage": "string: Updated sales stage.",
+            "WinProb": "integer: Updated win probability percentage.",
+            "CloseDate": "string: Updated expected close date. Format: YYYY-MM-DD.",
+            "Revenue": "number: Updated revenue value.",
+            "Status": "string: Opportunity status. Valid values: Open, Won, Lost.",
+            "StatusComment": "string: Reason for status change, especially for Won or Lost."
+        },
+        "functionality": "Updates an existing opportunity. Used to advance the sales stage, update forecast, or mark as won or lost.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-opportunities-optyid-patch.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Leads: List Leads",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/leads",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports LastName, CompanyName, Status, Rating, OwnerId, CreationDate. Example: q=Status='New' and Rating='Hot'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: phones, emails, addresses, activities",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves a list of sales leads. Filter by status or rating to prioritize follow-up actions.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-leads-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Leads: Create a Lead",
+        "api_call": "POST /crmRestApi/resources/11.13.18.05/leads",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "LastName": "[REQUIRED] string: Last name of the lead.",
+            "FirstName": "string: First name of the lead.",
+            "CompanyName": "string: Company the lead is associated with.",
+            "JobTitle": "string: Lead's job title.",
+            "EmailAddress": "string: Email address of the lead.",
+            "PhoneNumber": "string: Phone number of the lead.",
+            "LeadSource": "string: Source of the lead. Example: 'INBOUND_CALL', 'WEB_FORM', 'TRADE_SHOW'.",
+            "Rating": "string: Lead quality rating. Valid values: Hot, Warm, Cold.",
+            "Status": "string: Lead status. Valid values: New, In Progress, Converted, Dead.",
+            "Description": "string: Notes or description about the lead.",
+            "OwnerId": "integer: PersonId of the sales rep assigned to this lead.",
+            "CurrencyCode": "string: Currency for lead revenue estimates. Example: 'USD'.",
+            "Budget": "number: Estimated budget of the prospect."
+        },
+        "functionality": "Creates a new sales lead. Leads can later be converted into accounts, contacts, and opportunities.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-leads-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Leads: Convert a Lead",
+        "api_call": "POST /crmRestApi/resources/11.13.18.05/leads/{LeadId}/action/convert",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "LeadId": "[REQUIRED] integer: The unique identifier of the lead to convert.",
+            "CreateAccount": "boolean: If true, creates a new account from the lead company details. Default is true.",
+            "CreateContact": "boolean: If true, creates a new contact from the lead person details. Default is true.",
+            "CreateOpportunity": "boolean: If true, creates a new opportunity linked to the converted account. Default is false.",
+            "ExistingAccountPartyId": "integer: If provided, links the converted contact and opportunity to this existing account instead of creating a new one."
+        },
+        "functionality": "Converts a qualified lead into account, contact, and optionally opportunity records.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-leads-leadid-action-convert-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Activities: List Activities",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/activities",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ActivityType, Status, OwnerId, AssignedToPartyId, PlannedStartDate. Example: q=ActivityType='CALL' and Status='Open'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: contacts, accounts, opportunities, resources",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves sales activities such as calls, tasks, and appointments linked to accounts and opportunities.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-activities-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Activities: Create an Activity",
+        "api_call": "POST /crmRestApi/resources/11.13.18.05/activities",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ActivityType": "[REQUIRED] string: Type of activity. Valid values: CALL, TASK, APPOINTMENT.",
+            "Subject": "[REQUIRED] string: Subject or title of the activity.",
+            "Status": "string: Status of the activity. Valid values: Not Started, In Progress, Completed, Cancelled. Default: Not Started.",
+            "PlannedStartDate": "string: Planned start date and time. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "PlannedEndDate": "string: Planned end date and time. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "Priority": "string: Priority of the activity. Valid values: High, Normal, Low.",
+            "Description": "string: Notes or description of the activity.",
+            "OwnerId": "integer: PersonId of the activity owner.",
+            "AccountPartyId": "integer: PartyId of the linked account.",
+            "OptyId": "integer: Identifier of the linked opportunity."
+        },
+        "functionality": "Creates a new sales activity — a call log, task, or appointment — and optionally links it to an account or opportunity.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-activities-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Sales Forecasts: Get Sales Forecast Summary",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/forecasts",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ForecastPeriodId, OwnerId, ForecastCategory, Status. Example: q=ForecastCategory='Pipeline'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: items, adjustments",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves sales forecast summaries by period and owner. Used to review pipeline, best case, and commit amounts.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-forecasts-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Sales Territories: List Sales Territories",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/territories",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports Name, Status, OwnerId, ParentTerritoryId. Example: q=Status='Active'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: members, dimensions, quotas",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves the sales territory hierarchy used to assign accounts, contacts, and opportunities to sales teams.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-territories-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Quotes: List Quotes",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/quotes",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports QuoteNumber, Status, AccountPartyId, OptyId, ExpirationDate. Example: q=Status='Draft' and OptyId=300000001234567",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, contacts, charges",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves sales quotes linked to opportunities. Quotes become orders when accepted.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-quotes-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Sales Orders from Quote: Submit Quote as Order",
+        "api_call": "POST /crmRestApi/resources/11.13.18.05/quotes/{QuoteId}/action/submitOrder",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "QuoteId": "[REQUIRED] integer: The unique identifier of the quote to submit as an order.",
+            "RequestedShipDate": "string: Requested shipping date. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "Comments": "string: Additional comments or instructions for the order."
+        },
+        "functionality": "Submits an accepted quote to Oracle Order Management as a sales order.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-quotes-quoteid-action-submitorder-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Sales Partners: List Partners",
+        "api_call": "GET /crmRestApi/resources/11.13.18.05/partners",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports OrganizationName, PartnerType, Status, Tier. Example: q=Status='Active' and Tier='Gold'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: contacts, deals, certifications",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves channel partners registered in Oracle Partner Relationship Management.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-partners-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle CX Sales Cloud - Deal Registrations: Create a Deal Registration",
+        "api_call": "POST /crmRestApi/resources/11.13.18.05/dealRegistrations",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PartnerPartyId": "[REQUIRED] integer: PartyId of the partner registering the deal.",
+            "CustomerName": "[REQUIRED] string: Name of the end customer.",
+            "CustomerEmailAddress": "string: Primary email of the customer contact.",
+            "ProductLine": "string: Oracle product line the deal is related to.",
+            "EstimatedRevenue": "number: Estimated deal revenue.",
+            "CurrencyCode": "string: Currency code. Example: 'USD'.",
+            "ExpectedCloseDate": "[REQUIRED] string: Estimated deal close date. Format: YYYY-MM-DD.",
+            "Description": "string: Description of the deal and opportunity.",
+            "CompetitorName": "string: Name of the primary competitor for this deal."
+        },
+        "functionality": "Creates a deal registration for a channel partner to claim a new opportunity and protect their margin.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/sales/24d/farcx/op-dealregistrations-post.html"
+        }
+    }
+]

--- a/data/apizoo/REST_API_for_Oracle_EPM_Cloud_Planning.json
+++ b/data/apizoo/REST_API_for_Oracle_EPM_Cloud_Planning.json
@@ -1,0 +1,310 @@
+[
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Applications: List Planning Applications",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "offset": "integer: Starting position in the result set. Default is 0.",
+            "limit": "integer: Maximum number of applications to return. Default is 25.",
+            "fields": "string: Comma-separated list of fields to return."
+        },
+        "functionality": "Retrieves a list of Planning applications available in the Oracle EPM Cloud environment.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Dimensions: List Dimensions",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/dimensions",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "planType": "string: Plan type to filter dimensions. Example: 'Plan1', 'Plan2', 'Workforce'.",
+            "fields": "string: Comma-separated list of fields to return."
+        },
+        "functionality": "Retrieves all dimensions defined in a Planning application, such as Account, Entity, Period, Scenario, and Version.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-dimensions-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Members: List Dimension Members",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/dimensions/{dimension}/members",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "dimension": "[REQUIRED] string: Name of the dimension. Example: 'Account', 'Entity', 'Period'.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum members to return. Default is 50.",
+            "fields": "string: Comma-separated fields to return. Example: 'memberName,alias,parentName,level'.",
+            "q": "string: Filter expression. Example: q=memberName:contains:Total to filter members containing 'Total'."
+        },
+        "functionality": "Retrieves members of a specific dimension in a Planning application. Useful for listing accounts, entities, or periods.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-dimensions-dimension-members-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Members: Get a Member",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/dimensions/{dimension}/members/{memberName}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "dimension": "[REQUIRED] string: Name of the dimension.",
+            "memberName": "[REQUIRED] string: Name of the member to retrieve.",
+            "fields": "string: Comma-separated fields to return."
+        },
+        "functionality": "Retrieves properties of a specific dimension member including alias, parent, level, UDA, and custom attributes.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-dimensions-dimension-members-membername-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Members: Add a Member",
+        "api_call": "POST /HyperionPlanning/rest/v3/applications/{application}/dimensions/{dimension}/members",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "dimension": "[REQUIRED] string: Name of the dimension.",
+            "memberName": "[REQUIRED] string: Name of the new member to add.",
+            "parentName": "[REQUIRED] string: Name of the parent member under which this member is added.",
+            "alias": "string: Alias label for the member.",
+            "dataStorage": "string: Data storage type. Valid values: Store, NeverShare, SharedMember, DynamicCalc, DynamicCalcAndStore, LabelOnly.",
+            "aggregation": "string: Aggregation operator. Valid values: +, -, *, /, %, ~, None.",
+            "twoPassCalc": "boolean: If true, enables two-pass calculation for the member.",
+            "smartList": "string: Name of the smart list to associate with the member.",
+            "dataType": "string: Data type. Valid values: Currency, NonCurrency, Percentage, SmartList, Date, Text."
+        },
+        "functionality": "Adds a new member to a dimension in a Planning application.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-dimensions-dimension-members-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Data: Export Data to File",
+        "api_call": "POST /HyperionPlanning/rest/v3/applications/{application}/exportdatafromplan",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "planType": "[REQUIRED] string: Plan type from which to export data. Example: 'Plan1'.",
+            "scenario": "[REQUIRED] string: Scenario member name. Example: 'Actual', 'Budget'.",
+            "version": "[REQUIRED] string: Version member name. Example: 'Working', 'Final'.",
+            "entity": "string: Entity member or range. Example: 'Total Entity' or 'E001'.",
+            "account": "string: Account member or range.",
+            "period": "string: Period range. Example: 'Jan-Jun'.",
+            "fileName": "[REQUIRED] string: Name of the output file to store exported data in the Planning inbox.",
+            "columnMembers": "string: Comma-separated list of dimension members to use as columns.",
+            "rowMembers": "string: Comma-separated list of dimension members to use as rows."
+        },
+        "functionality": "Exports Planning data for a specified slice (scenario, version, entity, period) to a file in the EPM Cloud inbox.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-exportdatafromplan-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Data: Import Data from File",
+        "api_call": "POST /HyperionPlanning/rest/v3/applications/{application}/importdatafromfile",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "fileName": "[REQUIRED] string: Name of the file in the Planning inbox to import.",
+            "planType": "[REQUIRED] string: Target plan type for the import.",
+            "clearData": "boolean: If true, clears existing data in the target slice before importing. Default is false.",
+            "abortOnError": "boolean: If true, aborts the import if any data errors are encountered. Default is true."
+        },
+        "functionality": "Imports data from a file in the EPM Cloud inbox into a Planning application. The file must follow the Planning data load format.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-importdatafromfile-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Business Rules: List Business Rules",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/rules",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "planType": "string: Filter rules by plan type.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum rules to return. Default is 50.",
+            "fields": "string: Comma-separated fields to return."
+        },
+        "functionality": "Retrieves all business rules (calculation scripts) defined in a Planning application.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-rules-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Business Rules: Launch a Business Rule",
+        "api_call": "POST /HyperionPlanning/rest/v3/applications/{application}/rules/{ruleName}/launch",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "ruleName": "[REQUIRED] string: Name of the business rule to launch.",
+            "planType": "[REQUIRED] string: Plan type context for the rule execution.",
+            "runtimePrompts": "array: Array of runtime prompt objects required by the rule. Each object contains promptName and promptValue. Example: [{\"promptName\": \"Scenario\", \"promptValue\": \"Budget\"}, {\"promptName\": \"Version\", \"promptValue\": \"Working\"}]"
+        },
+        "functionality": "Launches a Planning business rule (Essbase calculation script) with optional runtime prompt values.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-rules-rulename-launch-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Task Lists: List Task Lists",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/tasklists",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum task lists to return.",
+            "fields": "string: Comma-separated fields to return."
+        },
+        "functionality": "Retrieves task lists used to guide users through the Planning process, such as budget submission workflows.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-tasklists-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Approval Units: List Approval Units",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/approvalunits",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "scenario": "[REQUIRED] string: Scenario name. Example: 'Budget'.",
+            "version": "[REQUIRED] string: Version name. Example: 'Working'.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum approval units to return.",
+            "fields": "string: Comma-separated fields to return."
+        },
+        "functionality": "Retrieves approval units (entity-scenario-version combinations) and their current approval status in the Planning workflow.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-approvalunits-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Approval Units: Change Approval Status",
+        "api_call": "POST /HyperionPlanning/rest/v3/applications/{application}/approvalunits/action/changeStatus",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "scenario": "[REQUIRED] string: Scenario name.",
+            "version": "[REQUIRED] string: Version name.",
+            "entity": "[REQUIRED] string: Entity member name.",
+            "action": "[REQUIRED] string: Approval action to perform. Valid values: Promote, Approve, Reject, SignOff, Exclude.",
+            "comments": "string: Comments accompanying the approval action.",
+            "notifyUsers": "boolean: If true, sends notifications to affected users. Default is true."
+        },
+        "functionality": "Promotes, approves, or rejects a Planning approval unit in the budget approval workflow.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-approvalunits-action-changestatus-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Jobs: List EPM Jobs",
+        "api_call": "GET /HyperionPlanning/rest/v3/jobs",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "jobType": "string: Filter by job type. Valid values: Rules, Ruleset, Plan, ImportData, ExportData, ClearData, ImportMetadata, ExportMetadata, Refresh.",
+            "status": "string: Filter by job status. Valid values: Processing, Completed, Failed, Cancelled.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum jobs to return. Default is 25.",
+            "fields": "string: Comma-separated fields to return."
+        },
+        "functionality": "Retrieves the job history and status of EPM Cloud Planning jobs such as rule launches and data imports.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-jobs-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Scenarios: List Scenarios",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/dimensions/Scenario/members",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "fields": "string: Comma-separated fields to return. Example: 'memberName,alias,startYear,startPeriod,endYear,endPeriod'.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum scenarios to return."
+        },
+        "functionality": "Retrieves all scenario members (e.g., Actual, Budget, Forecast) defined in the Planning application along with their time range properties.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-dimensions-dimension-members-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Substitution Variables: List Substitution Variables",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/substitutionvariables",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "planType": "string: Filter variables by plan type.",
+            "fields": "string: Comma-separated fields to return."
+        },
+        "functionality": "Retrieves substitution variables and their current values. Variables like CurMonth and CurYear are used in forms and rules to represent dynamic time periods.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-substitutionvariables-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Substitution Variables: Update a Substitution Variable",
+        "api_call": "PUT /HyperionPlanning/rest/v3/applications/{application}/substitutionvariables/{variableName}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "variableName": "[REQUIRED] string: Name of the substitution variable to update. Example: 'CurMonth'.",
+            "planType": "string: Plan type scope for the variable. Omit for global scope.",
+            "value": "[REQUIRED] string: New value for the variable. Example: 'Jun'."
+        },
+        "functionality": "Updates the value of a substitution variable, typically used to advance the current planning period at month-end.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-substitutionvariables-variablename-put.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Data Forms: List Forms",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/forms",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "planType": "string: Filter forms by plan type.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum forms to return.",
+            "fields": "string: Comma-separated fields to return."
+        },
+        "functionality": "Retrieves data entry forms defined in a Planning application, used by budget holders to enter or review data.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-forms-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle EPM Cloud Planning - Users: List Application Users",
+        "api_call": "GET /HyperionPlanning/rest/v3/applications/{application}/users",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "application": "[REQUIRED] string: Name of the Planning application.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum users to return.",
+            "fields": "string: Comma-separated fields to return."
+        },
+        "functionality": "Retrieves users who have access to a specific Planning application along with their assigned roles.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pfusa/op-HyperionPlanning-rest-v3-applications-application-users-get.html"
+        }
+    }
+]

--- a/data/apizoo/REST_API_for_Oracle_ERP_Fixed_Assets.json
+++ b/data/apizoo/REST_API_for_Oracle_ERP_Fixed_Assets.json
@@ -1,0 +1,260 @@
+[
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Assets: List Fixed Assets",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/assets",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports AssetNumber, AssetDescription, BookTypeCode, AssetCategoryId, AssetType, LifecycleState, MajorCategory. Example: q=BookTypeCode='OPS CORP' and LifecycleState='ACTIVE'",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: books, assignments, depreciation, invoices",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort order. Example: orderBy=AssetNumber:asc"
+        },
+        "functionality": "Retrieves a list of fixed assets across all asset books. Filter by book, category, or lifecycle state.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-assets-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Assets: Get a Fixed Asset",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/assets/{AssetId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "AssetId": "[REQUIRED] integer: The unique identifier of the fixed asset.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: books, assignments, invoices, retirements, revaluations",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves full details of a specific fixed asset including financial book information, location assignments, and depreciation details.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-assets-assetid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Assets: Add a Fixed Asset",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/assets",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "AssetDescription": "[REQUIRED] string: Description of the asset.",
+            "AssetNumber": "string: Asset number. Auto-generated if not provided.",
+            "AssetType": "[REQUIRED] string: Type of asset. Valid values: CAPITALIZED, EXPENSED, CIP (Construction in Progress).",
+            "AssetCategoryId": "[REQUIRED] integer: Asset category identifier.",
+            "DatePlacedInService": "[REQUIRED] string: Date the asset was placed into service. Format: YYYY-MM-DD.",
+            "BookTypeCode": "[REQUIRED] string: Name of the asset book. Example: 'OPS CORP'.",
+            "Cost": "[REQUIRED] number: Original cost of the asset.",
+            "CurrencyCode": "[REQUIRED] string: Currency of the asset cost. Example: 'USD'.",
+            "DepreciationMethod": "string: Depreciation method code. Example: 'STL' for Straight Line.",
+            "Life": "integer: Asset useful life in months.",
+            "SalvageValue": "number: Residual/salvage value at the end of useful life.",
+            "SerialNumber": "string: Manufacturer serial number of the asset.",
+            "TagNumber": "string: Internal tracking tag number.",
+            "Manufacturer": "string: Name of the manufacturer.",
+            "ModelNumber": "string: Model number of the asset.",
+            "AssignedTo": "integer: PersonId of the employee the asset is assigned to.",
+            "LocationId": "integer: Location identifier where the asset is physically located."
+        },
+        "functionality": "Creates a new fixed asset record and adds it to the specified asset book.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-assets-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Asset Books: Get Asset Book Details",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/assets/{AssetId}/child/books",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "AssetId": "[REQUIRED] integer: The unique identifier of the fixed asset.",
+            "q": "string: Filter condition. Supports BookTypeCode, LifecycleState. Example: q=BookTypeCode='OPS CORP'",
+            "fields": "string: Comma-separated fields to return.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves financial book details for a fixed asset, including cost, accumulated depreciation, net book value, and depreciation method.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-assets-assetid-child-books-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Asset Retirements: Retire an Asset",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/assetRetirements",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "AssetId": "[REQUIRED] integer: Identifier of the asset to retire.",
+            "BookTypeCode": "[REQUIRED] string: Asset book from which the asset is being retired.",
+            "RetirementDate": "[REQUIRED] string: Date of the retirement. Format: YYYY-MM-DD.",
+            "RetirementConventionCode": "string: Retirement convention. Example: 'HY' for half-year.",
+            "RetirementTypeCode": "string: Reason for retirement. Example: 'SALE', 'SCRAP', 'THEFT'.",
+            "UnitsRetired": "number: Number of units being retired. Defaults to all units.",
+            "CostRetired": "number: Cost amount being retired. Defaults to full asset cost.",
+            "ProceedsOfSale": "number: Proceeds received from sale of the asset.",
+            "RemovalCost": "number: Cost incurred to remove or dispose of the asset.",
+            "GainLossAccount": "string: Account segment string to post the gain or loss on disposal."
+        },
+        "functionality": "Records the retirement (disposal) of a fixed asset from an asset book, calculating gain or loss on disposal.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-assetretirements-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Asset Transfers: Transfer an Asset",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/assetTransfers",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "AssetId": "[REQUIRED] integer: Identifier of the asset to transfer.",
+            "BookTypeCode": "[REQUIRED] string: Asset book for the transfer.",
+            "TransferDate": "[REQUIRED] string: Effective date of the transfer. Format: YYYY-MM-DD.",
+            "FromDepartmentId": "integer: Source cost center or department identifier.",
+            "ToDepartmentId": "[REQUIRED] integer: Destination cost center or department identifier.",
+            "FromLocationId": "integer: Source location identifier.",
+            "ToLocationId": "[REQUIRED] integer: Destination location identifier.",
+            "FromAssignedTo": "integer: PersonId of the current asset custodian.",
+            "ToAssignedTo": "integer: PersonId of the new asset custodian.",
+            "UnitsTransferred": "number: Number of units to transfer. Defaults to all units."
+        },
+        "functionality": "Transfers a fixed asset between departments, locations, or employees, updating the asset assignment and depreciation charge accounts.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-assettransfers-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Asset Adjustments: Adjust Asset Cost",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/assetAdjustments",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "AssetId": "[REQUIRED] integer: Identifier of the asset to adjust.",
+            "BookTypeCode": "[REQUIRED] string: Asset book for the adjustment.",
+            "TransactionDate": "[REQUIRED] string: Effective date of the adjustment. Format: YYYY-MM-DD.",
+            "AdjustmentType": "[REQUIRED] string: Type of adjustment. Valid values: COST, LIFE, SALVAGE_VALUE, DEPRECIATION_METHOD.",
+            "NewCost": "number: Updated cost of the asset. Required when AdjustmentType is COST.",
+            "NewLife": "integer: Updated useful life in months. Required when AdjustmentType is LIFE.",
+            "NewSalvageValue": "number: Updated salvage value. Required when AdjustmentType is SALVAGE_VALUE.",
+            "NewDepreciationMethod": "string: Updated depreciation method code. Required when AdjustmentType is DEPRECIATION_METHOD.",
+            "Reason": "string: Description or reason for the cost adjustment."
+        },
+        "functionality": "Records an adjustment to a fixed asset's cost, life, salvage value, or depreciation method.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-assetadjustments-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Depreciation: Run Depreciation",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/depreciation",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "BookTypeCode": "[REQUIRED] string: Asset book for which to run depreciation.",
+            "Period": "[REQUIRED] string: Accounting period name. Example: 'MAY-24'.",
+            "RunMode": "string: Depreciation run mode. Valid values: PREVIEW, FINAL. Use PREVIEW to validate before committing. Default: PREVIEW.",
+            "RerunFlag": "string: Whether to rerun depreciation if already run for the period. Valid values: Y, N. Default: N."
+        },
+        "functionality": "Runs the depreciation process for all assets in a specified book and accounting period.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-depreciation-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Asset Categories: List Asset Categories",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/assetCategories",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports MajorCategory, MinorCategory, BookTypeCode, AssetType, Status. Example: q=AssetType='CAPITALIZED' and Status='Active'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: books, defaultRules",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves asset categories that define default depreciation rules, accounts, and useful lives for grouped assets.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-assetcategories-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Mass Additions: List Mass Additions",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/massAdditions",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports BookTypeCode, QueueName, AssetCategoryId, BatchName, InvoiceId. Example: q=BookTypeCode='OPS CORP' and QueueName='NEW'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves mass addition records — payables invoice lines that have been transferred to Fixed Assets for capitalization.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-massadditions-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Mass Additions: Post a Mass Addition",
+        "api_call": "PATCH /fscmRestApi/resources/11.13.18.05/massAdditions/{MassAdditionId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "MassAdditionId": "[REQUIRED] integer: The unique identifier of the mass addition record.",
+            "QueueName": "[REQUIRED] string: Set to 'POST' to approve the mass addition for capitalization as a fixed asset.",
+            "AssetCategoryId": "integer: Asset category to assign if not already set.",
+            "AssetDescription": "string: Override description for the resulting asset.",
+            "DatePlacedInService": "string: Override date placed in service. Format: YYYY-MM-DD.",
+            "DepreciationMethod": "string: Override depreciation method code.",
+            "Life": "integer: Override useful life in months.",
+            "LocationId": "integer: Location of the resulting asset.",
+            "AssignedTo": "integer: PersonId of the employee assigned to the asset."
+        },
+        "functionality": "Updates and approves a mass addition record to capitalize it as a fixed asset.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-massadditions-massadditionid-patch.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Revaluations: Revalue an Asset",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/assetRevaluations",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "BookTypeCode": "[REQUIRED] string: Asset book for the revaluation.",
+            "CategoryId": "integer: Limit revaluation to a specific asset category.",
+            "AssetId": "integer: Limit revaluation to a specific asset.",
+            "RevaluationDate": "[REQUIRED] string: Date of the revaluation. Format: YYYY-MM-DD.",
+            "RevaluationRule": "[REQUIRED] string: Revaluation method. Valid values: PERCENT_ADJUST (adjust by percentage) or REPLACEMENT_VALUE (set to a new replacement value).",
+            "RevaluationPercent": "number: Percentage adjustment. Required when RevaluationRule is PERCENT_ADJUST.",
+            "ReplacementValue": "number: New gross replacement value. Required when RevaluationRule is REPLACEMENT_VALUE.",
+            "RevalReserveAccount": "string: Account segment string for the revaluation reserve."
+        },
+        "functionality": "Revalues one or more fixed assets to reflect fair market value, posting the adjustment to the revaluation reserve.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-assetrevaluations-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP Fixed Assets - Physical Inventory: List Physical Inventory Lines",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/physicalInventory",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports BookTypeCode, LocationId, AssetCategoryId, ReconciliationStatus. Example: q=BookTypeCode='OPS CORP' and ReconciliationStatus='UNRECONCILED'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves physical inventory lines used to reconcile actual asset locations and quantities against the asset register.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-physicalinventory-get.html"
+        }
+    }
+]

--- a/data/apizoo/REST_API_for_Oracle_ERP_General_Ledger.json
+++ b/data/apizoo/REST_API_for_Oracle_ERP_General_Ledger.json
@@ -1,0 +1,269 @@
+[
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Journal Entries: List Journal Entries",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/journalEntries",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports JournalName, Status, LedgerId, PeriodName, Source, Category, CreatedBy, BatchName. Example: q=PeriodName='Apr-24' and Status='Posted'",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, attachments, approvals",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort order. Example: orderBy=CreationDate:desc"
+        },
+        "functionality": "Retrieves journal entries across accounting periods. Filter by ledger, period, source, or posting status.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-journalentries-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Journal Entries: Get a Journal Entry",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/journalEntries/{JournalHeaderId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "JournalHeaderId": "[REQUIRED] integer: The unique identifier of the journal entry header.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, attachments, approvals",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves full details of a journal entry including all debit and credit lines with account segment values.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-journalentries-journalheaderid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Journal Entries: Create a Journal Entry",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/journalEntries",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "LedgerId": "[REQUIRED] integer: Ledger identifier.",
+            "JournalName": "[REQUIRED] string: Name of the journal entry.",
+            "PeriodName": "[REQUIRED] string: Accounting period. Example: 'Apr-24'.",
+            "JournalSource": "[REQUIRED] string: Journal source name. Example: 'Manual'.",
+            "JournalCategory": "[REQUIRED] string: Journal category. Example: 'Accrual', 'Reclass'.",
+            "AccountingDate": "[REQUIRED] string: Accounting date for the journal. Format: YYYY-MM-DD.",
+            "CurrencyCode": "[REQUIRED] string: Currency of the journal. Example: 'USD'.",
+            "Description": "string: Description of the journal entry.",
+            "ReferenceDate": "string: Optional reference date. Format: YYYY-MM-DD.",
+            "lines": "[REQUIRED] array: Journal lines array. Each line requires AccountCombination (segment string like '01.000.1200.000'), EnteredDebit or EnteredCredit amount, and optionally Description and TaxCode."
+        },
+        "functionality": "Creates a journal entry with debit and credit lines for a specified ledger and accounting period.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-journalentries-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Journal Entries: Post a Journal Entry",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/journalEntries/{JournalHeaderId}/action/post",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "JournalHeaderId": "[REQUIRED] integer: The unique identifier of the journal entry to post."
+        },
+        "functionality": "Posts an approved journal entry to the general ledger, updating account balances.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-journalentries-journalheaderid-action-post-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Journal Entries: Reverse a Journal Entry",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/journalEntries/{JournalHeaderId}/action/reverse",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "JournalHeaderId": "[REQUIRED] integer: The unique identifier of the journal entry to reverse.",
+            "ReversalPeriodName": "[REQUIRED] string: Accounting period in which to post the reversal. Example: 'May-24'.",
+            "ReversalDate": "string: Accounting date for the reversal. Format: YYYY-MM-DD. Defaults to first day of the reversal period.",
+            "ReversalMethod": "string: Reversal method. Valid values: SWITCH_DR_CR (switch debits and credits), CHANGE_SIGN (change sign of amounts). Default: SWITCH_DR_CR."
+        },
+        "functionality": "Creates and posts a reversal of a previously posted journal entry in a specified period.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-journalentries-journalheaderid-action-reverse-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Account Balances: Get Account Balances",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/ledgerBalances",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports LedgerId, PeriodName, AccountCombination, CurrencyCode, BalanceType. Example: q=LedgerId=300000001234567 and PeriodName='Apr-24' and BalanceType='PTD'",
+            "fields": "string: Comma-separated fields to return. Example: 'AccountCombination,PeriodName,PeriodToDateDebit,PeriodToDateCredit,PeriodToDateBalance'",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves general ledger account balances for a specific period and ledger. Supports period-to-date, quarter-to-date, and year-to-date balance types.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-ledgerbalances-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Ledgers: List Ledgers",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/ledgers",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports LedgerName, LedgerShortName, CurrencyCode, PeriodSetName, Status. Example: q=Status='Active'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves ledgers defined in Oracle Financials, including primary and secondary ledgers with their chart of accounts and calendar.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-ledgers-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Accounting Periods: List Accounting Periods",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/accountingPeriods",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports LedgerId, PeriodName, PeriodStatus, StartDate, EndDate. Example: q=LedgerId=300000001234567 and PeriodStatus='Open'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves accounting periods and their current status (Open, Closed, Future Enterable) for a ledger.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-accountingperiods-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Accounting Periods: Open or Close a Period",
+        "api_call": "PATCH /fscmRestApi/resources/11.13.18.05/accountingPeriods/{PeriodId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PeriodId": "[REQUIRED] integer: The unique identifier of the accounting period.",
+            "PeriodStatus": "[REQUIRED] string: Target status for the period. Valid values: Open, Closed, Permanently Closed."
+        },
+        "functionality": "Opens or closes an accounting period for a ledger. Closing a period prevents further journal entry posting.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-accountingperiods-periodid-patch.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Chart of Accounts: List Account Combinations",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/accountCombinations",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports LedgerId, Company, CostCenter, Account, SubAccount, Product, Enabled. Example: q=Company='01' and Account='1200' and Enabled='Y'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves valid account combinations from the chart of accounts. Use this to look up active GL code combinations before creating journal lines.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-accountcombinations-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Account Combinations: Create an Account Combination",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/accountCombinations",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "LedgerId": "[REQUIRED] integer: Ledger identifier.",
+            "Company": "[REQUIRED] string: Company segment value.",
+            "CostCenter": "[REQUIRED] string: Cost center segment value.",
+            "Account": "[REQUIRED] string: Natural account segment value.",
+            "SubAccount": "string: Sub-account segment value.",
+            "Product": "string: Product segment value.",
+            "IntercompanySegment": "string: Intercompany segment value.",
+            "FutureSegment": "string: Future use segment value.",
+            "StartDateActive": "string: Date from which the combination is active. Format: YYYY-MM-DD.",
+            "EndDateActive": "string: Date after which the combination is inactive. Format: YYYY-MM-DD.",
+            "Enabled": "string: Whether the combination is enabled. Valid values: Y, N. Default: Y."
+        },
+        "functionality": "Creates a new account combination in the chart of accounts for use in journal entries and distributions.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-accountcombinations-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Budget Journals: Create a Budget Journal",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/budgetJournals",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "LedgerId": "[REQUIRED] integer: Ledger identifier.",
+            "BudgetVersionId": "[REQUIRED] integer: Budget version identifier.",
+            "PeriodName": "[REQUIRED] string: Accounting period for the budget amount. Example: 'Apr-24'.",
+            "AccountCombination": "[REQUIRED] string: Full account segment string. Example: '01.000.5100.000'.",
+            "BudgetAmount": "[REQUIRED] number: Budget amount to load. Use positive for increase, negative for decrease.",
+            "CurrencyCode": "[REQUIRED] string: Currency code for the budget amount. Example: 'USD'.",
+            "BudgetEntryType": "string: How to apply the budget. Valid values: ENTERED (add to existing), BALANCE (replace existing). Default: ENTERED."
+        },
+        "functionality": "Creates a budget journal to load or adjust budget amounts for a specific account and period.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-budgetjournals-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Financial Reports: Run a Financial Report",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/financialReports/{ReportId}/action/run",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ReportId": "[REQUIRED] integer: Identifier of the Financial Reporting (FR) report to run.",
+            "LedgerId": "[REQUIRED] integer: Ledger for which to run the report.",
+            "PeriodName": "[REQUIRED] string: Accounting period. Example: 'Apr-24'.",
+            "OutputFormat": "string: Output format. Valid values: PDF, EXCEL, HTML. Default: PDF.",
+            "PointOfView": "array: Array of POV dimension-member pairs to override default POV values. Example: [{\"dimension\": \"Scenario\", \"member\": \"Budget\"}]"
+        },
+        "functionality": "Runs a Financial Reporting report and returns the output in the specified format.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-financialreports-reportid-action-run-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Intercompany Transactions: List Intercompany Transactions",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/intercompanyTransactions",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports TransactionNumber, Status, InitiatingLedgerId, RecipientLedgerId, TransactionDate, BatchId. Example: q=Status='APPROVED'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, approvals",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves intercompany transactions between legal entities, used to eliminate intercompany balances in consolidation.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-intercompanytransactions-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle ERP General Ledger - Allocations: Run Allocation Rule",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/allocationRules/{AllocationRuleId}/action/run",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "AllocationRuleId": "[REQUIRED] integer: Identifier of the allocation rule to run.",
+            "PeriodName": "[REQUIRED] string: Period for which to run the allocation. Example: 'Apr-24'.",
+            "LedgerId": "[REQUIRED] integer: Ledger for which to run the allocation.",
+            "RunMode": "string: Run mode. Valid values: DRAFT (preview without posting), FINAL (post allocation entries). Default: DRAFT."
+        },
+        "functionality": "Runs an allocation rule to distribute costs or revenue from a source account to target accounts based on predefined allocation methods.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/financials/24d/farfa/op-allocationrules-allocationruleid-action-run-post.html"
+        }
+    }
+]

--- a/data/apizoo/REST_API_for_Oracle_HCM_Cloud.json
+++ b/data/apizoo/REST_API_for_Oracle_HCM_Cloud.json
@@ -1,0 +1,495 @@
+[
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Workers: List Workers",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/workers",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Query condition to filter workers. Supports standard Oracle REST query syntax. Example: q=PersonNumber='12345' or q=BusinessTitle like 'Manager%'",
+            "fields": "string: Comma-separated list of fields to return. Example: fields=PersonId,PersonNumber,DisplayName,PrimaryEmailAddress",
+            "expand": "string: Comma-separated list of child resources to include in the response. Valid values: assignments, emails, phones, addresses, names, visas, citizenships, legislativeInfo",
+            "onlyData": "boolean: If true, suppresses links in the response payload.",
+            "offset": "integer: Starting position in the result set. Default is 0.",
+            "limit": "integer: Maximum number of records to return. Default is 25, maximum is 500.",
+            "totalResults": "boolean: If true, includes a count of total matching records in the response.",
+            "orderBy": "string: Field to sort results by. Example: orderBy=PersonNumber:asc"
+        },
+        "functionality": "Retrieves a list of workers. Supports filtering by query parameters and expanding related resources like assignments and contact details.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-workers-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Workers: Get a Worker",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/workers/{PersonId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PersonId": "[REQUIRED] integer: The unique identifier of the person (worker).",
+            "fields": "string: Comma-separated list of fields to include in the response.",
+            "expand": "string: Comma-separated child resources to include. Valid values: assignments, emails, phones, addresses, names, visas, citizenships, legislativeInfo, workRelationships",
+            "onlyData": "boolean: If true, suppresses links in the response payload."
+        },
+        "functionality": "Retrieves details of a specific worker by PersonId, including personal information and optionally expanded related resources.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-workers-personid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Workers: Get Worker Assignments",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/workers/{PersonId}/child/workRelationships/{WorkerNumber}/child/assignments",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PersonId": "[REQUIRED] integer: The unique identifier of the person.",
+            "WorkerNumber": "[REQUIRED] string: The worker number identifying the work relationship.",
+            "effectiveDate": "string: Date for which assignment details are retrieved. Format: YYYY-MM-DD. Defaults to current date.",
+            "fields": "string: Comma-separated list of fields to include in the response.",
+            "expand": "string: Child resources to expand. Valid values: gradeLadders, workMeasures, managers",
+            "onlyData": "boolean: If true, suppresses links in the response payload."
+        },
+        "functionality": "Retrieves all assignments for a worker under a specific work relationship, including job, grade, position, department, and location details.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-workers-personid-child-workrelationships-workernumber-child-assignments-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Workers: Create a Worker",
+        "api_call": "POST /hcmRestApi/resources/11.13.18.05/workers",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "LastName": "[REQUIRED] string: Last name of the worker.",
+            "FirstName": "string: First name of the worker.",
+            "DateOfBirth": "string: Date of birth of the worker. Format: YYYY-MM-DD.",
+            "LegislationCode": "[REQUIRED] string: Legislation code of the country. Example: US",
+            "PersonNumber": "string: Unique person number. If not provided, system generates one.",
+            "StartDate": "[REQUIRED] string: Employment start date. Format: YYYY-MM-DD.",
+            "WorkerType": "[REQUIRED] string: Type of worker. Valid values: E (Employee), C (Contingent Worker).",
+            "BusinessUnitId": "[REQUIRED] integer: Identifier of the business unit the worker belongs to.",
+            "LegalEntityId": "[REQUIRED] integer: Identifier of the legal entity.",
+            "JobId": "integer: Identifier of the job associated with the assignment.",
+            "DepartmentId": "integer: Identifier of the department.",
+            "LocationId": "integer: Identifier of the work location.",
+            "GradeId": "integer: Identifier of the grade.",
+            "ReportsTo": "integer: PersonId of the manager this worker reports to."
+        },
+        "functionality": "Creates a new worker record including personal information and initial employment details.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-workers-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Workers: Update a Worker",
+        "api_call": "PATCH /hcmRestApi/resources/11.13.18.05/workers/{PersonId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PersonId": "[REQUIRED] integer: The unique identifier of the person to update.",
+            "DateOfBirth": "string: Updated date of birth. Format: YYYY-MM-DD.",
+            "BloodType": "string: Blood type of the worker.",
+            "MaritalStatus": "string: Marital status. Valid values: M (Married), S (Single), D (Divorced), W (Widowed).",
+            "MaritalStatusDate": "string: Date of marital status change. Format: YYYY-MM-DD."
+        },
+        "functionality": "Updates personal information of an existing worker. Assignment and employment data require updating through work relationship and assignment child resources.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-workers-personid-patch.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Absences: List Absence Records",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/absences",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Example: q=PersonNumber='100020' to retrieve absences for a specific employee.",
+            "fields": "string: Comma-separated fields to include in the response.",
+            "expand": "string: Child resources to expand. Valid value: absenceDates",
+            "offset": "integer: Starting record position. Default is 0.",
+            "limit": "integer: Number of records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns the total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links from the response."
+        },
+        "functionality": "Retrieves a list of absence records across all employees. Filter using the q parameter to scope to a specific employee or date range.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-absences-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Absences: Create an Absence",
+        "api_call": "POST /hcmRestApi/resources/11.13.18.05/absences",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PersonNumber": "[REQUIRED] string: Employee person number for whom the absence is being created.",
+            "AbsenceTypeId": "[REQUIRED] integer: Identifier of the absence type (e.g., Annual Leave, Sick Leave).",
+            "StartDate": "[REQUIRED] string: Start date of the absence. Format: YYYY-MM-DD.",
+            "EndDate": "string: End date of the absence. Format: YYYY-MM-DD. Required if absence type does not support open-ended absences.",
+            "StartDateDuration": "number: Duration of the first day. Use when partial days are applicable (e.g., 0.5 for half day).",
+            "EndDateDuration": "number: Duration of the last day. Use when partial days are applicable.",
+            "Approved": "boolean: If true, marks the absence as approved directly. Requires appropriate privileges.",
+            "Comments": "string: Optional comments or reason for the absence."
+        },
+        "functionality": "Creates a new absence record for an employee. Supports full-day and partial-day absences.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-absences-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Absences: Delete an Absence",
+        "api_call": "DELETE /hcmRestApi/resources/11.13.18.05/absences/{AbsenceEntryId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "AbsenceEntryId": "[REQUIRED] integer: The unique identifier of the absence record to delete."
+        },
+        "functionality": "Deletes an existing absence record. The absence must be in a status that allows deletion (e.g., not already approved or processed in payroll).",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-absences-absenceentryid-delete.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Jobs: List Jobs",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/jobs",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition for jobs. Supports filtering by JobCode, Name, JobFamilyId, ActiveStatus. Example: q=ActiveStatus='A'",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: grades, evaluationCriteria",
+            "offset": "integer: Starting record position. Default is 0.",
+            "limit": "integer: Number of records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: Suppresses HATEOAS links if true.",
+            "effectiveDate": "string: Effective date for date-effective records. Format: YYYY-MM-DD."
+        },
+        "functionality": "Retrieves a list of job definitions. Jobs define the role and responsibilities associated with a position or assignment.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-jobs-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Positions: List Positions",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/positions",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports PositionCode, Name, DepartmentId, LocationId, JobId, ActiveStatus. Example: q=ActiveStatus='A' and DepartmentId=300000001234567",
+            "fields": "string: Comma-separated fields to include in the response.",
+            "expand": "string: Child resources to expand. Valid values: incumbents, evaluationCriteria",
+            "offset": "integer: Starting position in result set. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count in response.",
+            "effectiveDate": "string: Date for which position data is retrieved. Format: YYYY-MM-DD.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves a list of positions. Positions are specific instances of a job within an organization structure, optionally tied to a department and location.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-positions-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Departments: List Departments",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/departments",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition for departments. Supports Name, DepartmentId, OrganizationId, EffectiveStartDate, Status. Example: q=Status='A'",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand.",
+            "offset": "integer: Starting record offset. Default is 0.",
+            "limit": "integer: Number of records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count of matching records.",
+            "effectiveDate": "string: Effective date for date-tracked department data. Format: YYYY-MM-DD.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links from the response."
+        },
+        "functionality": "Retrieves a list of departments in the organization hierarchy.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-departments-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Grades: List Grades",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/grades",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports GradeCode, Name, SetId, ActiveStatus. Example: q=ActiveStatus='A'",
+            "fields": "string: Comma-separated fields to return in the response.",
+            "expand": "string: Child resources to expand. Valid value: gradeSteps",
+            "offset": "integer: Starting position in result set. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count of records.",
+            "effectiveDate": "string: Effective date for date-effective grade data. Format: YYYY-MM-DD.",
+            "onlyData": "boolean: Suppresses HATEOAS links if true."
+        },
+        "functionality": "Retrieves a list of grades used in compensation and assignment structures.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-grades-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Locations: List Locations",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/locations",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports LocationCode, LocationName, ActiveStatus, Country. Example: q=Country='US' and ActiveStatus='A'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count.",
+            "effectiveDate": "string: Effective date for location data. Format: YYYY-MM-DD.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves a list of work locations, including address and geographic details.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-locations-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Person Email Addresses: Get Worker Emails",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/workers/{PersonId}/child/emails",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PersonId": "[REQUIRED] integer: The unique identifier of the worker.",
+            "q": "string: Filter condition. Example: q=EmailType='W1' to retrieve work emails only.",
+            "fields": "string: Comma-separated list of fields to return.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "offset": "integer: Starting offset. Default is 0.",
+            "limit": "integer: Maximum records to return."
+        },
+        "functionality": "Retrieves all email addresses associated with a worker. Supports filtering by email type (e.g., work, personal).",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-workers-personid-child-emails-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Person Phone Numbers: Get Worker Phones",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/workers/{PersonId}/child/phones",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PersonId": "[REQUIRED] integer: The unique identifier of the worker.",
+            "q": "string: Filter condition. Example: q=PhoneType='W1' to retrieve work phones only.",
+            "fields": "string: Comma-separated list of fields to return.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "offset": "integer: Starting offset. Default is 0.",
+            "limit": "integer: Maximum records to return."
+        },
+        "functionality": "Retrieves all phone numbers associated with a worker, including work, mobile, and home numbers.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-workers-personid-child-phones-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Payroll Elements: List Payroll Elements",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/payrollElements",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ElementName, ElementClassification, LegislativeDataGroupId, ProcessingType. Example: q=ElementClassification='Earnings'",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: inputValues, eligibilityRules",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "effectiveDate": "string: Effective date for element data. Format: YYYY-MM-DD.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves payroll elements such as earnings, deductions, and benefits used in payroll processing.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-payrollelements-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Element Entries: List Element Entries for a Worker",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/elementEntries",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports PersonId, AssignmentId, ElementName, EntryType, EffectiveStartDate. Example: q=PersonId=300000001234567",
+            "fields": "string: Comma-separated fields to include in the response.",
+            "expand": "string: Child resources to expand. Valid value: entryValues",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count.",
+            "effectiveDate": "string: Effective date for date-effective element entries. Format: YYYY-MM-DD.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves element entries (earnings, deductions, benefits) assigned to a worker's payroll. Filter by PersonId or AssignmentId to scope results.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-elemententries-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Element Entries: Create an Element Entry",
+        "api_call": "POST /hcmRestApi/resources/11.13.18.05/elementEntries",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "AssignmentId": "[REQUIRED] integer: The assignment identifier for the worker.",
+            "ElementId": "[REQUIRED] integer: Identifier of the payroll element to attach.",
+            "EntryType": "[REQUIRED] string: Type of element entry. Valid values: E (Recurring), A (Additional), S (Override), D (Additive).",
+            "EffectiveStartDate": "[REQUIRED] string: Start date of the element entry. Format: YYYY-MM-DD.",
+            "EffectiveEndDate": "string: End date of the element entry. Format: YYYY-MM-DD. Defaults to end of time if not provided.",
+            "entryValues": "array: Input values for the element entry. Each object contains InputValueId and ScreenEntryValue. Example: [{\"InputValueId\": 300000001, \"ScreenEntryValue\": \"5000\"}]"
+        },
+        "functionality": "Creates a new element entry to assign a payroll element (such as a bonus, deduction, or benefit) to a worker's assignment.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-elemententries-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Person Legislative Data: Get Legislative Information",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/workers/{PersonId}/child/legislativeInfo",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PersonId": "[REQUIRED] integer: The unique identifier of the worker.",
+            "fields": "string: Comma-separated list of fields to include in the response.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "effectiveDate": "string: Effective date for legislative data. Format: YYYY-MM-DD."
+        },
+        "functionality": "Retrieves country-specific legislative information for a worker, such as tax identification, social security number, and statutory details based on the worker's legislation code.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-workers-personid-child-legislativeinfo-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Work Relationships: Terminate a Work Relationship",
+        "api_call": "PATCH /hcmRestApi/resources/11.13.18.05/workers/{PersonId}/child/workRelationships/{WorkerNumber}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "PersonId": "[REQUIRED] integer: The unique identifier of the person.",
+            "WorkerNumber": "[REQUIRED] string: The worker number identifying the specific work relationship.",
+            "TerminationType": "[REQUIRED] string: Reason for termination. Lookup type: TERMINATION_REASON. Example: 'RESIGNATION', 'INVOLUNTARY'.",
+            "ActualTerminationDate": "[REQUIRED] string: Date on which the employment terminates. Format: YYYY-MM-DD.",
+            "LastWorkingDate": "string: Last date the worker is physically at work. Format: YYYY-MM-DD. Defaults to ActualTerminationDate if not provided.",
+            "NotifiedTerminationDate": "string: Date the termination was communicated. Format: YYYY-MM-DD.",
+            "Comments": "string: Additional comments or notes about the termination.",
+            "RehireRecommendation": "string: Rehire eligibility. Valid values: Y (Yes), N (No)."
+        },
+        "functionality": "Terminates an employee's work relationship by recording the termination reason, date, and related details.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-workers-personid-child-workrelationships-workernumber-patch.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Performance Documents: List Performance Documents",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/performanceDocuments",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports PersonId, PerformancePeriodId, Status, TemplateId. Example: q=PersonId=300000001234567 and Status='IN_PROGRESS'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: goals, feedbackRequests, ratings",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves performance documents for employees. Filter by person and performance period to retrieve specific review cycles.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-performancedocuments-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Goals: List Worker Goals",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/goals",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports PersonId, GoalPlanId, Status, GoalType. Example: q=PersonId=300000001234567 and Status='ACTIVE'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: keyResults, targetOutcomes",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves performance goals assigned to workers. Filter by person, goal plan, or status to narrow results.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-goals-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Learning Records: List Worker Learning Records",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/learningRecords",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports LearnerPersonId, CourseId, OfferingId, Status, CompletionDate. Example: q=LearnerPersonId=300000001234567",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves learning enrollment and completion records for workers. Used to track training compliance and course completions.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-learningrecords-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Requisitions: List Job Requisitions",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/requisitions",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports RequisitionId, Title, Status, RecruitingTypeCode, BusinessUnitId. Example: q=Status='OPEN'",
+            "fields": "string: Comma-separated fields to include in the response.",
+            "expand": "string: Child resources to expand. Valid values: hiringTeam, jobApplications",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves job requisitions created in Oracle Recruiting Cloud. Use Status filter to list open, closed, or draft requisitions.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-requisitions-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Job Applications: List Applications for a Requisition",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/requisitions/{RequisitionId}/child/jobApplications",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "RequisitionId": "[REQUIRED] integer: The unique identifier of the job requisition.",
+            "q": "string: Filter condition. Supports Status, CandidateId, Phase. Example: q=Phase='OFFER'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: candidate, offers, interviews",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves all job applications submitted for a specific requisition, including candidate details and current phase.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-requisitions-requisitionid-child-jobapplications-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle HCM Cloud - Compensation Plans: List Compensation Plans",
+        "api_call": "GET /hcmRestApi/resources/11.13.18.05/compensationPlans",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports PlanName, Status, PlanType. Example: q=Status='Active'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: components, eligibilityRules",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count.",
+            "effectiveDate": "string: Effective date for date-effective plan data. Format: YYYY-MM-DD.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves compensation plans defined in Oracle Compensation Cloud, including salary, bonus, and stock plans.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/human-resources/24d/farws/op-compensationplans-get.html"
+        }
+    }
+]

--- a/data/apizoo/REST_API_for_Oracle_Procurement_Cloud.json
+++ b/data/apizoo/REST_API_for_Oracle_Procurement_Cloud.json
@@ -1,0 +1,462 @@
+[
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Purchase Orders: List Purchase Orders",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/purchaseOrders",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports PONumber, SupplierId, Status, BuyerEmailAddress, CreationDate. Example: q=Status='OPEN' and BuyerEmailAddress='buyer@example.com'",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, schedules, distributions, attachments",
+            "offset": "integer: Starting position in the result set. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort order. Example: orderBy=CreationDate:desc"
+        },
+        "functionality": "Retrieves a list of purchase orders. Filter by supplier, buyer, or status to scope results.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-purchaseorders-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Purchase Orders: Get a Purchase Order",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/purchaseOrders/{POHeaderId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "POHeaderId": "[REQUIRED] integer: The unique identifier of the purchase order header.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, schedules, distributions, attachments, changes",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves full details of a specific purchase order, including line items, delivery schedules, and account distributions.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-purchaseorders-poheaderid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Purchase Orders: Create a Purchase Order",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/purchaseOrders",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "BuyingPartyName": "[REQUIRED] string: Name of the procurement business unit.",
+            "SupplierId": "[REQUIRED] integer: Identifier of the supplier.",
+            "SupplierSiteId": "[REQUIRED] integer: Identifier of the supplier site.",
+            "BuyerEmailAddress": "[REQUIRED] string: Email of the buyer responsible for this PO.",
+            "CurrencyCode": "[REQUIRED] string: Currency code for the purchase order. Example: 'USD'.",
+            "PaymentTerms": "string: Payment terms code. Example: 'NET30'.",
+            "ShipToLocationId": "integer: Default ship-to location identifier for all lines.",
+            "BillToLocationId": "integer: Bill-to location identifier.",
+            "FreightTermsCode": "string: Freight terms. Example: 'PREPAID'.",
+            "NoteToSupplier": "string: Notes or instructions sent to the supplier on the PO.",
+            "lines": "[REQUIRED] array: Array of PO line objects. Each line requires ItemDescription, Quantity, UOMCode, and UnitPrice. ItemNumber is optional for description-based lines."
+        },
+        "functionality": "Creates a new purchase order with header and line details. Supports both item-based and description-based lines.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-purchaseorders-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Purchase Orders: Update a Purchase Order",
+        "api_call": "PATCH /fscmRestApi/resources/11.13.18.05/purchaseOrders/{POHeaderId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "POHeaderId": "[REQUIRED] integer: The unique identifier of the purchase order to update.",
+            "NoteToSupplier": "string: Updated note to the supplier.",
+            "PaymentTerms": "string: Updated payment terms code.",
+            "ShipToLocationId": "integer: Updated default ship-to location.",
+            "FreightTermsCode": "string: Updated freight terms.",
+            "Description": "string: Updated description for the PO header."
+        },
+        "functionality": "Updates header-level attributes of an existing purchase order. Line-level changes require updating via the lines child resource.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-purchaseorders-poheaderid-patch.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Purchase Orders: Submit a Purchase Order for Approval",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/purchaseOrders/{POHeaderId}/action/submit",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "POHeaderId": "[REQUIRED] integer: The unique identifier of the purchase order to submit.",
+            "Comments": "string: Comments to include with the approval submission."
+        },
+        "functionality": "Submits a draft purchase order into the approval workflow.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-purchaseorders-poheaderid-action-submit-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Purchase Requisitions: List Purchase Requisitions",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/purchaseRequisitions",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports RequisitionNumber, Status, RequesterEmailAddress, CreationDate, OrganizationCode. Example: q=Status='APPROVED'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, attachments",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort order. Example: orderBy=CreationDate:desc"
+        },
+        "functionality": "Retrieves a list of purchase requisitions. Filter by status, requester, or organization to scope results.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-purchaserequisitions-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Purchase Requisitions: Create a Purchase Requisition",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/purchaseRequisitions",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "RequisitioningBUId": "[REQUIRED] integer: Identifier of the requisitioning business unit.",
+            "RequesterEmailAddress": "[REQUIRED] string: Email address of the person requesting the items.",
+            "Description": "string: Description or title of the requisition.",
+            "NoteToApprover": "string: Notes included with the approval request.",
+            "lines": "[REQUIRED] array: Array of requisition line objects. Each line requires LineTypeCode, ItemDescription, Quantity, UOMCode, UnitPrice, and CurrencyCode. ItemNumber is optional."
+        },
+        "functionality": "Creates a new purchase requisition for goods or services. Can trigger automatic sourcing into a purchase order upon approval.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-purchaserequisitions-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Suppliers: List Suppliers",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/suppliers",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports SupplierName, SupplierNumber, Status, TaxOrganizationType, SetId. Example: q=Status='Active'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: sites, contacts, bankAccounts, addresses, qualifications",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort field and direction. Example: orderBy=SupplierName:asc"
+        },
+        "functionality": "Retrieves a list of suppliers registered in Oracle Procurement. Supports expanding related resources like sites and contacts.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-suppliers-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Suppliers: Get a Supplier",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/suppliers/{SupplierId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "SupplierId": "[REQUIRED] integer: The unique identifier of the supplier.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: sites, contacts, bankAccounts, addresses, qualifications, products",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves full details of a specific supplier including profile, classification, and associated sites.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-suppliers-supplierid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Suppliers: Create a Supplier",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/suppliers",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "SupplierName": "[REQUIRED] string: Legal name of the supplier.",
+            "SupplierNumber": "string: Unique supplier number. Auto-generated if not provided.",
+            "TaxOrganizationType": "[REQUIRED] string: Tax classification of the supplier. Valid values: INDIVIDUAL, CORPORATION, PARTNERSHIP, GOVERNMENT.",
+            "TaxpayerIdentificationNumber": "string: Tax identification number (TIN or EIN).",
+            "BusinessRelationship": "[REQUIRED] string: Type of relationship. Valid values: Spend Authorized, Prospective.",
+            "SupplierType": "string: Category of supplier. Example: 'Goods', 'Services', 'Both'.",
+            "ParentSupplierId": "integer: Parent supplier identifier for subsidiary relationships.",
+            "OneTimeFlag": "boolean: If true, marks this as a one-time supplier. Default is false.",
+            "HoldFlag": "boolean: If true, places the supplier on procurement hold. Default is false."
+        },
+        "functionality": "Creates a new supplier record in Oracle Procurement. Supplier sites and contacts must be created separately.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-suppliers-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Supplier Sites: List Supplier Sites",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/suppliers/{SupplierId}/child/sites",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "SupplierId": "[REQUIRED] integer: The unique identifier of the supplier.",
+            "q": "string: Filter condition. Supports SiteName, Status, PurchasingSiteFlag, PaySiteFlag, PrimarySiteFlag. Example: q=PurchasingSiteFlag='Y'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: contacts, bankAccounts",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves all sites associated with a supplier, including purchasing, pay, and RFQ sites.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-suppliers-supplierid-child-sites-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Supplier Sites: Create a Supplier Site",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/suppliers/{SupplierId}/child/sites",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "SupplierId": "[REQUIRED] integer: The unique identifier of the parent supplier.",
+            "SiteName": "[REQUIRED] string: Name of the supplier site.",
+            "ProcurementBUId": "[REQUIRED] integer: Procurement business unit associated with this site.",
+            "AddressLine1": "[REQUIRED] string: First line of the site address.",
+            "AddressLine2": "string: Second line of the site address.",
+            "City": "[REQUIRED] string: City of the site address.",
+            "State": "string: State or province of the site address.",
+            "PostalCode": "[REQUIRED] string: Postal or ZIP code of the site address.",
+            "Country": "[REQUIRED] string: Country code of the site address. Example: 'US'.",
+            "PurchasingSiteFlag": "string: Whether this is a purchasing site. Valid values: Y, N. Default: Y.",
+            "PaySiteFlag": "string: Whether payments are made to this site. Valid values: Y, N. Default: N.",
+            "PrimaryPaySiteFlag": "string: Whether this is the primary payment site. Valid values: Y, N. Default: N.",
+            "PaymentTerms": "string: Payment terms code for this site. Example: 'NET30'.",
+            "CurrencyCode": "string: Currency for transactions with this site. Example: 'USD'."
+        },
+        "functionality": "Creates a new site for an existing supplier, defining the address, payment, and purchasing attributes.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-suppliers-supplierid-child-sites-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Blanket Purchase Agreements: List Agreements",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/blanketPurchaseAgreements",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports DocumentNumber, SupplierId, Status, StartDate, EndDate. Example: q=Status='ACTIVE' and SupplierId=300000001234567",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, controls, attachments",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves blanket purchase agreements (BPAs) that establish pricing and terms with suppliers for a period without committing to quantities.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-blanketpurchaseagreements-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Blanket Purchase Agreements: Create a Blanket Purchase Agreement",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/blanketPurchaseAgreements",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ProcurementBUId": "[REQUIRED] integer: Procurement business unit identifier.",
+            "SupplierId": "[REQUIRED] integer: Supplier identifier.",
+            "SupplierSiteId": "[REQUIRED] integer: Supplier site identifier.",
+            "BuyerEmailAddress": "[REQUIRED] string: Email of the responsible buyer.",
+            "CurrencyCode": "[REQUIRED] string: Currency code. Example: 'USD'.",
+            "StartDate": "[REQUIRED] string: Effective start date of the agreement. Format: YYYY-MM-DD.",
+            "EndDate": "[REQUIRED] string: Expiration date of the agreement. Format: YYYY-MM-DD.",
+            "AgreementAmount": "number: Total agreed-upon amount ceiling for the BPA.",
+            "PaymentTerms": "string: Payment terms code. Example: 'NET30'.",
+            "NoteToSupplier": "string: Notes sent to the supplier with the agreement.",
+            "lines": "array: Agreement line objects. Each line includes ItemNumber or ItemDescription, UnitPrice, UOMCode, and optionally Quantity."
+        },
+        "functionality": "Creates a new blanket purchase agreement to pre-negotiate pricing and terms with a supplier for future purchase orders.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-blanketpurchaseagreements-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Negotiations: List Negotiations",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/negotiations",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports DocumentNumber, Status, NegotiationType, BuyerEmailAddress, CloseDate. Example: q=Status='ACTIVE'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, suppliers, requirements",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves sourcing negotiations (RFQs, auctions, RFIs) created in Oracle Sourcing.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-negotiations-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Invoices: List Payables Invoices",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/invoices",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports InvoiceNumber, SupplierId, Status, InvoiceDate, PONumber, BusinessUnitId. Example: q=Status='Unpaid' and SupplierId=300000001234567",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, payments, holds, attachments",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort order. Example: orderBy=InvoiceDate:desc"
+        },
+        "functionality": "Retrieves supplier invoices from Oracle Payables. Filter by supplier, status, or purchase order number.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-invoices-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Invoices: Create a Supplier Invoice",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/invoices",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "BusinessUnitName": "[REQUIRED] string: Name of the payables business unit.",
+            "SupplierId": "[REQUIRED] integer: Supplier identifier.",
+            "SupplierSiteId": "[REQUIRED] integer: Supplier site identifier.",
+            "InvoiceNumber": "[REQUIRED] string: Supplier's invoice number.",
+            "InvoiceDate": "[REQUIRED] string: Date of the invoice. Format: YYYY-MM-DD.",
+            "InvoiceCurrencyCode": "[REQUIRED] string: Currency code of the invoice. Example: 'USD'.",
+            "InvoiceAmount": "[REQUIRED] number: Total invoice amount.",
+            "InvoiceType": "[REQUIRED] string: Type of invoice. Valid values: Standard, Credit, Debit, Prepayment.",
+            "PaymentTerms": "string: Payment terms code. Example: 'NET30'.",
+            "Description": "string: Description of the invoice.",
+            "lines": "[REQUIRED] array: Invoice lines. Each line requires LineNumber, LineType, Amount, and either POHeaderId+POLineId for PO-matched lines or AccountingDate and ChargeAccountId for non-PO lines."
+        },
+        "functionality": "Creates a supplier invoice in Oracle Payables. Supports PO-matched and non-PO invoice lines.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-invoices-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Invoices: Validate and Submit an Invoice for Payment",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/invoices/{InvoiceId}/action/validate",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "InvoiceId": "[REQUIRED] integer: The unique identifier of the invoice to validate.",
+            "AccountingDate": "string: Accounting date to use during validation. Format: YYYY-MM-DD. Defaults to system date.",
+            "CreateAccounting": "boolean: If true, creates accounting entries during validation. Default is false."
+        },
+        "functionality": "Validates an invoice to check for holds and errors, making it eligible for payment processing.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-invoices-invoiceid-action-validate-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Invoice Holds: List Invoice Holds",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/invoices/{InvoiceId}/child/holds",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "InvoiceId": "[REQUIRED] integer: The unique identifier of the invoice.",
+            "q": "string: Filter condition. Supports HoldName, HeldBy, HoldDate, ReleaseName. Example: q=ReleaseName is null to retrieve unreleased holds.",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves holds placed on a supplier invoice that are preventing payment processing.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-invoices-invoiceid-child-holds-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Payments: List Payments",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/payments",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports PaymentNumber, SupplierId, Status, PaymentDate, PaymentMethodCode, BusinessUnitId. Example: q=Status='Negotiable' and PaymentDate >= '2024-01-01'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: invoices, attachments",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves supplier payment records from Oracle Payables. Supports filtering by supplier, payment date, and status.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-payments-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Spending Categories: List Spending Categories",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/spendingCategories",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports CategoryName, CategoryCode, Status, SetId. Example: q=Status='Active'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves procurement spending categories used to classify purchased goods and services for spend analysis.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-spendingcategories-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Procurement Agents: List Procurement Agents",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/procurementAgents",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports AgentName, EmailAddress, ProcurementBUId, ActiveStatus. Example: q=ActiveStatus='Y'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: businessUnits, categories",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves procurement agents (buyers) and their associated business units and category assignments.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-procurementagents-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Approved Supplier Lists: List Approved Suppliers",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/approvedSupplierLists",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ItemId, ItemNumber, SupplierId, SupplierSiteId, Status, OrganizationCode. Example: q=ItemNumber='AS18947' and Status='Active'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: qualifications",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "effectiveDate": "string: Date for which ASL records are effective. Format: YYYY-MM-DD.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves the Approved Supplier List (ASL) entries defining which suppliers are authorized to supply specific items.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-approvedsupplierlists-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Procurement Cloud - Supplier Qualifications: Get Supplier Qualification",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/supplierQualifications/{QualificationId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "QualificationId": "[REQUIRED] integer: The unique identifier of the supplier qualification record.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: responses, assessments",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves details of a specific supplier qualification, including questionnaire responses and assessor evaluations.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/procurement/24d/fapra/op-supplierqualifications-qualificationid-get.html"
+        }
+    }
+]

--- a/data/apizoo/REST_API_for_Oracle_Project_Management_Cloud.json
+++ b/data/apizoo/REST_API_for_Oracle_Project_Management_Cloud.json
@@ -1,0 +1,243 @@
+[
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Projects: List Projects",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/projects",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ProjectNumber, ProjectName, ProjectStatus, BusinessUnit, ProjectManagerId, StartDate. Example: q=ProjectStatus='ACTIVE'",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: tasks, team, deliverables, budgets, costs",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort order. Example: orderBy=StartDate:desc"
+        },
+        "functionality": "Retrieves a list of projects. Supports filtering by status, business unit, and project manager.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projects-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Projects: Get a Project",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/projects/{ProjectId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ProjectId": "[REQUIRED] integer: The unique identifier of the project.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: tasks, team, deliverables, budgets, classifications, customers",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves full details of a specific project including schedule, team, and financial summary.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projects-projectid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Projects: Create a Project",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/projects",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ProjectName": "[REQUIRED] string: Name of the project.",
+            "ProjectNumber": "string: Unique project number. Auto-generated if not provided.",
+            "ProjectTemplateId": "integer: Template identifier to inherit structure and settings from.",
+            "BusinessUnitId": "[REQUIRED] integer: Business unit that owns this project.",
+            "LegalEntityId": "integer: Legal entity for financial reporting.",
+            "ProjectManagerId": "[REQUIRED] integer: PersonId of the project manager.",
+            "ProjectStatus": "string: Status of the project. Valid values: ACTIVE, PENDING, CLOSED. Default: PENDING.",
+            "StartDate": "[REQUIRED] string: Project start date. Format: YYYY-MM-DD.",
+            "FinishDate": "string: Project planned finish date. Format: YYYY-MM-DD.",
+            "Description": "string: Description of the project.",
+            "ProjectCurrency": "string: Currency code for project financials. Example: 'USD'.",
+            "BillingMethod": "string: Billing method for customer-facing projects. Valid values: Fixed Price, Time and Materials, Cost Plus.",
+            "CustomerId": "integer: Customer account identifier for billable projects."
+        },
+        "functionality": "Creates a new project in Oracle Project Management Cloud.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projects-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Tasks: List Project Tasks",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/projects/{ProjectId}/child/tasks",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ProjectId": "[REQUIRED] integer: The unique identifier of the project.",
+            "q": "string: Filter condition. Supports TaskName, TaskNumber, Status, MilestoneFlag, ParentTaskId. Example: q=MilestoneFlag='Y'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: resources, costs, dependencies",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 50.",
+            "totalResults": "boolean: If true, includes total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves tasks belonging to a specific project, including milestones and subtasks.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projects-projectid-child-tasks-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Tasks: Create a Task",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/projects/{ProjectId}/child/tasks",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ProjectId": "[REQUIRED] integer: The unique identifier of the project.",
+            "TaskName": "[REQUIRED] string: Name of the task.",
+            "TaskNumber": "string: Unique task number within the project. Auto-generated if not provided.",
+            "ParentTaskId": "integer: Identifier of the parent task for hierarchical WBS structures.",
+            "StartDate": "[REQUIRED] string: Planned start date. Format: YYYY-MM-DD.",
+            "FinishDate": "[REQUIRED] string: Planned finish date. Format: YYYY-MM-DD.",
+            "PercentComplete": "number: Completion percentage (0-100).",
+            "MilestoneFlag": "string: Whether this task is a milestone. Valid values: Y, N. Default: N.",
+            "BillableFlag": "string: Whether work on this task is billable to the customer. Valid values: Y, N.",
+            "ChargeableFlag": "string: Whether costs are charged to this task. Valid values: Y, N.",
+            "TaskManagerId": "integer: PersonId of the task manager.",
+            "Description": "string: Description or scope of the task."
+        },
+        "functionality": "Creates a new task in a project's work breakdown structure (WBS).",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projects-projectid-child-tasks-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Project Resources: List Project Team Members",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/projects/{ProjectId}/child/resources",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ProjectId": "[REQUIRED] integer: The unique identifier of the project.",
+            "q": "string: Filter condition. Supports PersonId, JobId, StartDate, FinishDate, ResourceType. Example: q=ResourceType='Named'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves team members assigned to a project, including their roles, planned hours, and assignment dates.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projects-projectid-child-resources-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Project Budgets: Get Project Budget",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/projectBudgets",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ProjectId, BudgetTypeCode, VersionStatus. Example: q=ProjectId=300000001234567 and VersionStatus='APPROVED'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, resources",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return.",
+            "totalResults": "boolean: If true, includes total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves cost or revenue budget versions for a project. Filter by budget type (cost or revenue) and status.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projectbudgets-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Expenditures: Create an Expenditure Item",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/expenditureItems",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ProjectId": "[REQUIRED] integer: Project identifier to charge.",
+            "TaskId": "[REQUIRED] integer: Task identifier to charge.",
+            "ExpenditureTypeId": "[REQUIRED] integer: Expenditure type identifier (e.g., Labor, Materials, Travel).",
+            "ExpenditureItemDate": "[REQUIRED] string: Date of the expenditure. Format: YYYY-MM-DD.",
+            "Quantity": "[REQUIRED] number: Quantity of the expenditure (e.g., hours, units).",
+            "UOMCode": "[REQUIRED] string: Unit of measure. Example: 'Hours', 'Each'.",
+            "RawCost": "number: Raw cost amount in project currency.",
+            "RawCostRate": "number: Cost rate per unit.",
+            "PersonId": "integer: PersonId of the employee incurring the cost.",
+            "OverrideToOrganizationId": "integer: Organization to override the default expenditure organization.",
+            "Comments": "string: Description or notes about the expenditure."
+        },
+        "functionality": "Creates an expenditure item to record costs against a project task. Used for labor, expense, and miscellaneous cost entry.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-expenditureitems-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Project Contracts: List Project Contracts",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/projectContracts",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ContractNumber, Status, CustomerId, ProjectId, ContractType. Example: q=Status='ACTIVE' and CustomerId=300000001234567",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, billingControls, fundingSources",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves project contracts used in Oracle Project Billing for customer invoicing and revenue recognition.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projectcontracts-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Project Invoices: List Project Invoices",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/projectInvoices",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ProjectId, ContractId, Status, InvoiceDate, CustomerId. Example: q=ProjectId=300000001234567 and Status='RELEASED'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, credits",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves customer invoices generated from Oracle Project Billing for billable project work.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projectinvoices-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Project Issues: List Project Issues",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/projectIssues",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ProjectId, Status, Priority, AssignedTo, DueDate. Example: q=ProjectId=300000001234567 and Priority='High'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves issues and risks tracked against a project.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projectissues-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle Project Management Cloud - Project Deliverables: List Deliverables",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/projects/{ProjectId}/child/deliverables",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ProjectId": "[REQUIRED] integer: The unique identifier of the project.",
+            "q": "string: Filter condition. Supports DeliverableName, Status, DueDate, OwnerId. Example: q=Status='In Progress'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves deliverables tracked against a project, including their due dates and owners.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/project-management/24d/fapjm/op-projects-projectid-child-deliverables-get.html"
+        }
+    }
+]

--- a/data/apizoo/REST_API_for_Oracle_SCM_Cloud.json
+++ b/data/apizoo/REST_API_for_Oracle_SCM_Cloud.json
@@ -1,0 +1,466 @@
+[
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Sales Orders: List Sales Orders",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/salesOrders",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports OrderNumber, Status, CustomerId, OrderedDate, SourceOrderSystem. Example: q=Status='BOOKED' and CustomerId=300000001234567",
+            "fields": "string: Comma-separated list of fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, charges, paymentTerms, addresses",
+            "offset": "integer: Starting position in the result set. Default is 0.",
+            "limit": "integer: Maximum number of records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count in the response.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort order. Example: orderBy=OrderedDate:desc"
+        },
+        "functionality": "Retrieves a list of sales orders. Supports filtering by status, customer, and order date.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-salesorders-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Sales Orders: Get a Sales Order",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/salesOrders/{HeaderId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "HeaderId": "[REQUIRED] integer: The unique identifier of the sales order header.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, charges, paymentTerms, addresses, attachments",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves full details of a specific sales order including lines, pricing, and fulfillment status.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-salesorders-headerid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Sales Orders: Create a Sales Order",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/salesOrders",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "SourceTransactionNumber": "[REQUIRED] string: Unique order number from the source system.",
+            "SourceTransactionSystem": "[REQUIRED] string: Identifier of the source system submitting the order. Example: 'OPS', 'CRM'.",
+            "SourceTransactionId": "[REQUIRED] string: Unique identifier for the transaction in the source system.",
+            "BuyingPartyId": "[REQUIRED] integer: Customer account identifier.",
+            "BuyingPartyContactId": "integer: Customer contact identifier.",
+            "TransactionTypeCode": "[REQUIRED] string: Order type code. Example: 'STD' for standard order.",
+            "RequestedShipDate": "string: Requested shipment date. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "PaymentTermsCode": "string: Payment terms code. Example: 'NET30'.",
+            "ShippingMethod": "string: Shipping carrier and method code.",
+            "lines": "[REQUIRED] array: Array of order line objects. Each line must include SourceTransactionLineId, SourceTransactionLineNumber, ProductNumber, OrderedQuantity, and UOMCode."
+        },
+        "functionality": "Creates a new sales order with header and line details. Supports import from external source systems.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-salesorders-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Sales Orders: Cancel a Sales Order",
+        "api_call": "PATCH /fscmRestApi/resources/11.13.18.05/salesOrders/{HeaderId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "HeaderId": "[REQUIRED] integer: The unique identifier of the sales order to cancel.",
+            "Status": "[REQUIRED] string: Set to 'CANCELLED' to cancel the order.",
+            "CancelReasonCode": "string: Reason code for cancellation. Example: 'CUSTOMER_REQUEST'.",
+            "CancelledQuantity": "number: Quantity to cancel. Omit to cancel the full order."
+        },
+        "functionality": "Cancels an existing sales order or reduces the ordered quantity on a line.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-salesorders-headerid-patch.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Inventory Items: List Inventory Items",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/inventoryItems",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ItemNumber, ItemDescription, OrganizationCode, LifecyclePhase, ItemType. Example: q=OrganizationCode='M1' and LifecyclePhase='Active'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: itemCategories, itemRelationships, substitutes, units",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links.",
+            "orderBy": "string: Sort field and direction. Example: orderBy=ItemNumber:asc"
+        },
+        "functionality": "Retrieves inventory items defined across organizations. Supports filtering by item number, organization, and lifecycle status.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-inventoryitems-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Inventory Items: Get an Inventory Item",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/inventoryItems/{ItemId}",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ItemId": "[REQUIRED] integer: The unique identifier of the inventory item.",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: itemCategories, itemRelationships, itemRevisions, units, substitutes",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves full details of a specific inventory item, including unit of measure, category assignments, and stocking attributes.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-inventoryitems-itemid-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Inventory Items: Create an Inventory Item",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/inventoryItems",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ItemNumber": "[REQUIRED] string: Unique item number.",
+            "ItemDescription": "[REQUIRED] string: Description of the inventory item.",
+            "OrganizationCode": "[REQUIRED] string: Organization code where the item is defined. Example: 'M1'.",
+            "ItemType": "string: Item type. Valid values: Standard, Kit, Model, Option Class, Planning.",
+            "UOMCode": "[REQUIRED] string: Primary unit of measure. Example: 'Ea' for Each.",
+            "LifecyclePhase": "string: Item lifecycle status. Valid values: Concept, Preproduction, Production, Discontinuation, Obsolete.",
+            "TrackingAttribute": "string: Inventory tracking method. Valid values: None, Lot, Serial.",
+            "StockedItem": "boolean: If true, the item is stocked in inventory.",
+            "PurchasedItem": "boolean: If true, the item can be purchased.",
+            "SoldItem": "boolean: If true, the item can be sold."
+        },
+        "functionality": "Creates a new inventory item in the specified organization.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-inventoryitems-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - On-Hand Quantities: Get On-Hand Quantity for an Item",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/onhandQuantities",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ItemNumber, OrganizationCode, SubinventoryCode, LotNumber. Example: q=ItemNumber='AS18947' and OrganizationCode='M1'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves current on-hand inventory quantities for items across organizations, subinventories, and locators.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-onhandquantities-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Inventory Transactions: Create a Miscellaneous Transaction",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/inventoryMiscTransactions",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "OrganizationCode": "[REQUIRED] string: Organization code where the transaction is performed.",
+            "ItemNumber": "[REQUIRED] string: Item number for the transaction.",
+            "TransactionTypeId": "[REQUIRED] integer: Identifier of the transaction type (e.g., Miscellaneous Issue, Miscellaneous Receipt).",
+            "TransactionQuantity": "[REQUIRED] number: Quantity for the transaction. Negative value for an issue.",
+            "TransactionUOMCode": "[REQUIRED] string: Unit of measure for the transaction quantity.",
+            "TransactionDate": "[REQUIRED] string: Date of the transaction. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "SubinventoryCode": "string: Subinventory for the transaction.",
+            "LotNumber": "string: Lot number if the item is lot-controlled.",
+            "SerialNumber": "string: Serial number if the item is serial-controlled.",
+            "AccountNumber": "string: General ledger account number to charge."
+        },
+        "functionality": "Records a miscellaneous inventory transaction such as an inventory issue or receipt not tied to a purchase order or sales order.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-inventorymisctransactions-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Shipments: List Shipments",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/shipments",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ShipmentNumber, Status, ShipFromOrganizationCode, ShipToPartyId, ShipDate. Example: q=Status='OPEN'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, containers, freightCosts, trackingNumbers",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves outbound shipments from Oracle Shipping. Use filters to scope by status, ship date, or customer.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-shipments-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Shipments: Confirm a Shipment",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/shipments/{ShipmentHeaderId}/action/confirm",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ShipmentHeaderId": "[REQUIRED] integer: The unique identifier of the shipment to confirm.",
+            "ShipDate": "[REQUIRED] string: Actual ship date. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "TrackingNumber": "string: Carrier tracking number for the shipment.",
+            "CarrierCode": "string: Carrier code used for shipping.",
+            "ServiceLevel": "string: Shipping service level. Example: 'GROUND', 'OVERNIGHT'.",
+            "FreightTermsCode": "string: Freight terms. Example: 'PREPAID', 'COLLECT'."
+        },
+        "functionality": "Confirms a shipment to record the actual ship date and carrier details, triggering inventory deduction and billing.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-shipments-shipmentheaderid-action-confirm-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Receipts: List Receipts",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/receipts",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ReceiptNumber, VendorId, OrganizationCode, ReceiptDate, PONumber. Example: q=OrganizationCode='M1' and ReceiptDate >= '2024-01-01'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, transactions",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves receiving transactions for purchased goods and services.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-receipts-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Receipts: Create a Receipt",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/receipts",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "ReceiptSourceCode": "[REQUIRED] string: Source of the receipt. Valid values: 'VENDOR' for supplier receipts, 'CUSTOMER' for customer returns.",
+            "OrganizationCode": "[REQUIRED] string: Receiving organization code.",
+            "ReceiptDate": "[REQUIRED] string: Date of the receipt. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "VendorId": "integer: Supplier identifier. Required when ReceiptSourceCode is 'VENDOR'.",
+            "VendorSiteId": "integer: Supplier site identifier.",
+            "PackingSlip": "string: Supplier packing slip number.",
+            "BillOfLading": "string: Bill of lading reference number.",
+            "WaybillAirbillNumber": "string: Waybill or air bill number.",
+            "lines": "[REQUIRED] array: Array of receipt line objects. Each line must include POHeaderId, POLineId, POLineLocationId, QuantityReceived, and UOMCode."
+        },
+        "functionality": "Creates a receiving transaction against a purchase order, recording quantity received and delivery details.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-receipts-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Work Orders: List Work Orders",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/workOrders",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports WorkOrderNumber, Status, OrganizationCode, ItemNumber, ScheduledStartDate. Example: q=Status='Released' and OrganizationCode='M1'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: operations, materials, outputItems",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves manufacturing work orders. Filter by status, organization, or item to scope results.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-workorders-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Work Orders: Create a Work Order",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/workOrders",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "OrganizationCode": "[REQUIRED] string: Manufacturing organization code.",
+            "ItemNumber": "[REQUIRED] string: Item number of the assembly to produce.",
+            "StartQuantity": "[REQUIRED] number: Quantity to manufacture.",
+            "UOMCode": "[REQUIRED] string: Unit of measure for the quantity.",
+            "WorkOrderType": "[REQUIRED] string: Type of work order. Valid values: Standard, Nonstandard, Rework, Transform.",
+            "ScheduledStartDate": "[REQUIRED] string: Planned start date. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "ScheduledCompletionDate": "[REQUIRED] string: Planned completion date. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "BOMRevision": "string: Bill of materials revision to use. Defaults to current revision.",
+            "RoutingRevision": "string: Routing revision to use. Defaults to current revision.",
+            "DemandSourceHeaderId": "integer: Sales order header identifier if this work order is demand-driven.",
+            "ProjectId": "integer: Project identifier if this work order is project-costed."
+        },
+        "functionality": "Creates a new manufacturing work order for producing an assembled item.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-workorders-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Item Structures (BOM): Get Bill of Materials",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/itemStructures",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports ItemNumber, OrganizationCode, StructureName, EffectiveDate. Example: q=ItemNumber='CM77862' and OrganizationCode='M1'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: components, substitutes",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, includes total count.",
+            "effectiveDate": "string: Date for which the BOM structure is effective. Format: YYYY-MM-DD.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves bill of materials (BOM) structures for manufacturing items, including component items and quantities.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-itemstructures-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Transfer Orders: List Transfer Orders",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/transferOrders",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports TransferOrderNumber, Status, SourceOrganizationCode, DestinationOrganizationCode, RequestedShipDate. Example: q=Status='OPEN'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid values: lines, shipments",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves inter-organization transfer orders used to move inventory between warehouses or plants.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-transferorders-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Transfer Orders: Create a Transfer Order",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/transferOrders",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "SourceOrganizationCode": "[REQUIRED] string: Organization code of the source (shipping) organization.",
+            "DestinationOrganizationCode": "[REQUIRED] string: Organization code of the destination (receiving) organization.",
+            "RequestedShipDate": "[REQUIRED] string: Requested date to ship the transfer. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "TransferOrderTypeId": "integer: Transfer order type identifier.",
+            "ShipmentPriority": "string: Priority of the shipment. Example: 'High', 'Medium', 'Low'.",
+            "lines": "[REQUIRED] array: Array of transfer order lines. Each line requires ItemNumber, RequestedQuantity, and UOMCode."
+        },
+        "functionality": "Creates a new inter-organization transfer order to move inventory between two Oracle SCM organizations.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-transferorders-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Supply Requests: Create a Supply Request",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/supplyRequests",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "SourceSystemCode": "[REQUIRED] string: Code of the source system submitting the request.",
+            "SourceRequestNumber": "[REQUIRED] string: Unique request number from the source system.",
+            "OrganizationCode": "[REQUIRED] string: Requesting organization code.",
+            "ItemNumber": "[REQUIRED] string: Item number for which supply is requested.",
+            "RequestedQuantity": "[REQUIRED] number: Quantity of supply requested.",
+            "UOMCode": "[REQUIRED] string: Unit of measure for the quantity.",
+            "RequestedDate": "[REQUIRED] string: Date by which supply is needed. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "ProjectId": "integer: Project identifier for project-driven supply.",
+            "TaskId": "integer: Task identifier within the project.",
+            "SubinventoryCode": "string: Target subinventory for the supply."
+        },
+        "functionality": "Creates an external supply request that can trigger planning recommendations for purchase orders, work orders, or transfers.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-supplyrequests-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Cycle Counts: List Cycle Count Sequences",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/cycleCountSequences",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports CycleCountName, OrganizationCode, Status, SubinventoryCode. Example: q=OrganizationCode='M1' and Status='UNCOUNTED'",
+            "fields": "string: Comma-separated fields to return.",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves cycle count sequences for physical inventory counting tasks in a warehouse.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-cyclecountsequences-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Cycle Counts: Submit a Cycle Count",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/cycleCountSequences/{CycleCountSequenceId}/action/submitCount",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "CycleCountSequenceId": "[REQUIRED] integer: Unique identifier of the cycle count sequence.",
+            "CountQuantity": "[REQUIRED] number: Actual counted quantity.",
+            "CountUOMCode": "[REQUIRED] string: Unit of measure of the counted quantity.",
+            "CountDate": "[REQUIRED] string: Date and time the count was performed. Format: YYYY-MM-DDThh:mm:ssZ.",
+            "LotNumber": "string: Lot number if the item is lot-controlled.",
+            "SerialNumber": "string: Serial number if the item is serial-controlled."
+        },
+        "functionality": "Submits a physical count against an existing cycle count sequence, recording the actual quantity found.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-cyclecountsequences-cyclecountsequenceid-action-submitcount-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Lot Numbers: List Lot Numbers",
+        "api_call": "GET /fscmRestApi/resources/11.13.18.05/lotNumbers",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "q": "string: Filter condition. Supports LotNumber, ItemNumber, OrganizationCode, ExpirationDate, Status. Example: q=ItemNumber='AS18947' and OrganizationCode='M1'",
+            "fields": "string: Comma-separated fields to return.",
+            "expand": "string: Child resources to expand. Valid value: serialNumbers",
+            "offset": "integer: Starting position. Default is 0.",
+            "limit": "integer: Maximum records to return. Default is 25.",
+            "totalResults": "boolean: If true, returns total record count.",
+            "onlyData": "boolean: If true, suppresses HATEOAS links."
+        },
+        "functionality": "Retrieves lot numbers for lot-controlled inventory items including expiration dates and current status.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-lotnumbers-get.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Picking Waves: Create a Picking Wave",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/pickingWaves",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "OrganizationCode": "[REQUIRED] string: Warehouse organization code.",
+            "ShipMethodCode": "string: Filter pick release to a specific shipping method.",
+            "ShipToPartyId": "integer: Filter pick release to a specific customer.",
+            "RequestedShipDateFrom": "string: Filter orders with requested ship date from. Format: YYYY-MM-DD.",
+            "RequestedShipDateTo": "string: Filter orders with requested ship date to. Format: YYYY-MM-DD.",
+            "AutoPickConfirm": "boolean: If true, automatically confirms picks after allocation. Default is false.",
+            "AutoAllocate": "boolean: If true, automatically allocates inventory during wave creation. Default is true.",
+            "BatchSize": "integer: Maximum number of shipment lines per picking batch."
+        },
+        "functionality": "Creates a wave of pick releases to group and allocate outbound shipment lines for warehouse picking.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-pickingwaves-post.html"
+        }
+    },
+    {
+        "user_name": "karthikchundi-commits",
+        "api_name": "REST API for Oracle SCM Cloud - Customer Returns: Create a Return Material Authorization",
+        "api_call": "POST /fscmRestApi/resources/11.13.18.05/customerReturns",
+        "api_version": "2024.11.05",
+        "api_arguments": {
+            "SourceTransactionNumber": "[REQUIRED] string: Unique RMA number from the source system.",
+            "SourceTransactionSystem": "[REQUIRED] string: Source system code.",
+            "SourceTransactionId": "[REQUIRED] string: Source system transaction ID.",
+            "ReturnReasonCode": "[REQUIRED] string: Reason code for the return. Example: 'DEFECTIVE', 'WRONG_ITEM', 'DAMAGED'.",
+            "BuyingPartyId": "[REQUIRED] integer: Customer account identifier.",
+            "OriginalOrderId": "integer: Header ID of the original sales order being returned.",
+            "lines": "[REQUIRED] array: Return lines. Each line requires SourceTransactionLineId, ProductNumber, ReturnQuantity, and UOMCode."
+        },
+        "functionality": "Creates a Return Material Authorization (RMA) to process a customer's return of goods.",
+        "metadata": {
+            "documentation_link": "https://docs.oracle.com/en/cloud/saas/supply-chain-management/24d/fasrp/op-customerreturns-post.html"
+        }
+    }
+]


### PR DESCRIPTION
## What this adds

Three Oracle Cloud API datasets covering enterprise modules that are currently missing from the APIZoo:

| File | Endpoints | Modules Covered |
|---|---|---|
| `REST_API_for_Oracle_HCM_Cloud.json` | 25 | Workers, Absences, Jobs, Positions, Departments, Grades, Locations, Payroll Elements, Element Entries, Legislative Data, Terminations, Performance, Goals, Learning, Recruiting, Compensation |
| `REST_API_for_Oracle_SCM_Cloud.json` | 24 | Sales Orders, Inventory Items, On-Hand Quantities, Inventory Transactions, Shipments, Receipts, Work Orders, BOMs, Transfer Orders, Supply Requests, Cycle Counts, Picking Waves, RMAs |
| `REST_API_for_Oracle_Procurement_Cloud.json` | 25 | Purchase Orders, Purchase Requisitions, Suppliers, Supplier Sites, Blanket Purchase Agreements, Negotiations, Invoices, Payments, Spending Categories, Approved Supplier Lists, Supplier Qualifications |

**74 endpoints total** across the three files, all following the existing APIZoo schema used by the other Oracle entries in the repo.

## Why these modules

The existing Oracle entries cover OCI, Primavera, ORDS, Process Automation, Financials, and Integration 3 — but the core ERP modules (HR, supply chain, procurement) were missing. These are among the most widely deployed Oracle Cloud products and represent high-value targets for LLM function-call evaluation.

## Background

I have 16 years of hands-on experience with Oracle ERP and integrations, currently pursuing a Master's in AI/ML. The endpoint signatures, parameter names, and descriptions are drawn from the official Oracle REST API documentation linked in each entry's `metadata.documentation_link`.