### PR TITLE
Handle textual responses when tool_calls is empty

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py
@@ -73,7 +73,7 @@ class OpenAICompletionsHandler(BaseHandler):
         end_time = time.time()
 
         return api_response, end_time - start_time
-
+        
     #### FC methods ####
 
     def _query_FC(self, inference_data: dict):
@@ -107,26 +107,37 @@ class OpenAICompletionsHandler(BaseHandler):
         return inference_data
 
     def _parse_query_response_FC(self, api_response: Any) -> dict:
-        try:
+        message = api_response.choices[0].message
+        tool_calls = message.tool_calls or []
+
+        if tool_calls:
             model_responses = [
-                {func_call.function.name: func_call.function.arguments}
-                for func_call in api_response.choices[0].message.tool_calls
+                {
+                    func_call.function.name: func_call.function.arguments,
+                }
+                for func_call in tool_calls
             ]
-            tool_call_ids = [
-                func_call.id for func_call in api_response.choices[0].message.tool_calls
-            ]
-        except:
-            model_responses = api_response.choices[0].message.content
+            tool_call_ids = [func_call.id for func_call in tool_calls]
+        else:
+            model_responses = message.content or ""
             tool_call_ids = []
 
-        model_responses_message_for_chat_history = api_response.choices[0].message
+        usage = getattr(api_response, "usage", None)
 
         return {
             "model_responses": model_responses,
-            "model_responses_message_for_chat_history": model_responses_message_for_chat_history,
+            "model_responses_message_for_chat_history": message,
             "tool_call_ids": tool_call_ids,
-            "input_token": api_response.usage.prompt_tokens,
-            "output_token": api_response.usage.completion_tokens,
+            "input_token": (
+                getattr(usage, "prompt_tokens", 0)
+                if usage is not None
+                else 0
+            ),
+            "output_token": (
+                getattr(usage, "completion_tokens", 0)
+                if usage is not None
+                else 0
+            ),
         }
 
     def add_first_turn_message_FC(

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/base_handler.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/base_handler.py
@@ -257,6 +257,15 @@ class BaseHandler:
 
                 current_step_inference_log.append(log_entry)
 
+                if isinstance(model_responses, str) and model_responses.strip():
+                    current_step_inference_log.append(
+                        {
+                            "role": "handler_log",
+                            "content": "Final textual response received.",
+                            "model_response_final": model_responses,
+                        }
+                    )
+                    break
                 # Try decoding the model response
                 try:
                     decoded_model_responses = self.decode_execute(
@@ -304,12 +313,10 @@ class BaseHandler:
                     ),
                     is_evaL_run=False,
                 )
-
                 # Add the execution results to the chat history for the next turn
                 inference_data = self._add_execution_results_FC(
                     inference_data, execution_results, model_response_data
                 )
-
                 for execution_result in execution_results:
                     current_step_inference_log.append(
                         {


### PR DESCRIPTION
## Problem

Some OpenAI-compatible APIs return `message.tool_calls` as an empty list
for final textual responses.

The previous parser only fell back to `message.content` when iterating
over `tool_calls` raised an exception. With `tool_calls=[]`, it instead
produced `model_responses=[]` and discarded the valid textual response.

## Fix

- Normalize `message.tool_calls` with `message.tool_calls or []`
- Preserve `message.content` when no tool calls are present
- Stop the function-call loop when a final textual response is received

## Validation

Tested with Qwen3-8B through a vLLM OpenAI-compatible endpoint on BFCL v4
memory subsets.

Before the fix, all memory subset scores were 0.

After the fix:

- memory_kv: 4.52%
- memory_rec_sum: 29.03%
- memory_vector: 9.68%
- average memory accuracy: 14.41%

This is close to the 14.62% reported for Qwen3-8B FC on the BFCL leaderboard.