### PR TITLE
Add BlueLM-Flash to leaderboard

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/.env.example
+++ b/berkeley-function-call-leaderboard/bfcl_eval/.env.example
@@ -9,6 +9,7 @@ OPENAI_BASE_URL=
 ANTHROPIC_API_KEY=
 # We use Google AI Studio to inference Google Gemini models
 GOOGLE_API_KEY=
+VIVO_API_KEY=sk-XXXXXX
 NVIDIA_API_KEY=nvapi-XXXXXX
 GROK_API_KEY=xai-XXXXXX
 COHERE_API_KEY=

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional
-
+from bfcl_eval.model_handler.api_inference.vllm import VLLMAPIHandler
 from bfcl_eval.model_handler.api_inference.claude import ClaudeHandler
 from bfcl_eval.model_handler.api_inference.cohere import CohereHandler
 from bfcl_eval.model_handler.api_inference.deepseek import DeepSeekAPIHandler
@@ -117,6 +117,18 @@ class ModelConfig:
 
 # Inference through API calls
 api_inference_model_map = {
+    "BlueLM-3.6-35B-A3B-0806": ModelConfig(
+    model_name="BlueLM-3.6-35B-A3B-0806",
+    display_name="BlueLM-3.6-35B-A3B-0806",
+    url="https://api-ai.vivo.com.cn/v1/completions",
+    org="vivo",
+    license="Proprietary",
+    model_handler=VLLMAPIHandler,
+    input_price=None,
+    output_price=None,
+    is_fc_model=True,
+    underscore_to_dot=True,
+    ),
     "gorilla-openfunctions-v2": ModelConfig(
         model_name="gorilla-openfunctions-v2",
         display_name="Gorilla-OpenFunctions-v2 (FC)",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional
-from bfcl_eval.model_handler.api_inference.vllm import VLLMAPIHandler
+from bfcl_eval.model_handler.api_inference.vivo import VivoAPIHandler
 from bfcl_eval.model_handler.api_inference.claude import ClaudeHandler
 from bfcl_eval.model_handler.api_inference.cohere import CohereHandler
 from bfcl_eval.model_handler.api_inference.deepseek import DeepSeekAPIHandler
@@ -123,7 +123,7 @@ api_inference_model_map = {
     url="https://api-ai.vivo.com.cn/v1/completions",
     org="vivo",
     license="Proprietary",
-    model_handler=VLLMAPIHandler,
+    model_handler=VivoAPIHandler,
     input_price=None,
     output_price=None,
     is_fc_model=True,

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -118,16 +118,16 @@ class ModelConfig:
 # Inference through API calls
 api_inference_model_map = {
     "BlueLM-Flash": ModelConfig(
-    model_name="BlueLM-Flash",
-    display_name="BlueLM-Flash",
-    url="https://api-ai.vivo.com.cn/v1/completions",
-    org="vivo",
-    license="Proprietary",
-    model_handler=VivoAPIHandler,
-    input_price=None,
-    output_price=None,
-    is_fc_model=True,
-    underscore_to_dot=True,
+        model_name="BlueLM-Flash",
+        display_name="BlueLM-Flash",
+        url="https://api-ai.vivo.com.cn/v1/completions",
+        org="vivo",
+        license="Proprietary",
+        model_handler=VivoAPIHandler,
+        input_price=None,
+        output_price=None,
+        is_fc_model=True,
+        underscore_to_dot=True,
     ),
     "gorilla-openfunctions-v2": ModelConfig(
         model_name="gorilla-openfunctions-v2",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/model_config.py
@@ -117,9 +117,9 @@ class ModelConfig:
 
 # Inference through API calls
 api_inference_model_map = {
-    "BlueLM-3.6-35B-A3B-0806": ModelConfig(
-    model_name="BlueLM-3.6-35B-A3B-0806",
-    display_name="BlueLM-3.6-35B-A3B-0806",
+    "BlueLM-Flash": ModelConfig(
+    model_name="BlueLM-Flash",
+    display_name="BlueLM-Flash",
     url="https://api-ai.vivo.com.cn/v1/completions",
     org="vivo",
     license="Proprietary",

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
@@ -187,4 +187,5 @@ SUPPORTED_MODELS = [
     "qwen3-4b-think-FC",
     "qwen3-4b-nothink-FC",
     "DM-Cito-32B-v1",
+    "BlueLM-3.6-35B-A3B-0806",
 ]

--- a/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/constants/supported_models.py
@@ -187,5 +187,5 @@ SUPPORTED_MODELS = [
     "qwen3-4b-think-FC",
     "qwen3-4b-nothink-FC",
     "DM-Cito-32B-v1",
-    "BlueLM-3.6-35B-A3B-0806",
+    "BlueLM-Flash",
 ]

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/vivo.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/vivo.py
@@ -1,0 +1,59 @@
+import json
+import os
+
+from bfcl_eval.model_handler.api_inference.openai_completion import OpenAICompletionsHandler
+from openai import OpenAI
+from overrides import override
+from typing import Any
+from bfcl_eval.model_handler.model_style import ModelStyle
+
+
+class VivoAPIHandler(OpenAICompletionsHandler):
+    """
+    Handler for vivo BlueLM models accessed via the vivo public API.
+    The API is OpenAI-compatible and supports function calling.
+    """
+
+    def __init__(self, model_name, temperature) -> None:
+        super().__init__(model_name, temperature)
+        self.model_style = ModelStyle.OpenAI
+        self.client = OpenAI(
+            api_key=os.getenv("VIVO_API_KEY", ""),
+            base_url="https://api-ai.vivo.com.cn/v1"
+        )
+        self.is_fc_model = True
+
+    @override
+    def _parse_query_response_FC(self, api_response: Any) -> dict:
+        try:
+            model_responses = [
+                {func_call.function.name: func_call.function.arguments}
+                for func_call in api_response.choices[0].message.tool_calls
+            ]
+            tool_call_ids = [
+                func_call.id for func_call in api_response.choices[0].message.tool_calls
+            ]
+            if len(model_responses) == 0:
+                model_responses = api_response.choices[0].message.content
+        except:
+            model_responses = api_response.choices[0].message.content
+            tool_call_ids = []
+
+        model_responses_message_for_chat_history = api_response.choices[0].message.__dict__
+        if model_responses_message_for_chat_history.get("tool_calls", None):
+            model_responses_message_for_chat_history["tool_calls"] = [
+                {
+                    "id": tool_call.id,
+                    "type": "function",
+                    "function": tool_call.function.__dict__,
+                }
+                for tool_call in model_responses_message_for_chat_history["tool_calls"]
+            ]
+
+        return {
+            "model_responses": model_responses,
+            "model_responses_message_for_chat_history": model_responses_message_for_chat_history,
+            "tool_call_ids": tool_call_ids,
+            "input_token": api_response.usage.prompt_tokens,
+            "output_token": api_response.usage.completion_tokens,
+        }

--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/vivo.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/vivo.py
@@ -1,11 +1,7 @@
-import json
 import os
 
 from bfcl_eval.model_handler.api_inference.openai_completion import OpenAICompletionsHandler
 from openai import OpenAI
-from overrides import override
-from typing import Any
-from bfcl_eval.model_handler.model_style import ModelStyle
 
 
 class VivoAPIHandler(OpenAICompletionsHandler):
@@ -14,46 +10,16 @@ class VivoAPIHandler(OpenAICompletionsHandler):
     The API is OpenAI-compatible and supports function calling.
     """
 
-    def __init__(self, model_name, temperature) -> None:
-        super().__init__(model_name, temperature)
-        self.model_style = ModelStyle.OpenAI
+    def __init__(
+        self,
+        model_name,
+        temperature,
+        registry_name,
+        is_fc_model,
+        **kwargs,
+    ) -> None:
+        super().__init__(model_name, temperature, registry_name, is_fc_model, **kwargs)
         self.client = OpenAI(
             api_key=os.getenv("VIVO_API_KEY", ""),
-            base_url="https://api-ai.vivo.com.cn/v1"
+            base_url="https://api-ai.vivo.com.cn/v1",
         )
-        self.is_fc_model = True
-
-    @override
-    def _parse_query_response_FC(self, api_response: Any) -> dict:
-        try:
-            model_responses = [
-                {func_call.function.name: func_call.function.arguments}
-                for func_call in api_response.choices[0].message.tool_calls
-            ]
-            tool_call_ids = [
-                func_call.id for func_call in api_response.choices[0].message.tool_calls
-            ]
-            if len(model_responses) == 0:
-                model_responses = api_response.choices[0].message.content
-        except:
-            model_responses = api_response.choices[0].message.content
-            tool_call_ids = []
-
-        model_responses_message_for_chat_history = api_response.choices[0].message.__dict__
-        if model_responses_message_for_chat_history.get("tool_calls", None):
-            model_responses_message_for_chat_history["tool_calls"] = [
-                {
-                    "id": tool_call.id,
-                    "type": "function",
-                    "function": tool_call.function.__dict__,
-                }
-                for tool_call in model_responses_message_for_chat_history["tool_calls"]
-            ]
-
-        return {
-            "model_responses": model_responses,
-            "model_responses_message_for_chat_history": model_responses_message_for_chat_history,
-            "tool_call_ids": tool_call_ids,
-            "input_token": api_response.usage.prompt_tokens,
-            "output_token": api_response.usage.completion_tokens,
-        }


### PR DESCRIPTION
## Summary

Add support for vivo's BlueLM-Flash model to the Berkeley Function Calling Leaderboard.

## Model Details

| Field | Value |
|-------|-------|
| Model Name | BlueLM-Flash |
| Organization | vivo |
| License | Proprietary |
| Mode | Function Calling (FC) |
| API Endpoint | https://api-ai.vivo.com.cn/v1 |
| API Compatibility | OpenAI-compatible (/v1/chat/completions) |

## Changes

### `bfcl_eval/model_handler/api_inference/vivo.py` (new file)

- Created `VivoAPIHandler` inheriting from `OpenAICompletionsHandler`
- Sets the vivo OpenAI-compatible base URL and reads the API key from the `VIVO_API_KEY` environment variable
- Uses the standard OpenAI function-calling flow provided by the parent handler

### `bfcl_eval/constants/model_config.py`

- Added `VivoAPIHandler` import
- Added `BlueLM-Flash` entry in `api_inference_model_map`

### `bfcl_eval/constants/supported_models.py`

- Added `BlueLM-Flash` to `SUPPORTED_MODELS`

### `bfcl_eval/.env.example`

- Added `VIVO_API_KEY=` placeholder
