### PR TITLE
Add APIBench eval data drift checker

### DIFF
--- a/gorilla/eval/README.md
+++ b/gorilla/eval/README.md
@@ -27,3 +27,18 @@ cd eval-scripts
 python ast_eval_th.py --api_dataset ../../../data/api/torchhub_api.jsonl --apibench ../../../data/apibench/torchhub_eval.json --llm_responses ../eval-data/responses/torchhub/response_torchhub_Gorilla_FT_0_shot.jsonl
 ```
 
+### Checking APIBench Eval Data Drift
+
+APIBench eval questions are represented in both `data/apibench/*_eval.json` and `gorilla/eval/eval-data/questions`.
+To compare the duplicated question text and make drift visible before running benchmarks:
+
+```bash
+python gorilla/eval/check_apibench_eval_data.py
+```
+
+Use `--strict` when wiring the check into CI so any missing, extra, or mismatched question text exits non-zero:
+
+```bash
+python gorilla/eval/check_apibench_eval_data.py --strict
+```
+

--- a/gorilla/eval/check_apibench_eval_data.py
+++ b/gorilla/eval/check_apibench_eval_data.py
@@ -1,0 +1,162 @@
+"""Check APIBench eval question files against canonical APIBench data.
+
+The APIBench eval split is stored in two review-friendly formats:
+
+* ``data/apibench/*_eval.json`` keeps the full prompt/output records.
+* ``gorilla/eval/eval-data/questions`` keeps question-only JSONL files used by
+  evaluation scripts.
+
+This checker compares the normalized instruction text in both locations so data
+drift is visible before benchmark results are generated from stale questions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+DATASET_PATHS = {
+    "huggingface": {
+        "source": Path("data/apibench/huggingface_eval.json"),
+        "questions": Path("gorilla/eval/eval-data/questions/huggingface"),
+        "prefix": "questions_huggingface",
+    },
+    "tensorflow": {
+        "source": Path("data/apibench/tensorflow_eval.json"),
+        "questions": Path("gorilla/eval/eval-data/questions/tensorflowhub"),
+        "prefix": "questions_tensorflowhub",
+    },
+    "torchhub": {
+        "source": Path("data/apibench/torchhub_eval.json"),
+        "questions": Path("gorilla/eval/eval-data/questions/torchhub"),
+        "prefix": "questions_torchhub",
+    },
+}
+
+
+PROMPT_SUFFIX_RE = re.compile(r"\s+Use this API documentation.*", re.DOTALL)
+WHITESPACE_RE = re.compile(r"\s+")
+INSTRUCTION_RE = re.compile(
+    r"###\s*Instruction:\s*(?P<instruction>.*?)(?:###\s*Output:|$)",
+    re.DOTALL,
+)
+
+
+@dataclass
+class FileReport:
+    file: str
+    expected_count: int
+    actual_count: int
+    missing_count: int
+    extra_count: int
+    mismatched_count: int
+
+    @property
+    def ok(self) -> bool:
+        return not (self.missing_count or self.extra_count or self.mismatched_count)
+
+
+def normalize_question_text(text: str) -> str:
+    """Normalize formatting-only differences between APIBench question files."""
+    text = text.replace("\\n", "\n")
+    text = PROMPT_SUFFIX_RE.sub("", text)
+    return WHITESPACE_RE.sub(" ", text).strip()
+
+
+def extract_instruction(code: str) -> str:
+    match = INSTRUCTION_RE.search(code)
+    if not match:
+        raise ValueError("APIBench record does not contain an instruction block")
+    return normalize_question_text(match.group("instruction"))
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    with path.open(encoding="utf-8") as file:
+        return [json.loads(line) for line in file if line.strip()]
+
+
+def read_source_questions(path: Path) -> list[str]:
+    return [extract_instruction(row["code"]) for row in read_jsonl(path)]
+
+
+def read_eval_questions(path: Path) -> list[str]:
+    return [normalize_question_text(row["text"]) for row in read_jsonl(path)]
+
+
+def compare_question_file(
+    repo_root: Path, source_questions: list[str], question_file: Path
+) -> FileReport:
+    eval_questions = read_eval_questions(question_file)
+    expected_set = set(source_questions)
+    actual_set = set(eval_questions)
+    pair_count = min(len(source_questions), len(eval_questions))
+    mismatched_count = sum(
+        1
+        for index in range(pair_count)
+        if source_questions[index] != eval_questions[index]
+    )
+
+    return FileReport(
+        file=str(question_file.relative_to(repo_root)),
+        expected_count=len(source_questions),
+        actual_count=len(eval_questions),
+        missing_count=len(expected_set - actual_set),
+        extra_count=len(actual_set - expected_set),
+        mismatched_count=mismatched_count,
+    )
+
+
+def build_report(repo_root: Path, datasets: list[str]) -> list[FileReport]:
+    reports: list[FileReport] = []
+    for dataset in datasets:
+        paths = DATASET_PATHS[dataset]
+        source_questions = read_source_questions(repo_root / paths["source"])
+        question_dir = repo_root / paths["questions"]
+        for question_file in sorted(question_dir.glob(f'{paths["prefix"]}_*.jsonl')):
+            reports.append(compare_question_file(repo_root, source_questions, question_file))
+    return reports
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Report APIBench eval question drift between duplicated data files."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root containing data/apibench and gorilla/eval/eval-data.",
+    )
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        choices=sorted(DATASET_PATHS),
+        help="Dataset to check. Defaults to all APIBench eval datasets.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when any checked question file has drift.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    datasets = args.dataset or sorted(DATASET_PATHS)
+    reports = build_report(args.repo_root, datasets)
+    payload = {
+        "ok": all(report.ok for report in reports),
+        "reports": [asdict(report) for report in reports],
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 1 if args.strict and not payload["ok"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/gorilla/eval/test_check_apibench_eval_data.py
+++ b/gorilla/eval/test_check_apibench_eval_data.py
@@ -1,0 +1,99 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from check_apibench_eval_data import build_report, normalize_question_text
+
+
+class APIBenchEvalDataCheckTest(unittest.TestCase):
+    def test_normalizes_literal_newlines_and_context_suffix(self):
+        text = " What is an API?\\n \n Use this API documentation: noisy context"
+
+        self.assertEqual(normalize_question_text(text), "What is an API?")
+
+    def test_reports_matching_fixture_as_ok(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "data/apibench/huggingface_eval.json"
+            questions = (
+                root
+                / "gorilla/eval/eval-data/questions/huggingface"
+                / "questions_huggingface_0_shot.jsonl"
+            )
+            source.parent.mkdir(parents=True)
+            questions.parent.mkdir(parents=True)
+            source.write_text(
+                json.dumps(
+                    {
+                        "code": (
+                            "###Instruction: Find a model for sentence similarity.\n"
+                            "###Output: <<<api_call>>>: model()"
+                        )
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            questions.write_text(
+                json.dumps(
+                    {
+                        "question_id": 1,
+                        "text": " Find a model for sentence similarity.\\n",
+                        "category": "generic",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_report(root, ["huggingface"])
+
+        self.assertEqual(len(report), 1)
+        self.assertTrue(report[0].ok)
+
+    def test_reports_missing_and_mismatch(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            source = root / "data/apibench/huggingface_eval.json"
+            questions = (
+                root
+                / "gorilla/eval/eval-data/questions/huggingface"
+                / "questions_huggingface_0_shot.jsonl"
+            )
+            source.parent.mkdir(parents=True)
+            questions.parent.mkdir(parents=True)
+            source.write_text(
+                json.dumps(
+                    {
+                        "code": (
+                            "###Instruction: Expected question.\n"
+                            "###Output: <<<api_call>>>: model()"
+                        )
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            questions.write_text(
+                json.dumps(
+                    {
+                        "question_id": 1,
+                        "text": "Different question.",
+                        "category": "generic",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_report(root, ["huggingface"])[0]
+
+        self.assertFalse(report.ok)
+        self.assertEqual(report.missing_count, 1)
+        self.assertEqual(report.extra_count, 1)
+        self.assertEqual(report.mismatched_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add an APIBench eval-data drift checker that compares `data/apibench/*_eval.json` with `gorilla/eval/eval-data/questions`.
- Normalize formatting-only differences such as literal `\n` markers and retriever prompt suffixes before comparing question text.
- Document report mode and `--strict` mode so maintainers can inspect current drift first, then wire the guard into CI when ready.

## Why
Issue #87 calls out duplicated APIBench eval data in two formats. This PR keeps the existing files intact and adds a small guardrail that makes missing, extra, or mismatched duplicated question text visible before benchmark runs rely on stale data.

Evidence limits:
- This PR does not remove the duplicated datasets.
- This PR does not repair all current APIBench data drift.
- The checker reports drift from the local files in this repository; it does not certify benchmark correctness.
- The report-mode command exits 0 by design so maintainers can inspect today’s drift before deciding whether to enforce `--strict` in CI.

I prepared this through an AANA-gated community issue workflow: the gate was used only to keep the contribution narrow, evidence-bound, and reviewable. It is not a runtime dependency and does not claim to certify benchmark correctness.

## Verification
- `python -m unittest test_check_apibench_eval_data.py`
- `python -m py_compile gorilla\eval\check_apibench_eval_data.py gorilla\eval\test_check_apibench_eval_data.py`
- `python gorilla\eval\check_apibench_eval_data.py` reports existing drift and exits 0 in report mode.

Note: `python -m unittest discover gorilla\eval -p 'test_*.py'` currently hits an unrelated import-time Pydantic v2 error in `gorilla/eval/retrievers/schema.py` via the existing `retrievers` package import.

Closes #87
