### PR TITLE
[BFCL] Fix ZeroDivisionError in memory kv backend when searching an empty memory

### DIFF
--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
-- [Oct 1, 2025] [#1177](https://github.com/ShishirPatil/gorilla/pull/1177): Fix ground truth for `multi_turn_base_154`.
+- [Jul 16, 2026] [#1347](https://github.com/ShishirPatil/gorilla/pull/1347): Fix ZeroDivisionError in the memory kv backend when core_memory_key_search or archival_memory_key_search is called on an empty memory store.
+- - [Oct 1, 2025] [#1177](https://github.com/ShishirPatil/gorilla/pull/1177): Fix ground truth for `multi_turn_base_154`.
 - [Sep 27, 2025] [#1185](https://github.com/ShishirPatil/gorilla/pull/1185): Introduce the `--partial-eval` flag to the `bfcl evaluate` command, allowing partial evaluation on a subset of available test entries in the model result files.
 - [Sep 17, 2025] [#1175](https://github.com/ShishirPatil/gorilla/pull/1175): Fix wrong date in ground truth for `live_simple_205-116-13`.
 - [Jul 17, 2025] [#1019](https://github.com/ShishirPatil/gorilla/pull/1019): BFCL V4 release:

--- a/berkeley-function-call-leaderboard/CHANGELOG.md
+++ b/berkeley-function-call-leaderboard/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Berkeley Function Calling Leaderboard will be documented in this file.
 
 - [Jul 16, 2026] [#1347](https://github.com/ShishirPatil/gorilla/pull/1347): Fix ZeroDivisionError in the memory kv backend when core_memory_key_search or archival_memory_key_search is called on an empty memory store.
-- - [Oct 1, 2025] [#1177](https://github.com/ShishirPatil/gorilla/pull/1177): Fix ground truth for `multi_turn_base_154`.
+- [Oct 1, 2025] [#1177](https://github.com/ShishirPatil/gorilla/pull/1177): Fix ground truth for `multi_turn_base_154`.
 - [Sep 27, 2025] [#1185](https://github.com/ShishirPatil/gorilla/pull/1185): Introduce the `--partial-eval` flag to the `bfcl evaluate` command, allowing partial evaluation on a subset of available test entries in the model result files.
 - [Sep 17, 2025] [#1175](https://github.com/ShishirPatil/gorilla/pull/1175): Fix wrong date in ground truth for `live_simple_205-116-13`.
 - [Jul 17, 2025] [#1019](https://github.com/ShishirPatil/gorilla/pull/1019): BFCL V4 release:

--- a/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/multi_turn_eval/func_source_code/memory_kv.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/multi_turn_eval/func_source_code/memory_kv.py
@@ -80,7 +80,12 @@ class MemoryAPI_kv(MemoryAPI):
         Returns:
             ranked_results (list[tuple[float, str]]): A list of tuples containing the BM25+ score and the text string.
         """
-        tokenized_corpus = [text.replace("_", " ").lower().split() for text in corpus]
+        # BM25Plus divides by the corpus size when computing the average document
+        # length, so an empty corpus raises ZeroDivisionError. Searching an empty
+        # memory is a valid operation that should simply return no matches.
+                if not corpus:
+                                return {"ranked_results": []}
+                    tokenized_corpus = [text.replace("_", " ").lower().split() for text in corpus]
         bm25 = BM25Plus(tokenized_corpus)
         tokenized_query = query.replace("_", " ").lower().split()
         scores = bm25.get_scores(tokenized_query)

--- a/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/multi_turn_eval/func_source_code/memory_kv.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/eval_checker/multi_turn_eval/func_source_code/memory_kv.py
@@ -83,9 +83,9 @@ class MemoryAPI_kv(MemoryAPI):
         # BM25Plus divides by the corpus size when computing the average document
         # length, so an empty corpus raises ZeroDivisionError. Searching an empty
         # memory is a valid operation that should simply return no matches.
-                if not corpus:
-                                return {"ranked_results": []}
-                    tokenized_corpus = [text.replace("_", " ").lower().split() for text in corpus]
+        if not corpus:
+            return {"ranked_results": []}
+        tokenized_corpus = [text.replace("_", " ").lower().split() for text in corpus]
         bm25 = BM25Plus(tokenized_corpus)
         tokenized_query = query.replace("_", " ").lower().split()
         scores = bm25.get_scores(tokenized_query)


### PR DESCRIPTION
## Summary

core_memory_key_search and archival_memory_key_search in the kv memory backend raise ZeroDivisionError: division by zero when the corresponding memory store is empty, instead of returning an empty result set.

## Root cause

Both methods pass the key list straight to _similarity_search without checking for emptiness:

```python
keys = deepcopy(list(self.archival_memory.keys()))
return self._similarity_search(query, keys, k)
```

_similarity_search then builds a BM25 index from that (possibly empty) corpus:

```python
tokenized_corpus = [text.replace("_", " ").lower().split() for text in corpus]
bm25 = BM25Plus(tokenized_corpus)
```

rank_bm25's BM25._initialize ends with self.avgdl = num_doc / self.corpus_size. For an empty corpus the loop never runs, corpus_size stays 0, and the division raises.

## Reproduction

```python
from bfcl_eval.eval_checker.multi_turn_eval.func_source_code.memory_kv import MemoryAPI_kv

m = MemoryAPI_kv()
m.archival_memory_key_search("vacation")  # ZeroDivisionError: division by zero
m.core_memory_key_search("vacation")      # ZeroDivisionError: division by zero
```

## Impact

The eval run does not crash: execute_multi_turn_func_call in multi_turn_utils.py catches the exception and appends "Error during execution: division by zero" to the execution results. The model therefore sees a backend error message in its context rather than a legitimate empty search result — which is exactly the state a model is in at the start of a memory task, before anything has been written. This penalises a reasonable tool-use pattern (search first, then decide whether to add) and pollutes the evaluation signal.

Notably, the vector backend already guards against this case in memory_vector.py:

```python
def retrieve(self, query: str, top_k: int = 5) -> list[dict[str, str]]:
    if not self._store:
        return []
```

so kv appears to be the only backend missing the guard.

## Fix

Return an empty ranked-results list before constructing the BM25 index. The return shape matches the normal path ({"ranked_results": [...]}), so no caller or prompt contract changes are needed.

## Verification

```
empty core : {'ranked_results': []}
empty arch : {'ranked_results': []}
non-empty  : {'ranked_results': [(1.3862943611198906, 'trip_notes')]}
no match   : {'ranked_results': [(0.0, 'trip_notes')]}
```

Behaviour on non-empty stores is unchanged; only the empty-store path is affected.

## Note on scores

This changes what the model observes in memory test entries where a key_search is issued against an empty store — an error string becomes an empty result. Existing memory-category results may shift slightly and could warrant a re-run for affected models.