### PR TITLE
Add Gemma 4 (26B A4B) prompt-mode handler

### DIFF
--- a/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
+++ b/berkeley-function-call-leaderboard/SUPPORTED_MODELS.md
@@ -52,6 +52,7 @@ For model names containing `{...}`, multiple versions are available. For example
 | Gemini-3.1-Flash-Lite-Preview          | Function Calling | Google         | gemini-3.1-flash-lite-preview-FC                            |
 | Gemini-3.1-Flash-Lite-Preview          | Prompt           | Google         | gemini-3.1-flash-lite-preview                               |
 | Gemma-3-{1b,4b,12b,27b}-it             | Prompt           | Self-hosted 💻 | google/gemma-3-{1b,4b,12b,27b}-it                           |
+| Gemma-4-26B-A4B-it                     | Prompt           | Self-hosted 💻 | google/gemma-4-26B-A4B-it                                   |
 | FunctionGemma-270m-it                  | Function Calling | Self-hosted 💻 | google/functiongemma-270m-it-FC                             |
 | GLM-4-9b-Chat                          | Function Calling | Self-hosted 💻 | THUDM/glm-4-9b-chat                                         |
 | GLM-4.5                                | Function Calling | Zhipu AI       | glm-4.5-FC                                                  |

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -39,6 +39,7 @@ from bfcl_eval.model_handler.local_inference.deepseek_reasoning import (
 )
 from bfcl_eval.model_handler.local_inference.falcon_fc import Falcon3FCHandler
 from bfcl_eval.model_handler.local_inference.gemma import GemmaHandler
