### PR TITLE
[BFCL] Defer qwen_agent import until handler initialization

### DIFF
--- a/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/qwen.py
+++ b/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/qwen.py
@@ -1,12 +1,22 @@
 import os
+import time
 from typing import Any
 
-from bfcl_eval.model_handler.api_inference.openai_completion import OpenAICompletionsHandler
-from bfcl_eval.constants.enums import ModelStyle
 from openai import OpenAI
 from overrides import override
-from qwen_agent.llm import get_chat_model
-import time
+
+from bfcl_eval.constants.enums import ModelStyle
+from bfcl_eval.model_handler.api_inference.openai_completion import (
+    OpenAICompletionsHandler,
+)
+
+
+def _build_qwen_agent_chat_model(config: dict[str, Any]) -> Any:
+    # Keep BFCL CLI startup independent of Qwen Agent's audio dependencies.
+    from qwen_agent.llm import get_chat_model
+
+    return get_chat_model(config)
+
 
 class QwenAPIHandler(OpenAICompletionsHandler):
     """
@@ -231,7 +241,7 @@ class QwenAgentThinkHandler(OpenAICompletionsHandler):
             --max-model-len 65536
         """
         
-        self.llm = get_chat_model({
+        self.llm = _build_qwen_agent_chat_model({
         'model': model_name,  # name of the model served by vllm server
         'model_type': 'oai',
         'model_server':'http://localhost:8000/v1', # can be replaced with server host
@@ -330,7 +340,7 @@ class QwenAgentNoThinkHandler(QwenAgentThinkHandler):
             --max-model-len 65536
         """
         
-        self.llm = get_chat_model({
+        self.llm = _build_qwen_agent_chat_model({
         'model': model_name, # name of the model served by vllm server
         'model_type': 'oai',
         'model_server':'http://localhost:8000/v1', # can be replaced with server host

--- a/berkeley-function-call-leaderboard/tests/test_cli_imports.py
+++ b/berkeley-function-call-leaderboard/tests/test_cli_imports.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+CLI_HELP_WITHOUT_SOUNDFILE = """
+import importlib.abc
+import runpy
+import sys
+
+
+class BlockSoundfileImport(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "soundfile":
+            raise ModuleNotFoundError("No module named 'soundfile'", name=fullname)
+        return None
+
+
+sys.meta_path.insert(0, BlockSoundfileImport())
+sys.argv = ["bfcl", "--help"]
+try:
+    runpy.run_module("bfcl_eval.__main__", run_name="__main__", alter_sys=True)
+except SystemExit as exc:
+    if exc.code not in (None, 0):
+        raise
+
+if "qwen_agent" in sys.modules:
+    raise AssertionError("bfcl --help imported qwen_agent")
+"""
+
+
+class CliImportTests(unittest.TestCase):
+    def test_help_does_not_import_qwen_agent_or_require_audio_dependencies(
+        self,
+    ) -> None:
+        result = subprocess.run(
+            [sys.executable, "-c", CLI_HELP_WITHOUT_SOUNDFILE],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Usage:", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

BFCL loaded `qwen_agent` while importing its model registry, so its audio dependency chain could prevent even `bfcl --help` from starting for users who were not using a Qwen model. This change moves that import into a small loader called only when a Qwen Agent-backed handler is initialized.

The existing handler classes, all `ModelConfig` mappings, and the arguments passed to `get_chat_model` remain unchanged. A subprocess regression test exercises CLI help in a fresh interpreter, blocks `soundfile` deterministically, and verifies that startup does not import `qwen_agent`.

## Verification

- Reproduced the failure on current `main` in a clean Python 3.12.14 environment: `ModuleNotFoundError: No module named 'soundfile'`
- Ran the new regression with `python -m unittest discover -s tests -v`
- Verified `bfcl --help` through the editable console entry point
- Built the wheel and installed it with the declared dependencies into a second clean environment; `soundfile` was absent and the installed `bfcl --help` succeeded
- Imported all 175 model mappings and confirmed `qwen3-4b-think-FC` still maps to `QwenAgentThinkHandler`
- Ran `compileall`, Black on the new test, isort on both changed files, and `git diff --check`

## Scope

This patch changes import timing only. `qwen-agent` remains a declared dependency, and Qwen Agent handler initialization still calls `get_chat_model` with the existing configuration. Moving the package to an optional extra would be a separate dependency-policy change.

Fixes #1338
