### PR TITLE
fix: model finishing with no tool calls gets misreported as a decode error

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/fireworks.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/fireworks.py
@@ -58,17 +58,22 @@ class FireworksHandler(OpenAICompletionsHandler):
         return super()._compile_tools(inference_data, test_entry)
 
     def _parse_query_response_FC(self, api_response: Any) -> dict:
-        try:
+        raw_tool_calls = api_response.choices[0].message.tool_calls
+        if raw_tool_calls:
             model_responses = [
                 {func_call.function.name: func_call.function.arguments}
-                for func_call in api_response.choices[0].message.tool_calls
+                for func_call in raw_tool_calls
             ]
-            tool_calls = [
-                tool_call.model_dump()
-                for tool_call in api_response.choices[0].message.tool_calls
-            ]
-        except:
-            model_responses = api_response.choices[0].message.content
+            tool_calls = [tool_call.model_dump() for tool_call in raw_tool_calls]
+        else:
+            # The model legitimately made no further tool calls (e.g. it already
+            # finished the task and is replying in plain text). `model_responses`
+            # must stay an empty list, not the raw text `content` -- passing text
+            # through here makes downstream `convert_to_function_call` iterate over
+            # the string's characters and crash with `'str' object has no
+            # attribute 'items'`, which gets misreported as a model/decoding
+            # failure even though the model behaved correctly.
+            model_responses = []
             tool_calls = []
 
         return {

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mistral.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/mistral.py
@@ -89,20 +89,25 @@ class MistralHandler(BaseHandler):
         return inference_data
 
     def _parse_query_response_FC(self, api_response: Any) -> dict:
-        try:
+        tool_calls = api_response.choices[0].message.tool_calls
+        if tool_calls:
             model_responses = [
                 {func_call.function.name: func_call.function.arguments}
-                for func_call in api_response.choices[0].message.tool_calls
+                for func_call in tool_calls
             ]
             tool_call_func_names = [
-                func_call.function.name
-                for func_call in api_response.choices[0].message.tool_calls
+                func_call.function.name for func_call in tool_calls
             ]
-            tool_call_ids = [
-                func_call.id for func_call in api_response.choices[0].message.tool_calls
-            ]
-        except:
-            model_responses = api_response.choices[0].message.content
+            tool_call_ids = [func_call.id for func_call in tool_calls]
+        else:
+            # The model legitimately made no further tool calls (e.g. it already
+            # finished the task and is replying in plain text). `model_responses`
+            # must stay an empty list, not the raw text `content` -- passing text
+            # through here makes downstream `convert_to_function_call` iterate over
+            # the string's characters and crash with `'str' object has no
+            # attribute 'items'`, which gets misreported as a model/decoding
+            # failure even though the model behaved correctly.
+            model_responses = []
             tool_call_func_names = []
             tool_call_ids = []
 

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
@@ -107,16 +107,24 @@ class OpenAICompletionsHandler(BaseHandler):
         return inference_data
 
     def _parse_query_response_FC(self, api_response: Any) -> dict:
-        try:
+        tool_calls = api_response.choices[0].message.tool_calls
+        if tool_calls:
             model_responses = [
                 {func_call.function.name: func_call.function.arguments}
-                for func_call in api_response.choices[0].message.tool_calls
+                for func_call in tool_calls
             ]
-            tool_call_ids = [
-                func_call.id for func_call in api_response.choices[0].message.tool_calls
-            ]
-        except:
-            model_responses = api_response.choices[0].message.content
+            tool_call_ids = [func_call.id for func_call in tool_calls]
+        else:
+            # The model legitimately made no further tool calls (e.g. it already
+            # finished the task and is replying in plain text). This is not an
+            # error, so `model_responses` must stay an empty list rather than the
+            # raw text `content`, which downstream `decode_execute` /
+            # `convert_to_function_call` expect to be a list of function-call
+            # dicts. Passing the text through used to make `convert_to_function_call`
+            # iterate over the string's characters and crash with
+            # `'str' object has no attribute 'items'`, which got misreported as a
+            # model/decoding failure even though the model behaved correctly.
+            model_responses = []
             tool_call_ids = []
 
         model_responses_message_for_chat_history = api_response.choices[0].message


### PR DESCRIPTION
## What

`OpenAICompletionsHandler._parse_query_response_FC()` — and the same
copy-pasted pattern in `MistralHandler` and `FireworksHandler` —
wraps tool_call extraction in a bare `except:`:

```python
try:
    model_responses = [
        {func_call.function.name: func_call.function.arguments}
        for func_call in api_response.choices[0].message.tool_calls
    ]
    ...
except:
    model_responses = api_response.choices[0].message.content
    ...
```

When a model has legitimately finished a multi-turn task and replies
with plain text (no further tool calls needed — completely valid
behavior), `tool_calls` is `None`, the list comprehension raises
`TypeError: 'NoneType' object is not iterable`, and the bare `except`
falls back to treating the raw text `content` as `model_responses`.

That string is then passed to `decode_execute()` →
`convert_to_function_call()`, which assumes a `list[dict]`. Python
happily iterates a string character-by-character, and calling
`.items()` on each single-character string raises:

```
AttributeError: 'str' object has no attribute 'items'
```

which gets caught by the outer handler and logged as
`"Failed to decode the model response"` — indistinguishable from an
actual model/serving failure, even though the model did nothing
wrong.

## Impact

Found while running BFCL v4 `multi_turn` locally across three
different models on three different backends/hardware:

| Model | Model Card | Serving Engine | Hardware |
|---|---|---|---|
| Devstral-Small-2-24B-Instruct-2512-AWQ-4bit | [HF](https://huggingface.co/cyankiwi/Devstral-Small-2-24B-Instruct-2512-AWQ-4bit) | vLLM 0.24.0 (bare-metal / venv) | 1x modded RTX 4090 48GB (PCIe passthrough) |
| Qwen3-Coder-30B-A3B-Instruct-AWQ | [HF](https://huggingface.co/tclf90/Qwen3-Coder-30B-A3B-Instruct-AWQ) | LMDeploy 0.14.0 (Docker, `openmmlab/lmdeploy:latest`) | 4x Tesla V100-SXM2-16GB |
| Qwen3.6-27B-int4-AutoRound | [HF](https://huggingface.co/Lorbus/Qwen3.6-27B-int4-AutoRound) | vLLM 0.24.0 (Docker, `vllm/vllm-openai:v0.24.0`) | NVIDIA DGX Spark GB10 |

The `'str' object has no attribute 'items'` error was **the only**
error type observed in the affected result files, at meaningful
volume across all three (different engines, different hardware):

| Model | Occurrences (4 multi_turn subcategories) |
|---|---|
| Devstral-Small-2-24B-Instruct-2512-AWQ-4bit | 2530 |
| Qwen3-Coder-30B-A3B-Instruct-AWQ | 3284 |
| Qwen3.6-27B-int4-AutoRound | 116 |

Since this reproduces identically across two engines (vLLM, LMDeploy)
and three hardware platforms, it's clearly the harness's own bug, not
an engine/model/quantization issue. It likely understates Multi-Turn
accuracy for **any** FC-mode model evaluated through
`OpenAICompletionsHandler`, `MistralHandler`, or `FireworksHandler`
whenever the model correctly stops calling tools mid-conversation.

## Fix

Check `tool_calls` explicitly instead of relying on exception
fallback. When there are none, return `model_responses = []`, which
`is_empty_execute_response()` already recognizes as "no further tool
calls" and handles as a normal turn-ending case — no exception, no
misreported error.

## Testing

No existing unit tests cover this handler. Verified manually with a
mocked `api_response`:

- `tool_calls=None` + plain-text `content` → `model_responses == []`
  (previously: raw string, crashing downstream)
- Normal `tool_calls` present → output unchanged from before this fix

## Scope note

`CohereHandler` already does this correctly (explicit
`if len(tool_calls) > 0` check) and wasn't touched.
`local_inference/minicpm_fc.py` has a structurally different
(non-exception-based) fallback to raw `content` that may warrant a
separate look, but I didn't want to touch a different code path/model
family without dedicated testing — flagging here for maintainers'
awareness rather than bundling an unverified change into this PR.

---

*Co-authored with Claude Code (Sonnet 5).*