+from bfcl_eval.model_handler.local_inference.gemma4 import Gemma4Handler
 from bfcl_eval.model_handler.local_inference.functiongemma import FunctionGemmaHandler
 from bfcl_eval.model_handler.local_inference.glm import GLMHandler
 from bfcl_eval.model_handler.local_inference.granite import (
@@ -1283,6 +1284,18 @@ local_inference_model_map = {
         input_price=None,
         output_price=None,
         is_fc_model=True,
+        underscore_to_dot=False,
+    ),
+    "google/gemma-4-26B-A4B-it": ModelConfig(
+        model_name="google/gemma-4-26B-A4B-it",
+        display_name="Gemma-4-26B-A4B-it (Prompt)",
+        url="https://blog.google/technology/developers/gemma-4/",
+        org="Google",
+        license="gemma-terms-of-use",
+        model_handler=Gemma4Handler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=False,
         underscore_to_dot=False,
     ),
     "meta-llama/Llama-3.1-8B-Instruct-FC": ModelConfig(

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
@@ -109,6 +109,7 @@ SUPPORTED_MODELS = [
     "google/gemma-3-4b-it",
     "google/gemma-3-12b-it",
     "google/gemma-3-27b-it",
+    "google/gemma-4-26B-A4B-it",
     "google/functiongemma-270m-it-FC",
     "meta-llama/Llama-3.1-8B-Instruct-FC",
     "meta-llama/Llama-3.1-8B-Instruct",

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gemma4.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/local_inference/gemma4.py
@@ -1,0 +1,152 @@
+import re
+
+from bfcl_eval.model_handler.local_inference.base_oss_handler import OSSHandler
+from bfcl_eval.model_handler.utils import (
+    combine_consecutive_user_prompts,
+    default_decode_ast_prompting,
+    default_decode_execute_prompting,
+    system_prompt_pre_processing_chat_model,
+)
+from overrides import override
+
+
+# Gemma 4 emits tool calls as: <|tool_call>call:func(args)<tool_call|>
+# Asymmetric delimiters — opener has no trailing pipe, closer has no leading
+# pipe. Multi-call responses concatenate back-to-back with no separator.
+_GEMMA4_NATIVE_CALL_RE = re.compile(
+    r"<\|tool_call>\s*(.*?)\s*<tool_call\|>",
+    re.DOTALL,
+)
+
+# Top-level `key:` -> `key=` for the JSON-dict-args quirk. Only matches at
+# string start or after a comma to avoid hitting colons inside string values.
+_DICT_KEY_RE = re.compile(r"(^|,\s*)(\w+)\s*:")
+
+
+def _normalize_call(inner: str) -> str | None:
+    """Normalize one captured tool-call body to a Python call expression.
+
+    Handles known model-emission quirks: fullwidth colon, `call[...]` wrapper,
+    `name{}` empty-args, `name{key: val}` JSON-dict-args. Returns None if the
+    body has an unknown shape — the caller drops it from the converted list.
+    """
+    s = inner.strip().replace("：", ":")  # fullwidth -> ASCII colon
+
+    if s.startswith("call:"):
+        s = s[len("call:"):].lstrip()
+    elif s.startswith("call["):
+        s = s[len("call["):].lstrip()
+        if s.endswith("]"):
+            s = s[:-1].rstrip()
+    else:
+        return None
+
+    m = re.fullmatch(r"(\w+)\{\}", s)
+    if m:
+        return f"{m.group(1)}()"
+
+    m = re.fullmatch(r"(\w+)\{(.+)\}", s, re.DOTALL)
+    if m:
+        name, body = m.group(1), m.group(2)
+        args = _DICT_KEY_RE.sub(r"\1\2=", body)
+        return f"{name}({args})"
+
+    return s
+
+
+def _gemma4_native_to_bfcl(result: str) -> str:
+    """Rewrite Gemma 4 native tool-call syntax into BFCL's `[func(args), ...]`.
+
+    Returns the input unchanged if no native markers are present, so
+    responses already in BFCL format (turn-0 system-prompt-driven) and
+    plain-prose refusals fall through to the default decoder unchanged.
+    """
+    matches = _GEMMA4_NATIVE_CALL_RE.findall(result)
+    if not matches:
+        return result
+    normalized = [n for n in (_normalize_call(m) for m in matches) if n is not None]
+    if not normalized:
+        return result
+    return "[" + ", ".join(normalized) + "]"
+
+
+class Gemma4Handler(OSSHandler):
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        dtype="bfloat16",
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
+        self._ctx_fixed = False
+
+    def _fix_context_length(self):
+        if not self._ctx_fixed:
+            # Gemma 4 is multimodal; the top-level HF config lacks
+            # max_position_embeddings (it lives under text_config), so
+            # spin_up_local_server falls back to the tokenizer sentinel (~10^18).
+            # The real value is 262144, from config.text_config.
+            self.max_context_length = 262144
+            self._ctx_fixed = True
+
+    @override
+    def inference(self, test_entry, include_input_log, exclude_state_log):
+        self._fix_context_length()
+        return super().inference(test_entry, include_input_log, exclude_state_log)
+
+    @override
+    def _format_prompt(self, messages, function):
+        return self.tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, tokenize=False
+        )
+
+    @override
+    def decode_ast(self, result, language, has_tool_call_tag):
+        return default_decode_ast_prompting(
+            _gemma4_native_to_bfcl(result), language, has_tool_call_tag
+        )
+
+    @override
+    def decode_execute(self, result, has_tool_call_tag):
+        return default_decode_execute_prompting(
+            _gemma4_native_to_bfcl(result), has_tool_call_tag
+        )
+
+    @override
+    def _add_execution_results_prompting(
+        self, inference_data: dict, execution_results: list[str], model_response_data: dict
+    ) -> dict:
+        # Gemma 4's chat template silently drops messages with role="tool"
+        # (the BFCL default). It renders role="tool_response" as a proper
+        # turn, so the model sees tool feedback. Without this override the
+        # model runs blind in multi-turn and loops on failed actions.
+        for execution_result, decoded_model_response in zip(
+            execution_results, model_response_data["model_responses_decoded"]
+        ):
+            inference_data["message"].append(
+                {
+                    "role": "tool_response",
+                    "name": decoded_model_response,
+                    "content": execution_result,
+                }
+            )
+        return inference_data
+
+    @override
+    def _pre_query_processing_prompting(self, test_entry: dict) -> dict:
+        functions: list = test_entry["function"]
+        test_entry_id: str = test_entry["id"]
+
+        test_entry["question"][0] = system_prompt_pre_processing_chat_model(
+            test_entry["question"][0], functions, test_entry_id
+        )
+
+        for round_idx in range(len(test_entry["question"])):
+            test_entry["question"][round_idx] = combine_consecutive_user_prompts(
+                test_entry["question"][round_idx]
+            )
+
+        return {"message": [], "function": functions}


### PR DESCRIPTION
## Summary

Adds a prompt-mode handler for Google **Gemma 4 26B A4B Instruct**
(`google/gemma-4-26B-A4B-it`), which BFCL does not currently support. The
existing Gemma 3 handler hardcodes the Gemma 3 chat template and is
incompatible with Gemma 4's new turn-token format, so a dedicated handler is
needed.

To my knowledge these are the first BFCL numbers published for Gemma 4. Full
methodology, per-category scores, and reproduction commands:
https://algollabs.com/blog/gemma4-bfcl

## What this changes

- **New** `bfcl_eval/model_handler/local_inference/gemma4.py` — `Gemma4Handler`
  (subclasses `OSSHandler`).
- **Modified** `bfcl_eval/constants/model_config.py` — register the model + import.
- **Modified** `bfcl_eval/constants/supported_models.py` — add the model id.
- **Modified** `SUPPORTED_MODELS.md` — add the table row.

## Implementation notes

1. **Chat template.** `_format_prompt` delegates to
   `tokenizer.apply_chat_template(...)` so the correct Gemma 4 template is
   picked up from the HF tokenizer (same approach as `QuickTestingOSSHandler`),
   rather than hardcoding tokens like the Gemma 3 handler.

2. **Native tool-call syntax (`decode_ast` / `decode_execute`).** With
   `--jinja`, Gemma 4 emits `<|tool_call>call:fn(arg="x")<tool_call|>` rather
   than the legacy `[fn(arg="x")]`. Single-turn cases are coerced by the
   system-prompt preprocessing; in multi-turn the model reverts to native
   syntax and the default parser fails ("Failed to decode the model response").
   A small converter rewrites native → BFCL form before delegating to the
   default decoder, handling five observed emission variants (standard,
   empty-args, bracket-prefix, fullwidth colon, JSON-dict args). Responses
   already in BFCL format and plain-prose refusals pass through untouched.

3. **Tool results in multi-turn (`_add_execution_results_prompting`).** The
   Gemma 4 chat template silently drops `role="tool"` messages (BFCL's
   default), so the model never sees tool feedback and loops on failed
   actions. Switching to `role="tool_response"`, which the template renders,
   is required — multi-turn accuracy floors at ~3% without it.

4. **Context-length detection.** Gemma 4 is multimodal; its top-level HF config
   has no `max_position_embeddings` (it lives under `text_config`), so
   `spin_up_local_server` falls back to the tokenizer sentinel (~1e18). The
   handler corrects `max_context_length` to the real value, 262144. See the
   open question below.

## Evaluation details

- Prompt mode (`is_fc_model=False`).
- Sampling used for the published run: `temperature=1.0, top_p=0.95, top_k=64`
  per Google's Gemma guidance (BFCL default is 0.001).
- Open-weight model, publicly accessible on Hugging Face.

## Open question for maintainers

The context-length fix is currently handler-local (corrected in `inference()`
because `spin_up_local_server` is decorated `@final`). The root cause is
generic to multimodal HF configs, so it may belong in `base_oss_handler.py`
instead — reading `text_config.max_position_embeddings` when the top-level
attribute is absent. Happy to move it there if you'd prefer the general fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
