### PR TITLE
feat: add LiteLLM handler for benchmarking any LiteLLM-supported model

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -11,6 +11,7 @@ from bfcl_eval.model_handler.api_inference.gemini import GeminiHandler
 from bfcl_eval.model_handler.api_inference.glm import GLMAPIHandler
 from bfcl_eval.model_handler.api_inference.gogoagent import GoGoAgentHandler
 from bfcl_eval.model_handler.api_inference.gorilla import GorillaHandler
+from bfcl_eval.model_handler.api_inference.litellm_handler import LiteLLMHandler
 from bfcl_eval.model_handler.api_inference.grok import GrokHandler
 from bfcl_eval.model_handler.api_inference.kimi import KimiHandler
 from bfcl_eval.model_handler.api_inference.ling import LingAPIHandler
@@ -2230,11 +2231,58 @@ third_party_inference_model_map = {
 }
 
 
-MODEL_CONFIG_MAPPING = {
-    **api_inference_model_map,
-    **local_inference_model_map,
-    **third_party_inference_model_map,
-}
+def _resolve_litellm_model(registry_name: str) -> ModelConfig:
+    """Dynamically create a ModelConfig for any litellm/<provider>/<model> key.
+
+    Append ``-FC`` to the registry name to run in function-calling mode::
+
+        bfcl generate --model "litellm/groq/llama-3.3-70b-versatile-FC"
+        bfcl generate --model "litellm/together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo"
+
+    Provider API keys are read from the environment automatically by LiteLLM
+    (e.g. GROQ_API_KEY, TOGETHERAI_API_KEY).
+    See https://docs.litellm.ai/docs/providers for the full provider list.
+    """
+    is_fc = registry_name.endswith("-FC")
+    litellm_model = registry_name[len("litellm/"):]
+    if is_fc:
+        litellm_model = litellm_model[: -len("-FC")]
+
+    mode = "FC" if is_fc else "Prompt"
+    return ModelConfig(
+        model_name=litellm_model,
+        display_name=f"{litellm_model} ({mode}) (via LiteLLM)",
+        url="https://docs.litellm.ai/docs/providers",
+        org="LiteLLM",
+        license="MIT",
+        model_handler=LiteLLMHandler,
+        is_fc_model=is_fc,
+    )
+
+
+class _LiteLLMAwareConfigMap(dict):
+    """A dict that dynamically resolves ``litellm/`` prefixed model keys."""
+
+    def __missing__(self, key):
+        if isinstance(key, str) and key.startswith("litellm/"):
+            config = _resolve_litellm_model(key)
+            self[key] = config
+            return config
+        raise KeyError(key)
+
+    def __contains__(self, key):
+        if super().__contains__(key):
+            return True
+        return isinstance(key, str) and key.startswith("litellm/")
+
+
+MODEL_CONFIG_MAPPING = _LiteLLMAwareConfigMap(
+    {
+        **api_inference_model_map,
+        **local_inference_model_map,
+        **third_party_inference_model_map,
+    }
+)
 
 # Uncomment to get the supported_models.py file contents
 # print(repr(list(MODEL_CONFIG_MAPPING.keys())))

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/litellm_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/litellm_handler.py
@@ -1,0 +1,248 @@
+import json
+import time
+from typing import Any
+
+import litellm
+from bfcl_eval.constants.enums import ModelStyle
+from bfcl_eval.constants.type_mappings import GORILLA_TO_OPENAPI
+from bfcl_eval.model_handler.base_handler import BaseHandler
+from bfcl_eval.model_handler.utils import (
+    convert_to_function_call,
+    convert_to_tool,
+    default_decode_ast_prompting,
+    default_decode_execute_prompting,
+    format_execution_results_prompting,
+    retry_with_backoff,
+    system_prompt_pre_processing_chat_model,
+)
+
+
+class LiteLLMHandler(BaseHandler):
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
+        self.model_style = ModelStyle.OPENAI_COMPLETIONS
+
+    def decode_ast(self, result, language, has_tool_call_tag):
+        if self.is_fc_model:
+            decoded_output = []
+            for invoked_function in result:
+                name = list(invoked_function.keys())[0]
+                params = json.loads(invoked_function[name])
+                decoded_output.append({name: params})
+            return decoded_output
+        else:
+            return default_decode_ast_prompting(result, language, has_tool_call_tag)
+
+    def decode_execute(self, result, has_tool_call_tag):
+        if self.is_fc_model:
+            return convert_to_function_call(result)
+        else:
+            return default_decode_execute_prompting(result, has_tool_call_tag)
+
+    @retry_with_backoff(error_type=litellm.RateLimitError)
+    def generate_with_backoff(self, **kwargs):
+        start_time = time.time()
+        api_response = litellm.completion(**kwargs)
+        end_time = time.time()
+
+        return api_response, end_time - start_time
+
+    #### FC methods ####
+
+    def _query_FC(self, inference_data: dict):
+        message: list[dict] = inference_data["message"]
+        tools = inference_data["tools"]
+        inference_data["inference_input_log"] = {"message": repr(message), "tools": tools}
+
+        kwargs = {
+            "messages": message,
+            "model": self.model_name,
+            "temperature": self.temperature,
+        }
+
+        if len(tools) > 0:
+            kwargs["tools"] = tools
+
+        return self.generate_with_backoff(**kwargs)
+
+    def _pre_query_processing_FC(self, inference_data: dict, test_entry: dict) -> dict:
+        inference_data["message"] = []
+        return inference_data
+
+    def _compile_tools(self, inference_data: dict, test_entry: dict) -> dict:
+        functions: list = test_entry["function"]
+
+        tools = convert_to_tool(functions, GORILLA_TO_OPENAPI, self.model_style)
+
+        inference_data["tools"] = tools
+
+        return inference_data
+
+    def _parse_query_response_FC(self, api_response: Any) -> dict:
+        try:
+            model_responses = [
+                {func_call.function.name: func_call.function.arguments}
+                for func_call in api_response.choices[0].message.tool_calls
+            ]
+            tool_call_ids = [
+                func_call.id for func_call in api_response.choices[0].message.tool_calls
+            ]
+        except (AttributeError, TypeError):
+            model_responses = api_response.choices[0].message.content
+            tool_call_ids = []
+
+        model_responses_message_for_chat_history = api_response.choices[0].message
+
+        result = {
+            "model_responses": model_responses,
+            "model_responses_message_for_chat_history": model_responses_message_for_chat_history,
+            "tool_call_ids": tool_call_ids,
+            "input_token": api_response.usage.prompt_tokens,
+            "output_token": api_response.usage.completion_tokens,
+        }
+
+        self._add_reasoning_content_if_available(api_response, result)
+
+        return result
+
+    def add_first_turn_message_FC(
+        self, inference_data: dict, first_turn_message: list[dict]
+    ) -> dict:
+        inference_data["message"].extend(first_turn_message)
+        return inference_data
+
+    def _add_next_turn_user_message_FC(
+        self, inference_data: dict, user_message: list[dict]
+    ) -> dict:
+        inference_data["message"].extend(user_message)
+        return inference_data
+
+    def _add_assistant_message_FC(
+        self, inference_data: dict, model_response_data: dict
+    ) -> dict:
+        inference_data["message"].append(
+            model_response_data["model_responses_message_for_chat_history"]
+        )
+        return inference_data
+
+    def _add_execution_results_FC(
+        self,
+        inference_data: dict,
+        execution_results: list[str],
+        model_response_data: dict,
+    ) -> dict:
+        for execution_result, tool_call_id in zip(
+            execution_results, model_response_data["tool_call_ids"]
+        ):
+            tool_message = {
+                "role": "tool",
+                "content": execution_result,
+                "tool_call_id": tool_call_id,
+            }
+            inference_data["message"].append(tool_message)
+
+        return inference_data
+
+    #### Prompting methods ####
+
+    def _query_prompting(self, inference_data: dict):
+        inference_data["inference_input_log"] = {"message": repr(inference_data["message"])}
+
+        return self.generate_with_backoff(
+            messages=inference_data["message"],
+            model=self.model_name,
+            temperature=self.temperature,
+        )
+
+    def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
+        functions: list = test_entry["function"]
+        test_entry_id: str = test_entry["id"]
+
+        test_entry["question"][0] = system_prompt_pre_processing_chat_model(
+            test_entry["question"][0], functions, test_entry_id
+        )
+
+        return {"message": []}
+
+    def _parse_query_response_prompting(self, api_response: Any) -> dict:
+        result = {
+            "model_responses": api_response.choices[0].message.content,
+            "model_responses_message_for_chat_history": api_response.choices[0].message,
+            "input_token": api_response.usage.prompt_tokens,
+            "output_token": api_response.usage.completion_tokens,
+        }
+
+        self._add_reasoning_content_if_available(api_response, result)
+
+        return result
+
+    def add_first_turn_message_prompting(
+        self, inference_data: dict, first_turn_message: list[dict]
+    ) -> dict:
+        inference_data["message"].extend(first_turn_message)
+        return inference_data
+
+    def _add_next_turn_user_message_prompting(
+        self, inference_data: dict, user_message: list[dict]
+    ) -> dict:
+        inference_data["message"].extend(user_message)
+        return inference_data
+
+    def _add_assistant_message_prompting(
+        self, inference_data: dict, model_response_data: dict
+    ) -> dict:
+        inference_data["message"].append(
+            model_response_data["model_responses_message_for_chat_history"]
+        )
+        return inference_data
+
+    def _add_execution_results_prompting(
+        self, inference_data: dict, execution_results: list[str], model_response_data: dict
+    ) -> dict:
+        formatted_results_message = format_execution_results_prompting(
+            inference_data, execution_results, model_response_data
+        )
+        inference_data["message"].append(
+            {"role": "user", "content": formatted_results_message}
+        )
+
+        return inference_data
+
+    def _add_reasoning_content_if_available(
+        self, api_response: Any, response_data: dict
+    ) -> None:
+        message = api_response.choices[0].message
+
+        if getattr(message, "tool_calls", None) and hasattr(message, "reasoning_content"):
+            assistant_message = {
+                "role": "assistant",
+                "content": message.content,
+                "tool_calls": [
+                    {
+                        "id": tool_call.id,
+                        "type": tool_call.type,
+                        "function": {
+                            "name": tool_call.function.name,
+                            "arguments": tool_call.function.arguments,
+                        },
+                    }
+                    for tool_call in message.tool_calls
+                ],
+            }
+            response_data["model_responses_message_for_chat_history"] = assistant_message
+
+        elif hasattr(message, "reasoning_content") and message.reasoning_content:
+            response_data["model_responses_message_for_chat_history"] = {
+                "role": "assistant",
+                "content": message.content,
+            }
+
+        if hasattr(message, "reasoning_content") and message.reasoning_content:
+            response_data["reasoning_content"] = message.reasoning_content

--- a/berkeley-function-call-leaderboard/pyproject.toml
+++ b/berkeley-function-call-leaderboard/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
     "sentence-transformers>=2.7.0",
     "faiss-cpu==1.11.0",
     "networkx==3.3",
-    "filelock==3.20.0"
+    "filelock==3.20.0",
+    "litellm>=1.67.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Adds [LiteLLM](https://github.com/BerriAI/litellm) as a new model handler, enabling benchmarking of **any of LiteLLM's 100+ supported LLM providers** on the Berkeley Function Calling Leaderboard without writing a dedicated handler for each provider.


```bash
# Function-calling mode (append -FC)
bfcl generate --model "litellm/groq/llama-3.3-70b-versatile-FC"

# Prompting mode
bfcl generate --model "litellm/together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo"

# Any LiteLLM-supported provider works
bfcl generate --model "litellm/deepinfra/meta-llama/Llama-3.3-70B-Instruct-FC"
```

Provider API keys are read from environment variables automatically by LiteLLM (e.g. `GROQ_API_KEY`, `TOGETHERAI_API_KEY`). See [LiteLLM provider docs](https://docs.litellm.ai/docs/providers) for the full list.

## Changes

| File | What |
|------|------|
| `bfcl_eval/model_handler/api_inference/litellm_handler.py` | New `LiteLLMHandler(BaseHandler)` using `litellm.completion()`. Supports FC + prompting modes, reasoning content extraction, rate limit retry. |
| `bfcl_eval/constants/model_config.py` | Import `LiteLLMHandler`, add `_resolve_litellm_model()` for dynamic `ModelConfig` creation, replace `MODEL_CONFIG_MAPPING` dict with `_LiteLLMAwareConfigMap` subclass that intercepts `litellm/` prefixed keys. |
| `pyproject.toml` | Add `litellm>=1.67.0` to dependencies. |

## Design decisions

- **Uses `ModelStyle.OPENAI_COMPLETIONS`** for tool formatting because `litellm.completion()` returns OpenAI chat-completions-compatible responses regardless of the underlying provider.
- **Dynamic resolution via `__missing__`/`__contains__`** on a dict subclass so that `MODEL_CONFIG_MAPPING["litellm/groq/llama-3.3-70b-versatile-FC"]` works transparently. Results are cached after first lookup. Non-`litellm/` keys behave identically to before.
- **`-FC` suffix convention** mirrors existing BFCL convention (e.g. `gpt-4o-2024-11-20-FC`). The suffix is stripped before passing the model string to LiteLLM.
- **Reasoning content handling** follows the same pattern as `OpenAICompletionsHandler._add_reasoning_content_if_available` -- strips `reasoning_content` from chat history while preserving it in metadata.

## Testing

**Dynamic model resolution:**
```python
from bfcl_eval.constants.model_config import MODEL_CONFIG_MAPPING
print('Static models:', len(MODEL_CONFIG_MAPPING))
print('litellm/ dynamic:', 'litellm/groq/llama-3.3-70b-versatile' in MODEL_CONFIG_MAPPING)
cfg = MODEL_CONFIG_MAPPING['litellm/groq/llama-3.3-70b-versatile-FC']
print('FC model_name:', cfg.model_name, '| is_fc:', cfg.is_fc_model)
cfg2 = MODEL_CONFIG_MAPPING['litellm/together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo']
print('Prompt model_name:', cfg2.model_name, '| is_fc:', cfg2.is_fc_model)
try:
    MODEL_CONFIG_MAPPING['nonexistent-model']
except KeyError:
    print('KeyError raised correctly for unknown model')
```
```
Static models: 175
litellm/ dynamic: True
FC model_name: groq/llama-3.3-70b-versatile | is_fc: True
Prompt model_name: together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo | is_fc: False
KeyError raised correctly for unknown model
```

**Live e2e -- FC mode (function calling):**
```python
import litellm, json
tools = [{'type': 'function', 'function': {'name': 'get_weather', ...}}]
resp = litellm.completion(
    model='anthropic/claude-sonnet-4-6', tools=tools,
    messages=[{'role': 'user', 'content': 'Weather in San Francisco in celsius?'}],
)
msg = resp.choices[0].message
for tc in msg.tool_calls:
    print(f'name: {tc.function.name}  args: {tc.function.arguments}  id: {tc.id}')
```

```
name: get_weather  args: {"city": "San Francisco", "unit": "celsius"}  id: toolu_01N95RbdCNUDhWXLEMWm3jZD
```

**Live e2e -- Multi-turn with tool results:**
```
# After feeding tool result {"temperature": 18, "unit": "celsius", "condition": "foggy"} back:
content: The current weather in San Francisco is 18°C and foggy.
tool_calls: None
```

**Live e2e -- Full BFCL pipeline with real test data:**
```python
from bfcl_eval.eval_checker.eval_runner import get_handler
from huggingface_hub import hf_hub_download
import json

path = hf_hub_download(repo_id='gorilla-llm/Berkeley-Function-Calling-Leaderboard',
                       filename='BFCL_v3_simple.json', repo_type='dataset')
with open(path) as f:
    test_entry = json.loads(f.readline())

handler = get_handler('litellm/anthropic/claude-sonnet-4-6-FC')
result, metadata = handler.inference(test_entry, include_input_log=False, exclude_state_log=True)
print('Test ID:', test_entry['id'])
print('model_responses:', result)
print('input_tokens:', metadata.get('input_token_count'))
print('latency:', round(metadata.get('latency', 0), 2), 'sec')
```

```
Test ID: simple_0
model_responses: [{'calculate_triangle_area': '{"base": 10, "height": 5, "unit": "units"}'}]
input_tokens: 649
latency: 3.22 sec
```

**Live e2e -- Prompting mode:**
```
handler = get_handler('litellm/anthropic/claude-sonnet-4-6')
result, metadata = handler.inference(test_entry, ...)

model_responses: [get_weather(city="San Francisco", unit="celsius")]
input_tokens: 401
```

**decode_ast / decode_execute:**
```
# FC result
decode_ast:     [{'get_weather': {'city': 'San Francisco', 'unit': 'celsius'}}]
decode_execute: ["get_weather(city='San Francisco',unit='celsius')"]

# Prompting result
decode_ast:     [{'get_weather': {'city': 'San Francisco', 'unit': 'celsius'}}]
decode_execute: ["get_weather(city='San Francisco', unit='celsius')"]
```

**Error handling -- missing API key:**
```
Error type: BadRequestError
Error: litellm.BadRequestError: GroqException - {"error":{"message":"Invalid API Key",...}}
```

**Backward compatibility -- existing models unaffected:**
- 175 static model entries still resolve correctly
- Non-`litellm/` unknown keys raise `KeyError` as expected
